### PR TITLE
ci(desktop): raise Node heap for frontend build to avoid OOM

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -115,6 +115,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # The frontend build (tsc + vite over Univer/AntD/Mermaid/KaTeX) peaks
+          # near Node's ~2 GB default heap and OOMs intermittently on runners
+          # (exit 134). tauri's beforeBuildCommand spawns it, so raise the limit
+          # here and it is inherited by the child process. Runners have 7 GB+.
+          NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           projectPath: desktop
           tagName: ${{ github.event.inputs.tag || github.ref_name }}


### PR DESCRIPTION
## Problem

The first release run (manual dispatch, `desktop-v0.1.0`) came back **Linux ✅ / Windows ✅ / macOS ❌**. The macOS failure was **not** macOS- or universal-build-specific:

```
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
##[error]Command "npm run tauri build ..." failed with exit code 1
beforeBuildCommand `npm --prefix ../src/frontend run build` failed with exit code 134
```

The frontend build (`tsc -b` + `vite build` over Univer / Ant Design / Mermaid / KaTeX) peaks near Node's ~2 GB default heap. macOS OOM-killed; Linux/Windows passed **only by a thin margin** — so this is nondeterministic and would eventually flake on any platform.

## Fix

Set `NODE_OPTIONS=--max-old-space-size=4096` on the `tauri-action` step. tauri's `beforeBuildCommand` spawns the frontend build as a child process, which inherits this env, giving it a 4 GB heap. GitHub runners have 7 GB+ RAM.

## Validation

- `actionlint` passes.
- Root cause confirmed from the failed run's logs (exit 134 = SIGABRT from V8 OOM).
- Full end-to-end re-run to follow once merged (re-dispatch the workflow).