### PR TITLE
fix(desktop): compare tracked content for CE release staging

### DIFF
--- a/desktop/scripts/ce-payload.mjs
+++ b/desktop/scripts/ce-payload.mjs
@@ -43,13 +43,24 @@ export function assertDerivedCeRepository(repoRoot) {
 }
 
 export function assertCleanRepository(repoRoot) {
-  // Build tools may leave ignored/untracked artifacts (for example frontend
-  // dist output). The payload is assembled exclusively from tracked files, so
-  // only staged or unstaged changes to tracked files can make it non-reproducible.
-  const trackedChanges = git(repoRoot, ["status", "--porcelain", "--untracked-files=no"]);
-  if (trackedChanges.trim()) {
+  // Tauri may touch Cargo.toml while inspecting dependencies. On Windows with
+  // CRLF conversion, `git status` can report that stat-only rewrite as modified
+  // even when the normalized content is identical to HEAD. Compare content
+  // directly so only real staged or unstaged tracked changes block a release.
+  const result = spawnSync("git", ["diff", "--quiet", "HEAD", "--"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell: false,
+  });
+  if (result.error) throw result.error;
+  if (result.status === 1) {
     throw new Error(
       "Desktop release payloads must be built from a clean Git checkout",
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `git diff --quiet HEAD -- failed with exit code ${result.status}`,
     );
   }
 }

--- a/desktop/scripts/ce-payload.test.mjs
+++ b/desktop/scripts/ce-payload.test.mjs
@@ -82,6 +82,21 @@ test("rejects release staging from a dirty CE repository", () => {
   }
 });
 
+test("rejects release staging when a tracked change is staged", () => {
+  const root = createCeFixture();
+  const output = join(root, "desktop", "generated", "server-ce");
+  try {
+    writeFileSync(join(root, "src", "backend", "app.py"), 'print("staged")\n');
+    git(root, ["add", "src/backend/app.py"]);
+    assert.throws(
+      () => stageTrackedCeRepository(root, output, { requireClean: true }),
+      /clean Git checkout/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects fallback staging without the derived CE marker", () => {
   const root = mkdtempSync(join(tmpdir(), "hugagent-not-ce-"));
   try {


### PR DESCRIPTION
## Summary / 概述

Fix the Windows desktop release false-positive dirty-tree failure caused by line-ending normalization while the desktop toolchain inspects dependency metadata. The release guard compares tracked content directly and continues to reject real staged, unstaged, or untracked changes.

## Type of change / 变更类型

- [x] Desktop release helper hardening

## Validation

- Desktop payload and version guard tests passed on Linux and Windows.
- The Windows desktop compile check completed successfully.
