### PR TITLE
docs(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+  Thanks for contributing to HugAgentOS! 感谢贡献！
+
+  ⚠️ IMPORTANT — this is a GENERATED community mirror. 重要说明：本仓库是生成镜像。
+  PRs are accepted ONLY for:  document/**, examples/**, README*.md, and other
+  non-generated docs. Changes to src/**, mcp_servers/**, or other generated code
+  CANNOT be merged here — please open an Issue instead so they can be fixed
+  upstream and flow back in the next release.
+  仅接受 document/**、examples/**、README 等非生成内容的 PR；src/** 等生成代码
+  请改提 Issue，由上游修复后回流。
+-->
+
+## Summary / 概述
+
+<!-- What does this PR change and why? 本次 PR 改了什么，为什么？ -->
+
+## Related issue / 关联 Issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change / 变更类型
+
+- [ ] 📖 Documentation (`document/**`, `README*.md`)
+- [ ] 🧩 Example / sample (`examples/**`)
+- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
+- [ ] Other (please describe / 请说明):
+
+## Checklist / 检查项
+
+- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
+- [ ] Links and code snippets were verified. 链接与代码片段已验证。
+- [ ] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。
+- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` — a pull request template that enforces the **docs/examples-only** contribution policy for this generated, read-only mirror (`src/**` fixes flow from upstream per release), with a bilingual (EN/中文) checklist.

Follow-up to #1 (issue templates), completing the `.github/` template set.

## Notes

- Bilingual (English + 简体中文), matching the project's EN/中文 docs.
- Single file, 33 lines. No existing files changed.