### PR TITLE
docs(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: 🐛 Bug report / 缺陷报告
+description: Report a reproducible problem. 报告一个可复现的问题。
+title: "[Bug] "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report! 感谢反馈！
+
+        > **Note**: `src/**` is a read-only generated mirror; bugs are fixed
+        > upstream and flow back per release. 代码为只读生成镜像，缺陷在上游修复后回流。
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight / 提交前检查
+      options:
+        - label: I searched existing issues and did not find a duplicate. 我已搜索现有 Issue，未发现重复。
+          required: true
+        - label: I am running the latest release. 我使用的是最新发布版本。
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened? / 问题描述
+      description: A clear and concise description of the bug. 清晰描述实际发生的现象。
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce / 复现步骤
+      description: Minimal, exact steps. Include commands, requests, or a repo link. 最小化的精确复现步骤。
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior / 期望行为
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment profile / 部署方式
+      options:
+        - One-command / no-Docker (install.sh)
+        - Docker Compose
+        - Manual / from source
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / 环境信息
+      description: OS, Python & Node versions, browser (if UI), model/provider. 操作系统、Python/Node 版本、浏览器、所用模型/供应商。
+      placeholder: |
+        - OS: macOS 14.5 / Ubuntu 22.04 / WSL2
+        - Python: 3.11 / Node: 20 / Model provider: OpenAI-compatible / local
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / 相关日志
+      description: Paste backend/frontend logs or a stack trace. Redact secrets. 粘贴后端/前端日志或堆栈，注意脱敏。
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions / 讨论区
+    url: https://github.com/ZJU-REAL/HugAgentOS/discussions
+    about: Ask questions, share ideas, or discuss usage. 提问、分享想法或讨论用法，请到讨论区。
+  - name: 🔒 Report a security vulnerability / 报告安全漏洞
+    url: https://github.com/ZJU-REAL/HugAgentOS/security/policy
+    about: Do NOT open a public issue for security problems. 请勿公开披露安全漏洞，参见 SECURITY.md。
+  - name: 📖 Documentation / 文档
+    url: https://github.com/ZJU-REAL/HugAgentOS/tree/main/document
+    about: Deployment, architecture, and module guides (EN / 简体中文).

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,29 @@
+name: 📖 Documentation / 文档问题
+description: Report a docs error, gap, or improvement. 报告文档错误、缺失或改进点。
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Documentation lives under `document/` (EN + 简体中文) and accepts pull
+        requests directly. If you can fix it, a PR is very welcome!
+        文档位于 `document/`，欢迎直接提交 PR 修复。
+  - type: input
+    id: location
+    attributes:
+      label: Page / location / 文档位置
+      description: File path or URL. 文件路径或链接。
+      placeholder: document/en/deployment/quick-install.md
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What's wrong or missing? / 问题描述
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix / 建议修改

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: ✨ Feature request / 功能建议
+description: Suggest an idea or improvement. 提出新功能或改进建议。
+title: "[Feature] "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? Please describe the use case and the value it brings.
+        请说明使用场景与预期收益，帮助我们评估。
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight / 提交前检查
+      options:
+        - label: I searched existing issues and discussions for a similar request. 我已搜索现有 Issue 与讨论，未发现类似建议。
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation / 要解决的问题
+      description: What are you trying to do, and what's blocking you today? 你想达成什么？当前受阻在哪里？
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution / 建议方案
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered / 已考虑的替代方案
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area / 涉及模块
+      options:
+        - Agent orchestration / 编排
+        - MCP tools / 工具
+        - Skills / 技能
+        - Knowledge base & RAG / 知识库
+        - Memory / 记忆
+        - Sandbox execution / 沙箱执行
+        - Ontology & governance / 本体与治理
+        - Deployment / 部署
+        - Frontend / UI
+        - Documentation / 文档
+        - Other
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

Adds a `.github/` directory (previously absent) with structured GitHub issue forms and a pull request template. All templates respect the fact that this is a **generated, read-only mirror** where `src/**` is synced from upstream — bugs are triaged here and fixed upstream per release.

## What's added

| File | Purpose |
|------|---------|
| `ISSUE_TEMPLATE/bug_report.yml` | Bilingual (EN/中文) bug form: repro steps, deployment profile, environment, logs |
| `ISSUE_TEMPLATE/feature_request.yml` | Feature request form with area dropdown |
| `ISSUE_TEMPLATE/documentation.yml` | Docs error/gap form |
| `ISSUE_TEMPLATE/config.yml` | Disables blank issues; routes security → policy, questions → Discussions, docs → guides |
| `PULL_REQUEST_TEMPLATE.md` | Enforces the docs/examples-only PR policy; bilingual checklist |

## Notes

- All templates are **bilingual (English + 简体中文)** to match the project's EN/中文 docs.
- All YAML forms validated against the GitHub issue-forms schema.
- No existing files changed; `.github/` is entirely new (5 files, 198 lines).