### PR TITLE
ci(desktop): add multi-platform build and release workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,126 @@
+# Build and publish the HugAgentOS Tauri desktop client for all platforms.
+#
+# Tauri cannot cross-compile, so each OS is built on its own native runner
+# (macOS / Ubuntu / Windows) and the artifacts are collected into a single
+# GitHub Release. Updater artifacts (*.sig + latest.json) are produced too,
+# using the shared signing key stored in repository secrets.
+#
+# ── Required repository secrets ─────────────────────────────────────────────
+#   TAURI_SIGNING_PRIVATE_KEY           updater private key (content of the
+#                                       `.key` file; base64 is expected as-is).
+#                                       Build FAILS without it because
+#                                       tauri.conf.json sets createUpdaterArtifacts.
+#   TAURI_SIGNING_PRIVATE_KEY_PASSWORD  key password ("" if none).
+#   GITHUB_TOKEN                         auto-provided; used to create the Release.
+#
+# ── How to cut a release ────────────────────────────────────────────────────
+#   1. Bump the version in desktop/package.json, desktop/src-tauri/Cargo.toml
+#      and desktop/src-tauri/tauri.conf.json (keep them in sync).
+#   2. Push a tag `desktop-vX.Y.Z` (or run this workflow manually with that tag).
+#   3. A DRAFT release is created with every platform's installer + latest.json;
+#      review it, then publish.
+#
+# Note: macOS bundles are NOT Apple-code-signed/notarized (no Apple cert). They
+# work, but users must right-click → Open (or clear the quarantine attribute) on
+# first launch. Add APPLE_* secrets + signing env later to make this seamless.
+
+name: Desktop Release
+
+on:
+  push:
+    tags:
+      - "desktop-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. desktop-v0.2.0)"
+        required: true
+
+# Allow the job to create the GitHub Release.
+permissions:
+  contents: write
+
+# One release build per ref at a time.
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS: one universal (arm64 + x86_64) build → .dmg + .app(.tar.gz updater).
+          - platform: macos-latest
+            args: "--target universal-apple-darwin --bundles app dmg"
+            rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
+          # Linux: tauri.linux.conf.json overrides targets to appimage + deb.
+          - platform: ubuntu-22.04
+            args: ""
+            rust-targets: ""
+          # Windows: base tauri.conf.json targets are nsis + msi.
+          - platform: windows-latest
+            args: ""
+            rust-targets: ""
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            patchelf \
+            file
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-targets }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri -> target
+
+      # The frontend dist is built by tauri's beforeBuildCommand
+      # (`npm --prefix ../src/frontend run build`), which needs deps installed.
+      - name: Install frontend dependencies
+        working-directory: src/frontend
+        run: npm install
+
+      - name: Install desktop toolchain (@tauri-apps/cli)
+        working-directory: desktop
+        run: npm install
+
+      - name: Build and publish release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: desktop
+          tagName: ${{ github.event.inputs.tag || github.ref_name }}
+          releaseName: "HugAgentOS Desktop __VERSION__"
+          releaseBody: "Download the installer for your platform below. See the docs for setup."
+          releaseDraft: true
+          prerelease: false
+          includeUpdaterJson: true
+          args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/desktop-release.yml` — a CI workflow that builds the **Tauri v2 desktop client** for **macOS, Linux, and Windows** and publishes all installers + updater artifacts to a single GitHub Release.

Since Tauri cannot cross-compile, each OS builds on its own native runner via a matrix, using the official [`tauri-apps/tauri-action`](https://github.com/tauri-apps/tauri-action).

## How it works

| Aspect | Choice |
|---|---|
| Trigger | Push a `desktop-v*` tag, or manual `workflow_dispatch` (tag input) |
| Platforms | `macos-latest` (universal arm64+x86_64), `ubuntu-22.04` (appimage+deb), `windows-latest` (nsis+msi) |
| Output | **Draft** GitHub Release with every platform's installer + `latest.json` + `.sig` |
| Updater signing | `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repo secrets (already configured) |
| Frontend | `npm install` in `src/frontend`; tauri's `beforeBuildCommand` builds the dist |
| Rust cache | `Swatinem/rust-cache` scoped to `desktop/src-tauri` |

## Release procedure

1. Bump version in `desktop/package.json`, `desktop/src-tauri/Cargo.toml`, `desktop/src-tauri/tauri.conf.json` (keep in sync).
2. Push tag `desktop-vX.Y.Z`.
3. Review the generated **draft** release, then publish.

## Scope notes / follow-ups

- **Pure repo meta**: only `.github/workflows/` is added — no changes to the read-only `desktop/**` source.
- **macOS is unsigned** (no Apple cert): bundles work but trigger Gatekeeper on first launch. Add `APPLE_*` signing secrets later to make it seamless.
- **Self-update channel**: this Release carries `latest.json` for the Tauri updater. The client's `update.rs` currently resolves the updater endpoint from the runtime `server_base` (backend-served). To have clients self-update **from GitHub Releases** instead, the updater endpoint/logic in `desktop/src-tauri` must be adjusted upstream — out of scope for this meta-only PR.
- Frontend build runs the repo's `check-i18n.mjs` + `tsc -b` + `vite build`; if i18n/type checks are strict they may need attention on the first run.