### PR TITLE
feat(desktop): support native macOS onboarding and local setup

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -46,7 +46,7 @@ jobs:
         include:
           - name: macOS Rust tests
             os: macos-latest
-            prepare_payload: false
+            prepare_payload: true
           - name: Windows CE payload and Rust tests
             os: windows-latest
             prepare_payload: true
@@ -77,12 +77,7 @@ jobs:
         working-directory: desktop
         run: npm ci --no-audit --no-fund
 
-      - name: Build frontend for macOS tests
-        if: ${{ !matrix.prepare_payload }}
-        working-directory: src/frontend
-        run: npm run build
-
-      - name: Stage the public CE local-server payload on Windows
+      - name: Stage the public CE local-server payload
         if: ${{ matrix.prepare_payload }}
         working-directory: desktop
         run: node scripts/prepare-bundle.mjs

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,9 +1,10 @@
 # Build and publish the HugAgentOS Tauri desktop client from the public CE tree.
 #
 # This workflow belongs to the CE overlay because the main repository excludes
-# `.github/**` during derivation. Windows stages the already-derived tracked CE
-# checkout as its local-server payload; the private FULL checkout continues to
-# generate that payload with scripts/build_ce.py before it reaches this tree.
+# `.github/**` during derivation. Windows and macOS stage the already-derived
+# tracked CE checkout as their local-server payload; the private FULL checkout
+# continues to generate that payload with scripts/build_ce.py before it reaches
+# this tree.
 #
 # Required repository secrets:
 #   TAURI_SIGNING_PRIVATE_KEY

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,8 +1,8 @@
 # HugAgentOS 桌面客户端（Tauri v2）
 
-把现有 Web 平台封装为桌面客户端（Windows / Linux，Mac 待接入构建机）。客户端支持两种
-运行方式：连接已部署的团队服务器，或在 Windows 首装时选择由客户端一键安装并托管本机
-CE 单机服务。两种方式都通过内置本地反代访问后端。
+把现有 Web 平台封装为桌面客户端（Windows / macOS / Linux）。客户端支持两种运行方式：
+连接已部署的团队服务器，或在 Windows 和 macOS 上由客户端从零安装并托管本机 CE 单机服务。
+两种方式都通过内置本地反代访问后端。
 
 登录走**方案 B**——系统浏览器跳转登录 + `hugagent://` deep-link 唤起 App + 一次性
 handoff 票据换 token。前端源码零改动（复用 `src/frontend`）。
@@ -30,12 +30,12 @@ handoff 票据换 token。前端源码零改动（复用 `src/frontend`）。
 
 deep-link 上只走**单次、秒级过期**的 handoff 票据，长期 token 永不进 URL。
 
-Windows 本机服务模式在这条链路前增加一层客户端托管：
+Windows 和 macOS 本机服务模式在这条链路前增加一层客户端托管：
 
 ```text
-NSIS 首装选择“本机服务”
+首次启动选择“从零开始安装”
   → 安装包内同版本 CE 派生树
-  → %LOCALAPPDATA%\com.hugagent.desktop\local-server\venv
+  → 应用本地数据目录下的 local-server/venv
   → hugagent serve --host 127.0.0.1 --port 32101
   → 健康检查通过
   → 桌面本地反代继续复用既有登录与 API 转发链路
@@ -78,7 +78,8 @@ Windows 机器上打，**Linux 包可在任意装好 Rust 的 Linux / WSL 环境
 }
 ```
 
-- `<应用配置目录>`：Windows `%APPDATA%\com.hugagent.desktop`，Linux `~/.config/com.hugagent.desktop`
+- `<应用配置目录>`：Windows `%APPDATA%\com.hugagent.desktop`，macOS
+  `~/Library/Application Support/com.hugagent.desktop`，Linux `~/.config/com.hugagent.desktop`
 - `deployment_mode` 可取 `remote` / `local`；切换本机服务时客户端会把地址固定为
   `http://127.0.0.1:32101`
 - 也可用环境变量 `HUGAGENT_SERVER_BASE` 覆盖（优先级高于 server.json，并强制切回远程模式）
@@ -95,20 +96,24 @@ cd desktop
 npm install            # 装 @tauri-apps/cli
 
 # 生产构建（自动先 build 前端；构建须注入更新签名私钥，见《自动更新》）
