### PR TITLE
fix(desktop): ignore untracked build artifacts in CE payload staging

### DIFF
--- a/desktop/scripts/ce-payload.mjs
+++ b/desktop/scripts/ce-payload.mjs
@@ -43,8 +43,11 @@ export function assertDerivedCeRepository(repoRoot) {
 }
 
 export function assertCleanRepository(repoRoot) {
-  const status = git(repoRoot, ["status", "--porcelain"]);
-  if (status.trim()) {
+  // Build tools may leave ignored/untracked artifacts (for example frontend
+  // dist output). The payload is assembled exclusively from tracked files, so
+  // only staged or unstaged changes to tracked files can make it non-reproducible.
+  const trackedChanges = git(repoRoot, ["status", "--porcelain", "--untracked-files=no"]);
+  if (trackedChanges.trim()) {
     throw new Error(
       "Desktop release payloads must be built from a clean Git checkout",
     );


### PR DESCRIPTION
## Summary
- keep CE payload staging restricted to tracked-file changes
- allow ignored and untracked build artifacts created by frontend/Tauri tooling

## Validation
- node --test desktop/scripts/ce-payload.test.mjs
- reproduced the Windows failure path from run 29803577476

The previous lockfile installation fix is already included on this branch.