### PR TITLE
fix(desktop): use https for updater endpoint to prevent startup crash

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI4MjI4Q0QxNzlCODE3NjYKUldSbUY3aDUwWXdpS0w2bW1tYzU4Tk4xUDJpRnRLdUhZVjc4ZXIyYzhoWUtHUjMzUkhnRS9RRkoK",
       "endpoints": [
-        "http://localhost:3000/api/v1/desktop/latest.json"
+        "https://localhost:3000/api/v1/desktop/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## Problem

The `desktop-v0.1.0` build (all three platforms green in CI) **crashes immediately on launch**. Reproduced by running the macOS universal binary from a terminal:

```
thread 'main' panicked at src/lib.rs:252:10:
运行 Tauri 应用失败: PluginInitialization("updater",
  "The configured updater endpoint must use a secure protocol like `https`.")
```

`tauri-plugin-updater` **2.10.1** validates `plugins.updater.endpoints` at plugin-init time and **rejects any non-`https` scheme**. The committed placeholder was:

```json
"endpoints": ["http://localhost:3000/api/v1/desktop/latest.json"]
```

So the app panics before the window is created and dies on startup. This is **not** platform-specific — Windows/Linux bundles crash identically; macOS was just the first one tested. CI stayed green because it only compiles/bundles, it never launches the app.

## Fix

Change the endpoint scheme `http://` → `https://` (one line). Per the desktop README this endpoint is only a placeholder/fallback that is **overridden at runtime by `server_base`**, so the change is behavior-neutral — it just satisfies the init-time validator.

```diff
- "http://localhost:3000/api/v1/desktop/latest.json"
+ "https://localhost:3000/api/v1/desktop/latest.json"
```

## Validation

- Root cause captured from a real run of the shipped universal binary (not a guess).
- `tauri.conf.json` re-validated as JSON.
- After merge: re-dispatch the release workflow and re-run the macOS binary to confirm it reaches the window instead of aborting.

## ⚠️ Mirror note

`desktop/**` is part of the generated community mirror. This same fix **must also be applied upstream**, otherwise the next generated release will regenerate the `http://` value and reintroduce the crash.