-# Windows 侧 → 打 NSIS .exe：       产物 src-tauri/target/release/bundle/nsis/
-# Linux 本机 → 打 AppImage + deb： 产物 src-tauri/target/release/bundle/{appimage,deb}/
+# Windows 侧 → 打 NSIS .exe：      产物 src-tauri/target/release/bundle/nsis/
+# macOS 侧 → 打 universal DMG：    npm run build -- --target universal-apple-darwin
+# Linux 本机 → 打 AppImage + deb：产物 src-tauri/target/release/bundle/{appimage,deb}/
 npm run build
 
 # 开发调试：先确保 src/frontend 已 npm run build（反代直接 serve dist），再
 HUGAGENT_SERVER_BASE=https://你的后端 npm run dev
 ```
 
-> 平台打包目标由 `src-tauri/tauri.linux.conf.json`（Linux：appimage+deb）覆盖基础配置
-> （Windows：NSIS）；Mac 接入时同理加 `tauri.macos.conf.json`。Linux 只有 **AppImage
-> 支持自动更新**，deb 仅作首装分发。WSL 下打 AppImage 建议带 `APPIMAGE_EXTRACT_AND_RUN=1`。
+> 平台打包目标由 `src-tauri/tauri.linux.conf.json`（Linux：AppImage + deb）、
+> `src-tauri/tauri.windows.conf.json`（Windows：NSIS + CE 本机服务）和
+> `src-tauri/tauri.macos.conf.json`（macOS：app + DMG + CE 本机服务）覆盖基础配置。
+> Linux 只有 **AppImage 支持自动更新**，deb 仅作首装分发。WSL 下打 AppImage 建议带
+> `APPIMAGE_EXTRACT_AND_RUN=1`。
 
-> Windows overlay 的 `beforeBuildCommand` 会运行 `scripts/prepare-bundle.mjs`：构建桌面前端、准备
-> CE 服务树、构建 CE 登录前端，并删除构建期 `node_modules` 后再交给 Tauri 打包。FULL 主仓存在
+> Windows 和 macOS overlay 的 `beforeBuildCommand` 会运行 `scripts/prepare-bundle.mjs`：构建
+> 桌面前端、准备 CE 服务树、构建 CE 登录前端，并删除构建期 `node_modules` 后再交给 Tauri
+> 打包。FULL 主仓存在
 > `scripts/build_ce.py` 时，脚本正常运行生成器并执行开源边界门禁；公开 CE 仓不含生成器，脚本会先
 > 校验根目录 `.hugagent-edition` 为 `ce`，再只复制当前已派生 checkout 中的 Git tracked 文件。
 > Linux 仍只构建桌面前端，不携带 Windows 本机服务载荷；dev 模式从仓库内
@@ -136,6 +141,7 @@ HUGAGENT_SERVER_BASE=https://你的后端 npm run dev
 | `src-tauri/tauri.conf.json` | 窗口/打包/deep-link scheme/资源/**updater 配置（pubkey + endpoints）** |
 | `src-tauri/installer-hooks.nsh` | Windows 首装时选择“本机服务”或“仅客户端”；静默更新不重复询问 |
 | `resources/server-bootstrap/install-local-server.ps1` | Windows 用户目录内创建 Python 环境并安装随包 CE 服务 |
+| `resources/server-bootstrap/install-local-server.sh` | macOS 应用数据目录内准备独立 Python 运行时并安装随包 CE 服务 |
 | `scripts/prepare-bundle.mjs` | 发行构建前生成同版本 CE 服务资源和 `desktop-bundle.json` |
 | `scripts/ce-payload.mjs` | 在公开 CE 仓校验版本标识并只暂存 tracked tree，FULL 仓仍走生成器 |
 | `scripts/validate-release-version.mjs` | CI 三平台矩阵启动前校验桌面版本文件与 release tag |
@@ -151,12 +157,13 @@ HUGAGENT_SERVER_BASE=https://你的后端 npm run dev
   `chatStream.ts` 全部对话能力，零重复实现）。未登录时退化为唤起主窗。
 - **A3 一键自动更新**（`update.rs`）：菜单「帮助 → 检查更新…」或托盘触发，见下方《自动更新》。
 - **A4 托盘增强**：托盘菜单新增「新建对话」「检查更新…」。
-- **平台化菜单与标题栏**（`menu.rs` + `proxy.rs`）：Windows/Linux 保留紧凑的一体化窗口菜单；macOS
-  使用系统菜单栏和左侧原生交通灯，窗口内只保留半透明工具栏及「新建对话」「服务设置」两个 Mac
-  风格图标按钮，不显示 Windows 式右侧最小化、最大化和关闭按钮。
+- **平台化菜单与标题栏**（`menu.rs` + `proxy.rs`）：Windows/Linux 保留紧凑的一体化窗口菜单；
+  macOS 使用系统菜单栏和左侧原生交通灯，窗口内只保留 38px 可拖动标题区，不再重复展示品牌栏
+  或右侧操作按钮。
 - **设置服务器地址 UI**（菜单「文件 → 设置服务器地址…」）：填后端地址→写回 server.json→重启生效，
   不再必须手改 JSON。
-- **本机服务一键安装**（菜单「文件 → 本机服务…」）：后端不可达时也会自动显示。安装过程提供
+- **本机服务一键安装**（菜单「文件 → 本机服务…」）：Windows 和 macOS 后端不可达时也会自动
+  显示。安装过程提供
   阶段进度、实时日志、失败重试和健康检查；客户端更新携带新 CE 资源时自动升级服务代码，
   `data/` 目录保持不变。远程模式下点击安装会先在当前页面完成安装，服务通过健康检查后才切换
   `server.json` 并重启，避免提前重启造成按钮无响应或安装状态不可见。
@@ -246,8 +253,13 @@ npm run build
   优先用 `winget` 为当前用户静默安装；系统同时缺少 Python 和 `winget` 时，进度页会给出可重试错误。
   Node.js 20+ 缺失时也会尝试通过 `winget` 补齐；这一步失败不阻断核心服务，但 React 建站和高级
   PDF 渲染会保持降级状态。
-- 本机服务数据位于 `%LOCALAPPDATA%\com.hugagent.desktop\local-server\data`。卸载桌面客户端
-  默认保留该目录，避免误删用户数据；确认不再需要后可手动删除。
+- macOS 本机服务首次安装会在应用数据目录下载独立的 `uv` 和 Python 3.11，不修改系统 Python
+  或 shell 配置。安装仍需联网下载 Python wheels；Node.js 20+ 仅影响可选的建站和高级文档能力，
+  缺失时不阻断核心服务启动。
+- 本机服务数据位于应用本地数据目录的 `local-server/data`。Windows 的默认位置是
+  `%LOCALAPPDATA%\com.hugagent.desktop\local-server\data`，macOS 的默认位置是
+  `~/Library/Application Support/com.hugagent.desktop/local-server/data`。卸载桌面客户端默认保留
+  该目录，避免误删用户数据；确认不再需要后可手动删除。
 - Linux 托盘依赖 libayatana-appindicator；Wayland 下全局快捷键（Ctrl+Shift+Space）兼容性因桌面
   环境而异。
 - 依赖版本号（tauri 插件、axum/reqwest 等）以实际 `cargo build` 为准；个别 capability

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hugagent-desktop",
   "version": "0.2.1",
   "private": true,
-  "description": "HugAgentOS 桌面客户端（远程连接 + Windows 无 Docker 本机服务）",
+  "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS 无 Docker 本机服务）",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev",

--- a/desktop/resources/server-bootstrap/install-local-server.sh
+++ b/desktop/resources/server-bootstrap/install-local-server.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BundleDir=""
+InstallRoot=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-dir)
+      BundleDir="${2:-}"
+      shift 2
+      ;;
+    --install-root)
+      InstallRoot="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+progress() {
+  printf 'HUGAGENT_PROGRESS|%s|%s\n' "$1" "$2"
+}
+
+if [[ -z "$BundleDir" || -z "$InstallRoot" ]]; then
+  echo "Both --bundle-dir and --install-root are required." >&2
+  exit 2
+fi
+if [[ ! -f "$BundleDir/pyproject.toml" ]]; then
+  echo "The desktop package doesn't contain a valid CE server payload." >&2
+  exit 3
+fi
+if [[ ! -f "$BundleDir/src/frontend/dist/index.html" ]]; then
+  echo "The bundled CE web application is missing." >&2
+  exit 3
+fi
+
+SourceDir="$InstallRoot/source"
+VenvDir="$InstallRoot/venv"
+VenvPython="$VenvDir/bin/python"
+InstalledManifest="$InstallRoot/installed-bundle.json"
+ToolsDir="$InstallRoot/tools"
+UvBin="$ToolsDir/uv"
+PythonDir="$InstallRoot/python"
+
+mkdir -p "$InstallRoot"
+
+progress 5 "正在复制同版本服务端资源…"
+rm -rf "$SourceDir"
+mkdir -p "$SourceDir"
+if [[ -x /usr/bin/ditto ]]; then
+  /usr/bin/ditto "$BundleDir" "$SourceDir"
+else
+  /bin/cp -R "$BundleDir/." "$SourceDir/"
+fi
+
+progress 12 "正在准备独立运行环境…"
+if [[ ! -x "$UvBin" ]]; then
+  mkdir -p "$ToolsDir"
+  progress 16 "正在下载运行环境管理器…"
+  /usr/bin/curl --fail --location --silent --show-error \
+    https://astral.sh/uv/0.11.30/install.sh \
+    | env UV_UNMANAGED_INSTALL="$ToolsDir" UV_NO_MODIFY_PATH=1 /bin/sh
+fi
+if [[ ! -x "$UvBin" ]]; then
+  echo "The local runtime manager couldn't be installed." >&2
+  exit 4
+fi
+
+export UV_CACHE_DIR="$InstallRoot/cache/uv"
+export UV_PYTHON_INSTALL_DIR="$PythonDir"
+export UV_PYTHON_BIN_DIR="$InstallRoot/python-bin"
+
+progress 20 "正在下载 Python 3.11 运行环境…"
+"$UvBin" python install 3.11 --install-dir "$PythonDir" --no-bin
+
+RebuildVenv=1
+if [[ -x "$VenvPython" ]] \
+  && "$VenvPython" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
+  RebuildVenv=0
+fi
+if [[ "$RebuildVenv" -eq 1 ]]; then
+  progress 26 "正在创建独立 Python 环境…"
+  rm -rf "$VenvDir"
+  "$UvBin" venv --python 3.11 "$VenvDir"
+fi
+
+progress 34 "正在准备 Python 安装工具…"
+"$UvBin" pip install --python "$VenvPython" --upgrade pip setuptools wheel
+
+progress 42 "正在安装服务端依赖，首次安装需要数分钟…"
+"$UvBin" pip install --python "$VenvPython" --prefer-binary \
+  --requirements "$SourceDir/requirements.txt"
+
+progress 70 "正在安装本机脚本与文档处理能力…"
+"$UvBin" pip install --python "$VenvPython" --prefer-binary \
+  --requirements "$SourceDir/docker/requirements-script-runner.txt"
+
+progress 78 "正在检查可选的 Node.js 文档能力…"
+NodeExecutable=""
+if [[ "${HUGAGENT_SKIP_OPTIONAL_NODE:-0}" != "1" ]]; then
+  for Candidate in \
+    "$(command -v node 2>/dev/null || true)" \
+    "/opt/homebrew/bin/node" \
+    "/usr/local/bin/node"; do
+    if [[ -n "$Candidate" && -x "$Candidate" ]] \
+      && [[ "$("$Candidate" -p 'Number(process.versions.node.split(".")[0]) >= 20 ? "ok" : "old"' 2>/dev/null)" == "ok" ]]; then
+      NodeExecutable="$Candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -n "$NodeExecutable" ]]; then
+  printf '%s' "$NodeExecutable" > "$InstallRoot/node-executable.txt"
+  NodeDir="$(dirname "$NodeExecutable")"
+  NpmExecutable="$NodeDir/npm"
+  if [[ ! -x "$NpmExecutable" ]]; then
+    NpmExecutable="$(command -v npm 2>/dev/null || true)"
+  fi
+  if [[ -n "$NpmExecutable" && -x "$NpmExecutable" ]]; then
+    NodeDataDir="$InstallRoot/data/node"
+    export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+    if "$NpmExecutable" install --silent --no-audit --no-fund --no-package-lock \
+      --prefix "$NodeDataDir" pptxgenjs playwright; then
+      Playwright="$NodeDataDir/node_modules/.bin/playwright"
+      if [[ -x "$Playwright" ]]; then
+        export PLAYWRIGHT_BROWSERS_PATH="$NodeDataDir/browsers"
+        "$Playwright" install chromium \
+          || echo "Chromium download failed; advanced PDF rendering will use its fallback." >&2
+      fi
+    else
+      echo "Optional Node.js tools couldn't be prepared; the core service will still start." >&2
+    fi
+  fi
+else
+  rm -f "$InstallRoot/node-executable.txt"
+  echo "Node.js 20+ isn't installed; optional site and document tools remain unavailable." >&2
+fi
+
+progress 86 "正在注册 HugAgentOS 本机服务…"
+"$UvBin" pip install --python "$VenvPython" --no-deps --editable "$SourceDir"
+
+if [[ ! -x "$VenvDir/bin/hugagent" ]]; then
+  echo "The HugAgentOS service command wasn't installed correctly." >&2
+  exit 5
+fi
+
+/bin/cp "$BundleDir/desktop-bundle.json" "$InstalledManifest"
+progress 90 "本机服务安装完成，正在启动…"
+printf 'Local server installed at %s\n' "$InstallRoot"

--- a/desktop/scripts/mac-installer.test.mjs
+++ b/desktop/scripts/mac-installer.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const desktopDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const installer = join(
+  desktopDir,
+  "resources",
+  "server-bootstrap",
+  "install-local-server.sh",
+);
+
+function writeExecutable(path, contents) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, "utf8");
+  chmodSync(path, 0o755);
+}
+
+test("macOS bootstrap completes a clean CE install with an isolated runtime", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "hugagent-macos-installer-"));
+  const bundle = join(fixture, "bundle");
+  const installRoot = join(fixture, "installed");
+
+  try {
+    mkdirSync(join(bundle, "src", "frontend", "dist"), { recursive: true });
+    mkdirSync(join(bundle, "docker"), { recursive: true });
+    writeFileSync(join(bundle, "pyproject.toml"), "[project]\nname='test'\n");
+    writeFileSync(join(bundle, "requirements.txt"), "");
+    writeFileSync(join(bundle, "docker", "requirements-script-runner.txt"), "");
+    writeFileSync(join(bundle, "src", "frontend", "dist", "index.html"), "ok");
+    writeFileSync(join(bundle, "desktop-bundle.json"), '{"desktop_version":"test"}\n');
+
+    writeExecutable(
+      join(installRoot, "tools", "uv"),
+      `#!/bin/bash
+set -e
+if [[ "$1" == "venv" ]]; then
+  destination="\${!#}"
+  mkdir -p "$destination/bin"
+  printf '#!/bin/bash\\nexit 0\\n' > "$destination/bin/python"
+  chmod +x "$destination/bin/python"
+elif [[ "$1" == "pip" && " $* " == *" --editable "* ]]; then
+  previous=""
+  python=""
+  for argument in "$@"; do
+    if [[ "$previous" == "--python" ]]; then python="$argument"; fi
+    previous="$argument"
+  done
+  printf '#!/bin/bash\\nexit 0\\n' > "$(dirname "$python")/hugagent"
+  chmod +x "$(dirname "$python")/hugagent"
+fi
+`,
+    );
+
+    const result = spawnSync(
+      "/bin/bash",
+      [
+        installer,
+        "--bundle-dir",
+        bundle,
+        "--install-root",
+        installRoot,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, HUGAGENT_SKIP_OPTIONAL_NODE: "1" },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /HUGAGENT_PROGRESS\|90\|/);
+    assert.equal(
+      readFileSync(join(installRoot, "installed-bundle.json"), "utf8"),
+      '{"desktop_version":"test"}\n',
+    );
+    assert.equal(
+      readFileSync(join(installRoot, "source", "src", "frontend", "dist", "index.html"), "utf8"),
+      "ok",
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -265,12 +265,15 @@ pub fn run() {
                 .path()
                 .app_local_data_dir()
                 .unwrap_or_else(|_| config_dir.clone());
+            let installer_name = if cfg!(target_os = "macos") {
+                "install-local-server.sh"
+            } else {
+                "install-local-server.ps1"
+            };
             let local_server = local_server::LocalServerManager::new(
                 local_data_dir.join("local-server"),
                 resource_dir.join("server-ce"),
-                resource_dir
-                    .join("server-bootstrap")
-                    .join("install-local-server.ps1"),
+                resource_dir.join("server-bootstrap").join(installer_name),
                 http.clone(),
             );
 
@@ -587,7 +590,7 @@ fn build_window(app: &tauri::AppHandle, url: &str) -> tauri::Result<()> {
         .decorations(true)
         .title_bar_style(tauri::TitleBarStyle::Overlay)
         .hidden_title(true)
-        .traffic_light_position(tauri::LogicalPosition::new(18.0, 18.0));
+        .traffic_light_position(tauri::LogicalPosition::new(14.0, 13.0));
     #[cfg(not(target_os = "macos"))]
     let builder = builder.decorations(false);
 

--- a/desktop/src-tauri/src/local_server.rs
+++ b/desktop/src-tauri/src/local_server.rs
@@ -1,6 +1,6 @@
 //! 桌面端托管的无 Docker 本机服务。
 //!
-//! Windows 安装包携带同版本 CE 派生树。这里负责调用 PowerShell 引导脚本创建
+//! Windows 与 macOS 安装包携带同版本 CE 派生树。这里负责调用平台引导脚本创建
 //! 独立 Python 环境、启动 `hugagent serve`、轮询健康状态，并在桌面进程退出时
 //! 回收子进程。业务数据和 Python 环境都在应用本地数据目录，不写安装目录。
 
@@ -42,7 +42,7 @@ impl Default for LocalServerStatus {
             logs: Vec::new(),
             installed: false,
             ready: false,
-            supported: cfg!(target_os = "windows"),
+            supported: cfg!(any(target_os = "windows", target_os = "macos")),
             server_base: LOCAL_SERVER_BASE.to_string(),
         }
     }
@@ -375,8 +375,8 @@ impl LocalServerManager {
     }
 
     async fn run_install(self: &Arc<Self>) -> Result<(), String> {
-        if !cfg!(target_os = "windows") {
-            return Err("当前版本仅支持在 Windows 安装包中一键部署本机服务".to_string());
+        if !cfg!(any(target_os = "windows", target_os = "macos")) {
+            return Err("当前版本暂不支持在此系统一键部署本机服务".to_string());
         }
         if !self.bundle_dir.join("pyproject.toml").is_file() {
             return Err("安装包未携带本机服务资源，请重新下载完整安装包".to_string());
@@ -397,12 +397,14 @@ impl LocalServerManager {
         self.append_log("开始安装本机服务；首次安装通常需要数分钟。")
             .await;
 
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
         {
             use tokio::io::{AsyncBufReadExt, BufReader as AsyncBufReader};
             use tokio::process::Command as TokioCommand;
 
+            #[cfg(target_os = "windows")]
             let mut command = TokioCommand::new("powershell.exe");
+            #[cfg(target_os = "windows")]
             command
                 .args([
                     "-NoLogo",
@@ -420,11 +422,28 @@ impl LocalServerManager {
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
+            #[cfg(target_os = "windows")]
             command.kill_on_drop(true);
+            #[cfg(target_os = "windows")]
             hide_tokio_console(&mut command);
+
+            #[cfg(target_os = "macos")]
+            let mut command = TokioCommand::new("/bin/bash");
+            #[cfg(target_os = "macos")]
+            command
+                .arg(&self.installer_script)
+                .arg("--bundle-dir")
+                .arg(&self.bundle_dir)
+                .arg("--install-root")
+                .arg(&self.root)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true);
+
             let mut child = command
                 .spawn()
-                .map_err(|e| format!("无法启动 PowerShell 安装器：{e}"))?;
+                .map_err(|e| format!("无法启动本机服务安装器：{e}"))?;
             let stdout = child.stdout.take().ok_or("无法读取安装器输出")?;
             let stderr = child.stderr.take().ok_or("无法读取安装器错误输出")?;
 
@@ -458,7 +477,7 @@ impl LocalServerManager {
         self.start_server().await
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     async fn consume_installer_line(&self, line: String) {
         if let Some(rest) = line.strip_prefix("HUGAGENT_PROGRESS|") {
             let mut parts = rest.splitn(2, '|');

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -196,7 +196,7 @@ async fn setup_page(State(state): State<ProxyState>) -> Html<String> {
         )
         .replace(
             "__LOCAL_SUPPORTED__",
-            if cfg!(target_os = "windows") {
+            if cfg!(any(target_os = "windows", target_os = "macos")) {
                 "true"
             } else {
                 "false"
@@ -257,10 +257,10 @@ const TB_OFFSET_SPA: &str =
     "body{box-sizing:border-box!important;padding-top:36px!important}.jx-appLoading{height:100%!important}";
 const TB_OFFSET_PAGE: &str = "body{box-sizing:border-box!important;padding-top:36px!important}";
 
-const MAC_TITLEBAR_HEIGHT: u8 = 52;
+const MAC_TITLEBAR_HEIGHT: u8 = 38;
 const MAC_OFFSET_SPA: &str =
-    "body{box-sizing:border-box!important;padding-top:52px!important}.jx-appLoading{height:100%!important}";
-const MAC_OFFSET_PAGE: &str = "body{box-sizing:border-box!important;padding-top:52px!important}";
+    "body{box-sizing:border-box!important;padding-top:38px!important}.jx-appLoading{height:100%!important}";
+const MAC_OFFSET_PAGE: &str = "body{box-sizing:border-box!important;padding-top:38px!important}";
 
 const TB_CSS: &str = r##"
 #hugagent-titlebar{position:fixed;inset:0 0 auto 0;height:36px;z-index:2147483647;display:flex;align-items:center;background:#F7F8FA;border-bottom:1px solid #E5E9EF;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei",sans-serif;color:#30343B}
@@ -355,20 +355,12 @@ bar.addEventListener('mousedown',function(event){if(event.button!==0||isControl(
 bar.addEventListener('dblclick',function(event){if(isControl(event.target))return;sentinel('/__desktop/win?action=toggle-maximize');});
 })();"##;
 
-// macOS keeps the application menu in the system menu bar and the native
-// traffic-light controls on the left. The in-window strip only exposes app
-// actions, matching the compact icon-toolbar pattern used by modern Mac apps.
+// macOS keeps application actions in the native system menu. Inside the window
+// we only reserve a compact draggable title region for the traffic lights; a
+// second branded toolbar would duplicate the native chrome and waste space.
 const MAC_TB_CSS: &str = r##"
-#hugagent-mac-titlebar{position:fixed;inset:0 0 auto 0;height:52px;z-index:2147483647;display:flex;align-items:center;padding:0 12px 0 82px;background:rgba(247,247,246,.86);border-bottom:1px solid rgba(28,28,28,.09);backdrop-filter:saturate(180%) blur(22px);-webkit-backdrop-filter:saturate(180%) blur(22px);font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text",sans-serif;color:#252522;-webkit-user-select:none;user-select:none}
+#hugagent-mac-titlebar{position:fixed;inset:0 0 auto 0;height:38px;z-index:2147483647;background:rgba(250,250,248,.78);border-bottom:1px solid rgba(28,28,28,.075);backdrop-filter:saturate(160%) blur(18px);-webkit-backdrop-filter:saturate(160%) blur(18px);-webkit-user-select:none;user-select:none}
 #hugagent-mac-titlebar *{box-sizing:border-box}
-#hugagent-mac-titlebar .mac-brand{display:flex;align-items:center;min-width:0;gap:8px;font-size:13px;font-weight:590;letter-spacing:-.01em;color:#3a3935}
-#hugagent-mac-titlebar .mac-logo{width:18px;height:18px;border-radius:5px;object-fit:cover;box-shadow:0 1px 2px rgba(0,0,0,.08)}
-#hugagent-mac-titlebar .mac-spacer{flex:1;height:100%;min-width:24px}
-#hugagent-mac-titlebar .mac-actions{display:flex;align-items:center;gap:7px}
-#hugagent-mac-titlebar .mac-toolButton{width:30px;height:30px;padding:0;border:1px solid rgba(28,28,28,.1);border-radius:8px;background:rgba(255,255,255,.64);color:#45443f;display:flex;align-items:center;justify-content:center;box-shadow:0 1px 1px rgba(0,0,0,.03);cursor:default;transition:background .12s ease,border-color .12s ease,transform .08s ease}
-#hugagent-mac-titlebar .mac-toolButton:hover{background:rgba(255,255,255,.96);border-color:rgba(28,28,28,.16)}
-#hugagent-mac-titlebar .mac-toolButton:active{background:rgba(232,231,227,.92);transform:scale(.96)}
-@media(prefers-color-scheme:dark){#hugagent-mac-titlebar{background:rgba(38,38,36,.88);border-bottom-color:rgba(255,255,255,.09);color:#f2f2ef}#hugagent-mac-titlebar .mac-brand{color:#e7e6e1}#hugagent-mac-titlebar .mac-toolButton{background:rgba(255,255,255,.07);border-color:rgba(255,255,255,.12);color:#e9e8e3}#hugagent-mac-titlebar .mac-toolButton:hover{background:rgba(255,255,255,.13);border-color:rgba(255,255,255,.18)}}
 "##;
 
 const MAC_TB_JS: &str = r##"(function(){
@@ -376,18 +368,12 @@ var bar=document.getElementById('hugagent-mac-titlebar');if(!bar)return;
 if(new URLSearchParams(location.search).get('quickask')==='1'){
   bar.remove();var style=document.getElementById('hugagent-titlebar-style');if(style)style.remove();return;
 }
-function sentinel(path){window.location.href=path;}
-bar.querySelectorAll('[data-act]').forEach(function(item){
-  item.addEventListener('mousedown',function(event){event.preventDefault();});
-  item.addEventListener('click',function(event){event.stopPropagation();sentinel('/__desktop/menu?action='+encodeURIComponent(item.dataset.act));});
-});
 bar.addEventListener('mousedown',function(event){
-  if(event.button!==0||(event.target instanceof Element&&event.target.closest('button')))return;
-  sentinel('/__desktop/win?action=drag');
+  if(event.button!==0)return;
+  window.location.href='/__desktop/win?action=drag';
 });
 bar.addEventListener('dblclick',function(event){
-  if(event.target instanceof Element&&event.target.closest('button'))return;
-  sentinel('/__desktop/win?action=toggle-maximize');
+  window.location.href='/__desktop/win?action=toggle-maximize';
 });
 })();"##;
 
@@ -411,17 +397,10 @@ fn titlebar_block(offset_css: &str) -> String {
 fn mac_titlebar_block(offset_css: &str) -> String {
     format!(
         "<style id=\"hugagent-titlebar-style\">{css}{offset}</style>\
-<header id=\"hugagent-mac-titlebar\" data-height=\"{height}\">\
-<div class=\"mac-brand\"><img class=\"mac-logo\" src=\"{logo}\" alt=\"\" onerror=\"this.style.display='none'\"/><span>{name}</span></div>\
-<div class=\"mac-spacer\"></div><div class=\"mac-actions\">\
-<button class=\"mac-toolButton\" type=\"button\" data-act=\"new_chat\" aria-label=\"新建对话\" title=\"新建对话\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 16 16\" fill=\"none\"><path d=\"M9.8 2.5H4.2A1.7 1.7 0 0 0 2.5 4.2v7.6a1.7 1.7 0 0 0 1.7 1.7h7.6a1.7 1.7 0 0 0 1.7-1.7V6.2M8 8l5.2-5.2M10.5 2.5h3v3\" stroke=\"currentColor\" stroke-width=\"1.35\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></button>\
-<button class=\"mac-toolButton\" type=\"button\" data-act=\"server_config\" aria-label=\"服务设置\" title=\"服务设置\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 16 16\" fill=\"none\"><path d=\"M3 4h10M5.5 8h5M4 12h8\" stroke=\"currentColor\" stroke-width=\"1.35\" stroke-linecap=\"round\"/><circle cx=\"10.5\" cy=\"4\" r=\"1.25\" fill=\"currentColor\"/><circle cx=\"6.5\" cy=\"8\" r=\"1.25\" fill=\"currentColor\"/><circle cx=\"9.5\" cy=\"12\" r=\"1.25\" fill=\"currentColor\"/></svg></button>\
-</div></header><script>{script}</script>",
+<header id=\"hugagent-mac-titlebar\" data-height=\"{height}\" aria-hidden=\"true\"></header><script>{script}</script>",
         css = MAC_TB_CSS,
         offset = offset_css,
         height = MAC_TITLEBAR_HEIGHT,
-        logo = brand::LOGIN_LOGO_URL,
-        name = brand::NAME,
         script = MAC_TB_JS,
     )
 }
@@ -435,9 +414,12 @@ fn platform_titlebar_block(spa: bool) -> String {
 }
 
 fn inject_after_body(html: &str, block: &str) -> String {
-    match html.find("<body>") {
-        Some(position) => {
-            let index = position + "<body>".len();
+    match html.find("<body").and_then(|position| {
+        html[position..]
+            .find('>')
+            .map(|closing| position + closing + 1)
+    }) {
+        Some(index) => {
             let mut output = String::with_capacity(html.len() + block.len());
             output.push_str(&html[..index]);
             output.push_str(block);
@@ -456,66 +438,58 @@ const LOGIN_HTML: &str = r##"<!doctype html>
 <title>登录 · HugAgentOS</title>
 <style>
   :root{
-    --primary:#126DFF; --primary-hover:#3C87FF; --primary-active:#0862F3;
-    --text:#262626; --text-2:#808080; --text-3:#B3B3B3; --border:#E8EBF0; --card:#fff;
+    color-scheme:light;--primary:#0A66FF;--primary-hover:#005BE6;--primary-active:#0052CC;
+    --text:#1D1D1F;--text-2:#6E6E73;--text-3:#8E8E93;
   }
   *{box-sizing:border-box}
   html,body{height:100%;margin:0}
   body{
-    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei",sans-serif;
+    font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","PingFang SC","Segoe UI",sans-serif;
     color:var(--text);
-    background:
-      radial-gradient(1200px 560px at 50% -12%, #E5EFFF 0%, rgba(229,239,255,0) 62%),
-      linear-gradient(180deg,#FBFCFE 0%, #EEF2F8 100%);
+    background:linear-gradient(180deg,#FBFBFA 0%,#F4F4F2 100%);
     display:flex; align-items:center; justify-content:center;
     -webkit-user-select:none; user-select:none;
   }
   .card{
-    width:392px; padding:46px 42px 30px; text-align:center;
-    background:var(--card); border:1px solid var(--border); border-radius:22px;
-    box-shadow:0 24px 70px rgba(18,109,255,.12), 0 2px 10px rgba(15,23,42,.05);
+    width:min(380px,calc(100% - 40px));padding:32px 20px;text-align:center;margin-top:-18px;
   }
   .logo{
-    width:74px;height:74px;border-radius:19px;margin:0 auto 20px;display:block;
-    box-shadow:0 10px 24px rgba(18,109,255,.24);
+    width:64px;height:64px;border-radius:16px;margin:0 auto 20px;display:block;
+    box-shadow:0 8px 24px rgba(0,0,0,.1);
   }
-  h1{font-size:22px;font-weight:600;margin:0 0 8px;letter-spacing:.4px}
-  .sub{font-size:13.5px;color:var(--text-2);margin:0 0 32px;line-height:1.75}
+  .edition{display:inline-flex;height:24px;align-items:center;padding:0 10px;margin-bottom:14px;
+    border:1px solid rgba(60,60,67,.16);border-radius:999px;color:var(--text-2);background:rgba(255,255,255,.72);
+    font-size:11px;font-weight:600}
+  h1{font-size:28px;line-height:1.2;font-weight:650;margin:0;letter-spacing:-.035em}
+  .sub{font-size:14px;color:var(--text-2);margin:12px 0 28px;line-height:1.65}
   .btn{
-    width:100%;height:48px;border:none;border-radius:13px;cursor:pointer;
-    background:var(--primary);color:#fff;font-size:15px;font-weight:500;
-    display:inline-flex;align-items:center;justify-content:center;gap:9px;
-    transition:background .15s ease, transform .04s ease, box-shadow .15s ease;
-    box-shadow:0 6px 16px rgba(18,109,255,.28);
+    width:100%;height:46px;border:none;border-radius:11px;cursor:pointer;
+    background:var(--primary);color:#fff;font-size:14px;font-weight:600;
+    transition:background .14s ease,transform .08s ease;box-shadow:0 1px 2px rgba(0,0,0,.08);
   }
   .btn:hover{background:var(--primary-hover)}
-  .btn:active{background:var(--primary-active);transform:translateY(1px)}
-  .hint{margin-top:16px;font-size:12.5px;color:var(--text-3)}
+  .btn:active{background:var(--primary-active);transform:scale(.99)}
+  .hint{margin-top:14px;font-size:12px;color:var(--text-3)}
   .links{margin-top:8px;font-size:13px}
   .links a{color:var(--primary);text-decoration:none;cursor:pointer;margin:0 8px}
   .links a:hover{text-decoration:underline}
-  .spin{width:36px;height:36px;margin:8px auto 20px;border:3px solid #E8EBF0;
+  .spin{width:32px;height:32px;margin:8px auto 22px;border:3px solid #E5E5EA;
     border-top-color:var(--primary);border-radius:50%;animation:r .9s linear infinite}
   @keyframes r{to{transform:rotate(360deg)}}
-  .foot{margin-top:30px;padding-top:18px;border-top:1px solid #F0F2F6;
-    font-size:12px;color:var(--text-3)}
+  .foot{margin-top:24px;font-size:11px;color:var(--text-3)}
   .hidden{display:none}
 </style>
 </head>
 <body>
   <div class="card">
     <img class="logo" src="/icon.png" alt="HugAgentOS" onerror="this.style.display='none'"/>
+    <span class="edition">社区版 CE</span>
     <!-- 初始态：等待用户点击登录 -->
     <div id="idle">
       <h1>HugAgentOS</h1>
-      <p class="sub">在系统浏览器中安全登录后<br/>自动返回桌面客户端继续使用</p>
-      <button class="btn" onclick="startLogin()">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5M10 17l5-5-5-5M15 12H3"
-            stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        开始使用
-      </button>
-      <div class="hint">点击后将在系统默认浏览器中打开登录页面</div>
+      <p class="sub">登录后即可在桌面端继续使用。<br/>验证会在系统浏览器中安全完成。</p>
+      <button class="btn" onclick="startLogin()">登录并继续</button>
+      <div class="hint">完成后会自动返回此窗口</div>
     </div>
     <!-- 等待态：浏览器已打开，等待回跳 -->
     <div id="waiting" class="hidden">
@@ -559,85 +533,76 @@ const SETUP_HTML: &str = r##"<!doctype html>
 <title>服务设置 · HugAgentOS</title>
 <style>
   :root{
-    --primary:#126DFF;--primary-hover:#3C87FF;--text:#1F2937;--text-2:#64748B;
-    --border:#E5EAF1;--bg:#F4F7FB;--ok:#0F9D68;--danger:#D4380D;
+    color-scheme:light;
+    --accent:#0A66FF;--accent-hover:#005BE6;--accent-active:#0052CC;
+    --text:#1D1D1F;--secondary:#6E6E73;--tertiary:#8E8E93;
+    --line:rgba(60,60,67,.16);--ok:#248A3D;--danger:#D70015;
   }
   *{box-sizing:border-box}
   html,body{height:100%;margin:0}
-  body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei",sans-serif;
-    color:var(--text);background:radial-gradient(900px 440px at 50% -15%,#DCE9FF 0,transparent 68%),var(--bg);
-    display:flex;align-items:center;justify-content:center;padding:28px}
-  .shell{width:min(760px,100%);background:#fff;border:1px solid var(--border);border-radius:22px;
-    box-shadow:0 24px 70px rgba(30,64,175,.12);overflow:hidden}
-  .head{padding:28px 32px 22px;border-bottom:1px solid #EEF1F5}
-  .brand{font-size:13px;color:var(--primary);font-weight:650;margin-bottom:8px}
-  h1{font-size:24px;margin:0 0 8px}.lead{margin:0;color:var(--text-2);font-size:14px;line-height:1.7}
-  .body{padding:24px 32px 30px}.choices{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-  .choice{border:1px solid var(--border);border-radius:16px;padding:20px;background:#fff}
-  .choice.recommended{border-color:#B8D2FF;background:#F8FBFF}
-  .tag{display:inline-flex;padding:3px 8px;border-radius:999px;background:#E8F1FF;color:var(--primary);
-    font-size:11px;font-weight:650;margin-bottom:10px}
-  h2{font-size:17px;margin:0 0 8px}.desc{font-size:13px;color:var(--text-2);line-height:1.7;min-height:66px}
-  .btn{height:42px;border-radius:10px;padding:0 17px;border:1px solid var(--border);background:#fff;
-    color:var(--text);font-size:14px;font-weight:550;cursor:pointer;transition:.15s}
-  .btn:hover{background:#F8FAFC}.btn.primary{width:100%;border:0;background:var(--primary);color:#fff;
-    box-shadow:0 5px 14px rgba(18,109,255,.25)}.btn.primary:hover{background:var(--primary-hover)}
-  .btn:disabled{opacity:.55;cursor:not-allowed}.actions{display:flex;gap:10px;margin-top:14px;flex-wrap:wrap}
-  .progress-wrap{display:none;margin-top:22px;border-top:1px solid #EEF1F5;padding-top:20px}
-  .progress-head{display:flex;justify-content:space-between;gap:12px;font-size:13px;margin-bottom:9px}
-  .progress{height:8px;border-radius:999px;background:#E9EEF5;overflow:hidden}.bar{height:100%;width:0;
-    background:linear-gradient(90deg,#126DFF,#5B9BFF);transition:width .3s ease}
-  .message{color:var(--text-2)}.percent{font-variant-numeric:tabular-nums;color:var(--primary)}
-  .log{margin-top:12px;height:128px;overflow:auto;padding:11px 12px;border-radius:10px;background:#101827;
-    color:#D5DEEC;font:11.5px/1.55 Consolas,"SFMono-Regular",monospace;white-space:pre-wrap;word-break:break-all}
-  .error{display:none;color:var(--danger);font-size:13px;margin-top:12px}.ready{color:var(--ok)}
-  .current{margin-top:17px;color:#94A3B8;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  body.platform-macos{background:#ECECEA;padding-left:22px;padding-right:22px}
-  body.platform-macos .shell{max-width:720px;border-color:rgba(28,28,28,.1);border-radius:16px;box-shadow:0 22px 55px rgba(0,0,0,.12)}
-  body.platform-macos .head{padding-top:25px;background:rgba(252,252,250,.92)}
-  body.platform-macos .body{background:#FAFAF8}
-  body.platform-macos .choice{border-color:rgba(28,28,28,.1);border-radius:13px;box-shadow:0 1px 1px rgba(0,0,0,.025)}
-  body.platform-macos .choice.recommended{border-color:rgba(18,109,255,.3);background:#F7FAFF}
-  body.platform-macos .btn{border-radius:9px;box-shadow:none}
-  @media(max-width:640px){.choices{grid-template-columns:1fr}.desc{min-height:0}.head,.body{padding-left:22px;padding-right:22px}}
+  body{font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","PingFang SC","Segoe UI",sans-serif;
+    color:var(--text);background:#FAFAF8;display:flex;align-items:center;justify-content:center;
+    padding:28px;-webkit-user-select:none;user-select:none}
+  .setup{width:min(520px,100%);text-align:center;padding:24px 34px 28px}
+  .logo{display:block;width:64px;height:64px;margin:0 auto 20px;border-radius:16px;
+    box-shadow:0 8px 24px rgba(0,0,0,.1)}
+  .edition{display:inline-flex;align-items:center;height:24px;padding:0 10px;margin-bottom:14px;
+    border:1px solid var(--line);border-radius:999px;color:var(--secondary);background:rgba(255,255,255,.72);
+    font-size:11px;font-weight:600;letter-spacing:.02em}
+  h1{margin:0;font-size:28px;line-height:1.2;font-weight:650;letter-spacing:-.035em}
+  .lead{max-width:430px;margin:12px auto 0;color:var(--secondary);font-size:14px;line-height:1.65}
+  .actions{width:min(360px,100%);margin:28px auto 0}
+  .button{width:100%;height:46px;border:0;border-radius:11px;padding:0 18px;font:600 14px/1 inherit;
+    cursor:pointer;transition:background .14s ease,transform .08s ease,opacity .14s ease}
+  .button.primary{background:var(--accent);color:#fff;box-shadow:0 1px 2px rgba(0,0,0,.08)}
+  .button.primary:hover{background:var(--accent-hover)}.button.primary:active{background:var(--accent-active);transform:scale(.99)}
+  .button:disabled{opacity:.5;cursor:default;transform:none}
+  .link-button{margin-top:13px;padding:6px 10px;border:0;background:transparent;color:var(--accent);
+    font:500 13px/1.2 inherit;cursor:pointer;border-radius:7px}
+  .link-button:hover{background:rgba(10,102,255,.07)}
+  .promise{display:flex;justify-content:center;gap:8px;margin:18px 0 0;color:var(--tertiary);font-size:12px}
+  .promise span+span::before{content:"·";margin-right:8px;color:#C7C7CC}
+  .progress-wrap{display:none;margin-top:28px;padding-top:24px;border-top:1px solid var(--line);text-align:left}
+  .progress-head{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:10px;font-size:13px}
+  .message{color:var(--secondary)}.percent{color:var(--accent);font-variant-numeric:tabular-nums}
+  .progress{height:6px;border-radius:999px;background:#E5E5EA;overflow:hidden}
+  .bar{height:100%;width:0;border-radius:inherit;background:var(--accent);transition:width .28s ease}
+  .error{display:none;margin-top:12px;padding:10px 12px;border-radius:9px;background:#FFF1F0;color:var(--danger);
+    font-size:12.5px;line-height:1.5}.ready{color:var(--ok);font-weight:600}
+  details{margin-top:12px;color:var(--secondary);font-size:12px}summary{width:max-content;cursor:pointer;outline:none}
+  .log{height:116px;margin:9px 0 0;padding:11px 12px;overflow:auto;border:1px solid var(--line);
+    border-radius:9px;background:#F2F2F4;color:#48484A;font:11px/1.55 "SFMono-Regular",Consolas,monospace;
+    white-space:pre-wrap;word-break:break-all;-webkit-user-select:text;user-select:text}
+  .ready-actions{display:none;margin-top:16px}
+  .connection{margin-top:26px;color:var(--tertiary);font-size:11px;line-height:1.5;
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .connection button{padding:2px 4px;border:0;background:transparent;color:var(--secondary);font:inherit;cursor:pointer}
+  body.platform-macos{background:linear-gradient(180deg,#FBFBFA 0%,#F4F4F2 100%)}
+  body.platform-macos .setup{margin-top:-18px}
+  @media(max-width:620px){body{padding:18px}.setup{padding:18px 12px 24px}h1{font-size:25px}.promise{flex-wrap:wrap}}
 </style>
 </head>
 <body class="platform-__PLATFORM__">
-  <main class="shell">
-    <header class="head">
-      <div class="brand">HugAgentOS 桌面端</div>
-      <h1>选择服务运行方式</h1>
-      <p class="lead" id="lead">当前服务不可用。你可以在本机一键安装单用户服务，也可以连接已经部署的团队服务器。</p>
-    </header>
-    <section class="body">
-      <div class="choices">
-        <article class="choice recommended">
-          <span class="tag">推荐 · 无需 Docker</span>
-          <h2>安装本机服务</h2>
-          <p class="desc">自动创建独立 Python 环境并启动内置 CE 单机服务。数据只保存在当前电脑，适合个人使用。</p>
-          <button class="btn primary" id="install" onclick="installLocal()">一键安装并启动</button>
-          <div class="actions" id="readyActions" style="display:none">
-            <button class="btn primary" id="readyButton" onclick="finishReady()">切换到本机服务</button>
-          </div>
-        </article>
-        <article class="choice">
-          <span class="tag">团队 / 私有化</span>
-          <h2>连接已有服务器</h2>
-          <p class="desc">继续使用组织已经部署的 HugAgentOS 服务。填写 HTTP 或 HTTPS 后端地址即可。</p>
-          <div class="actions">
-            <button class="btn" onclick="connectServer()">设置服务器地址</button>
-            <button class="btn" onclick="retry()">重试当前地址</button>
-          </div>
-        </article>
-      </div>
-      <div class="progress-wrap" id="progressWrap">
-        <div class="progress-head"><span class="message" id="message">准备安装…</span><span class="percent" id="percent">0%</span></div>
-        <div class="progress"><div class="bar" id="bar"></div></div>
-        <pre class="log" id="log">等待安装日志…</pre>
-        <div class="error" id="error"></div>
-      </div>
-      <div class="current">当前地址：__CURRENT_BASE__</div>
+  <main class="setup">
+    <img class="logo" src="/icon.png" alt="HugAgentOS" onerror="this.style.visibility='hidden'" />
+    <span class="edition">社区版 CE</span>
+    <h1 id="title">在这台电脑上开始使用</h1>
+    <p class="lead" id="lead">自动准备运行环境并启动本机服务。完成后即可直接进入 HugAgentOS，无需 Docker，也无需手动配置。</p>
+    <section class="actions" aria-label="初始化操作">
+      <button class="button primary" id="install" type="button" onclick="installLocal()">从零开始安装</button>
+      <button class="link-button" id="connect" type="button" onclick="connectServer()">连接已有服务器</button>
+      <p class="promise"><span>单用户运行</span><span>数据保存在本机</span><span>可随时切换服务器</span></p>
     </section>
+    <section class="progress-wrap" id="progressWrap" aria-live="polite">
+      <div class="progress-head"><span class="message" id="message">准备安装…</span><span class="percent" id="percent">0%</span></div>
+      <div class="progress" role="progressbar" aria-label="安装进度" aria-valuemin="0" aria-valuemax="100"><div class="bar" id="bar"></div></div>
+      <div class="error" id="error"></div>
+      <details id="details"><summary>查看安装详情</summary><pre class="log" id="log">等待安装日志…</pre></details>
+      <div class="ready-actions" id="readyActions">
+        <button class="button primary" id="readyButton" type="button" onclick="finishReady()">进入 HugAgentOS</button>
+      </div>
+    </section>
+    <div class="connection">当前连接：__CURRENT_BASE__ <button type="button" onclick="retry()">重新检测</button></div>
   </main>
 <script>
   var manage = new URLSearchParams(location.search).get('manage') === '1';
@@ -645,7 +610,14 @@ const SETUP_HTML: &str = r##"<!doctype html>
   var localSupported = __LOCAL_SUPPORTED__;
   var installing = false;
   var pollTimer = null;
-  if(manage){document.getElementById('lead').textContent='查看或切换本机单用户服务，也可以继续连接已部署的团队服务器。';}
+  if(document.body.classList.contains('platform-macos')){
+    document.getElementById('title').textContent='在这台 Mac 上开始使用';
+  }
+  if(manage){
+    document.getElementById('title').textContent='本机服务';
+    document.getElementById('lead').textContent='查看当前状态，重新安装本机服务，或切换到团队服务器。';
+    document.getElementById('install').textContent='安装或修复本机服务';
+  }
   function sentinel(path){ window.location.href = path; }
   function connectServer(){ sentinel('/__desktop/connect-server'); }
   function retry(){ sentinel('/__desktop/retry-server'); }
@@ -655,7 +627,9 @@ const SETUP_HTML: &str = r##"<!doctype html>
     if(!localSupported){showError('当前安装包暂不支持在此系统一键部署本机服务。');return;}
     installing = true;
     var button=document.getElementById('install');
-    button.disabled=true;button.textContent='正在启动安装…';
+    button.disabled=true;button.textContent='正在开始…';
+    document.getElementById('connect').style.display='none';
+    document.querySelector('.promise').style.display='none';
     document.getElementById('progressWrap').style.display = 'block';
     document.getElementById('message').textContent='正在准备本机服务…';
     document.getElementById('error').style.display='none';
@@ -668,7 +642,8 @@ const SETUP_HTML: &str = r##"<!doctype html>
   }
   function showError(text){
     var el=document.getElementById('error');el.textContent=text;el.style.display='block';
-    var button=document.getElementById('install');button.disabled=false;button.textContent='重试安装';
+    document.getElementById('details').open=true;
+    var button=document.getElementById('install');button.disabled=false;button.textContent='重新安装';
   }
   async function poll(){
     if(pollTimer){clearTimeout(pollTimer);pollTimer=null;}
@@ -678,8 +653,10 @@ const SETUP_HTML: &str = r##"<!doctype html>
       activeLocal=!!s.active_local;
       var active=['installing','starting','ready','error'].includes(s.phase) || installing;
       if(active) document.getElementById('progressWrap').style.display='block';
-      document.getElementById('bar').style.width=(s.progress||0)+'%';
-      document.getElementById('percent').textContent=(s.progress||0)+'%';
+      var progress=Math.max(0,Math.min(100,s.progress||0));
+      document.getElementById('bar').style.width=progress+'%';
+      document.querySelector('.progress').setAttribute('aria-valuenow',String(progress));
+      document.getElementById('percent').textContent=progress+'%';
       document.getElementById('message').textContent=s.message||'准备安装…';
       document.getElementById('log').textContent=(s.logs&&s.logs.length?s.logs.join('\n'):'等待安装日志…');
       document.getElementById('log').scrollTop=document.getElementById('log').scrollHeight;
@@ -704,7 +681,9 @@ const SETUP_HTML: &str = r##"<!doctype html>
       }
       if(s.phase==='installing'||s.phase==='starting'){
         installing=true;var button=document.getElementById('install');button.disabled=true;
-        button.textContent=s.phase==='starting'?'正在启动服务…':'正在安装…';
+        button.textContent=s.phase==='starting'?'正在启动…':'正在安装…';
+      }else if(s.installed&&!manage){
+        document.getElementById('install').textContent='启动本机服务';
       }
     }catch(e){ if(installing) showError('读取安装状态失败：'+e.message); }
     pollTimer=setTimeout(poll,900);
@@ -841,11 +820,12 @@ mod tests {
     }
 
     #[test]
-    fn mac_titlebar_keeps_native_window_controls_and_uses_app_actions() {
+    fn mac_titlebar_is_a_compact_drag_region_without_duplicate_actions() {
         let block = mac_titlebar_block(MAC_OFFSET_SPA);
         assert!(block.contains("hugagent-mac-titlebar"));
-        assert!(block.contains("data-act=\"new_chat\""));
-        assert!(block.contains("data-act=\"server_config\""));
+        assert!(block.contains("height:38px"));
+        assert!(!block.contains("data-act="));
+        assert!(!block.contains("mac-toolButton"));
         assert!(!block.contains("data-win=\"minimize\""));
         assert!(!block.contains("data-win=\"close\""));
         assert!(!block.contains("tb-menuLabel"));
@@ -854,8 +834,15 @@ mod tests {
     #[test]
     fn setup_install_starts_in_place_before_switching_modes() {
         assert!(SETUP_HTML.contains("fetch('/__desktop/setup/install'"));
-        assert!(SETUP_HTML.contains("正在启动安装"));
+        assert!(SETUP_HTML.contains("从零开始安装"));
         assert!(!SETUP_HTML.contains("if(!activeLocal){ activateLocal(); return; }"));
+    }
+
+    #[test]
+    fn setup_mac_copy_and_single_primary_action_are_present() {
+        assert!(SETUP_HTML.contains("在这台 Mac 上开始使用"));
+        assert_eq!(SETUP_HTML.matches("id=\"install\"").count(), 1);
+        assert!(!SETUP_HTML.contains("class=\"choices\""));
     }
 
     #[test]
@@ -865,6 +852,16 @@ mod tests {
         assert_eq!(
             output,
             "<html><body><header>titlebar</header><main>content</main></body></html>"
+        );
+    }
+
+    #[test]
+    fn titlebar_is_injected_inside_body_with_attributes() {
+        let html = "<!doctype html><html><body class=\"platform-macos\"><main>content</main></body></html>";
+        let output = inject_after_body(html, "<header>titlebar</header>");
+        assert_eq!(
+            output,
+            "<!doctype html><html><body class=\"platform-macos\"><header>titlebar</header><main>content</main></body></html>"
         );
     }
 }

--- a/desktop/src-tauri/tauri.macos.conf.json
+++ b/desktop/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeBuildCommand": "node scripts/prepare-bundle.mjs"
+  },
+  "bundle": {
+    "targets": ["app", "dmg"],
+    "resources": {
+      "../resources/server-bootstrap": "server-bootstrap",
+      "../generated/server-ce": "server-ce"
+    },
+    "macOS": {
+      "minimumSystemVersion": "12.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- redesign the macOS desktop title bar and initialization screens around a compact, native-style single-action flow
- enable the CE “从零开始安装” path on macOS with an app-local Python 3.11 environment and bundled CE server payload
- add macOS Tauri resource configuration plus CI coverage for payload staging, frontend builds, installer behavior, and Rust logic

## Why

The previous macOS flow reused a visually heavy injected toolbar, exposed duplicate actions, and deliberately marked local installation as unsupported. The macOS bundle also lacked the bootstrap script and CE server resources required to complete a clean installation.

## User impact

CE users can now start from a clean macOS installation directly from the welcome screen. The desktop app keeps its runtime and data inside the application-local data directory and still supports connecting to an existing server as a secondary path.

## Validation

- CE derivation: all 7 generation, required-file, license, and brand gates passed
- CE frontend production build: passed
- desktop resource staging: passed
- desktop Node tests: 9 passed
- Rust tests: 14 passed
- shell syntax and diff checks: passed

The current development host is Linux/WSL, so the signed universal macOS DMG remains delegated to the repository’s macOS release workflow.
