### PR TITLE
fix(desktop): align Windows chrome and service lifecycle

### DIFF
--- a/desktop/src-tauri/installer-hooks.nsh
+++ b/desktop/src-tauri/installer-hooks.nsh
@@ -51,3 +51,12 @@
 
   hugagent_install_mode_done:
 !macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  ; 本机模式把 venv、CE 源码、SQLite/上传文件、Node 工具与日志统一放在
+  ; app_local_data_dir/local-server。卸载前只结束该目录下、且 PID 与记录
+  ; 匹配的进程，避免陈旧 PID 误杀其它 Python；随后清理整套托管数据。
+  nsExec::ExecToLog `powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$root=[IO.Path]::GetFullPath('$LOCALAPPDATA\com.hugagent.desktop\local-server').TrimEnd('\'); $$pidFile=Join-Path $$root 'server.pid'; if(Test-Path -LiteralPath $$pidFile){ $$pidText=(Get-Content -LiteralPath $$pidFile -Raw).Trim(); if($$pidText -match '^\d+$$'){ $$p=Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $$pidText) -ErrorAction SilentlyContinue; if($$p -and $$p.ExecutablePath -and [IO.Path]::GetFullPath($$p.ExecutablePath).StartsWith($$root + '\',[StringComparison]::OrdinalIgnoreCase)){ & taskkill.exe /PID $$pidText /T /F | Out-Null } } }"`
+  Sleep 500
+  RMDir /r "$LOCALAPPDATA\com.hugagent.desktop\local-server"
+!macroend

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ pub(crate) struct Shared {
     pub(crate) http: reqwest::Client,
     pub(crate) port: u16,
     pub(crate) config_dir: std::path::PathBuf,
+    pub(crate) local_server: Arc<local_server::LocalServerManager>,
 }
 
 impl Shared {
@@ -345,6 +346,7 @@ pub fn run() {
                 http: http.clone(),
                 port,
                 config_dir: config_dir.clone(),
+                local_server: local_server.clone(),
             });
 
             // 运行时 deep-link 回调（macOS / 已运行实例）。
@@ -391,6 +393,19 @@ pub fn run() {
         .expect("运行 Tauri 应用失败");
 
     app.run(|_app_handle, _event| {
+        // Tauri may tear down the async runtime before managed-state Drop runs.
+        // Stop the Python process synchronously while the AppHandle and PID
+        // metadata are still available; repeated exit events are idempotent.
+        if matches!(
+            _event,
+            tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
+        ) {
+            let local_server = _app_handle.state::<Shared>().local_server.clone();
+            if let Err(error) = local_server.shutdown() {
+                eprintln!("[local-server] 退出时停止本机服务失败: {error}");
+            }
+        }
+
         // 主窗口被红色关闭按钮隐藏后，点击 Dock 图标应立即恢复，而不是只激活一个
         // 没有可见窗口的后台进程。
         #[cfg(target_os = "macos")]

--- a/desktop/src-tauri/src/local_server.rs
+++ b/desktop/src-tauri/src/local_server.rs
@@ -56,6 +56,7 @@ pub struct LocalServerManager {
     status: RwLock<LocalServerStatus>,
     child: Mutex<Option<Child>>,
     install_running: AtomicBool,
+    shutting_down: AtomicBool,
 }
 
 impl LocalServerManager {
@@ -77,6 +78,7 @@ impl LocalServerManager {
             status: RwLock::new(initial_status),
             child: Mutex::new(None),
             install_running: AtomicBool::new(false),
+            shutting_down: AtomicBool::new(false),
         })
     }
 
@@ -241,6 +243,9 @@ impl LocalServerManager {
 
     /// 后台启动已安装的本机服务；重复调用是幂等的。
     pub fn start_in_background(self: &Arc<Self>) {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return;
+        }
         let manager = self.clone();
         tauri::async_runtime::spawn(async move {
             if let Err(error) = manager.start_server().await {
@@ -250,6 +255,9 @@ impl LocalServerManager {
     }
 
     async fn start_server(self: &Arc<Self>) -> Result<(), String> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err("桌面端正在退出，不再启动本机服务".to_string());
+        }
         if self.is_ready().await {
             self.update("ready", 100, "本机服务已就绪").await;
             return Ok(());
@@ -276,6 +284,9 @@ impl LocalServerManager {
             };
 
             if !already_running {
+                if self.shutting_down.load(Ordering::SeqCst) {
+                    return Err("桌面端正在退出，不再启动本机服务".to_string());
+                }
                 std::fs::create_dir_all(self.root.join("logs"))
                     .map_err(|e| format!("创建日志目录失败：{e}"))?;
                 let stdout = open_log(&self.log_path())?;
@@ -294,6 +305,7 @@ impl LocalServerManager {
                     .arg("--no-browser")
                     .current_dir(self.source_dir())
                     .env("HUGAGENT_HOME", self.data_dir())
+                    .env("HUGAGENT_BOOTSTRAP_DEFAULT_PLUGINS", "1")
                     .env(
                         "FRONTEND_DIST_DIR",
                         self.source_dir().join("src").join("frontend").join("dist"),
@@ -376,6 +388,9 @@ impl LocalServerManager {
 
     /// 从桌面安装包携带的 CE 派生树安装或升级本机服务。
     pub fn install_in_background(self: &Arc<Self>) -> bool {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return false;
+        }
         if self
             .install_running
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -397,6 +412,9 @@ impl LocalServerManager {
 
     /// 用户点击「一键安装并启动」时，已安装同版本则只启动，否则执行安装/升级。
     pub fn prepare_in_background(self: &Arc<Self>) -> bool {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return false;
+        }
         if self.needs_install() {
             self.install_in_background()
         } else {
@@ -406,6 +424,9 @@ impl LocalServerManager {
     }
 
     async fn run_install(self: &Arc<Self>) -> Result<(), String> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err("桌面端正在退出，已取消本机服务安装".to_string());
+        }
         if !cfg!(any(target_os = "windows", target_os = "macos")) {
             return Err("当前版本暂不支持在此系统一键部署本机服务".to_string());
         }
@@ -549,10 +570,27 @@ impl LocalServerManager {
     fn stop_server(&self) -> Result<(), String> {
         if let Ok(mut guard) = self.child.lock() {
             if let Some(child) = guard.as_mut() {
+                let running = child
+                    .try_wait()
+                    .map_err(|error| format!("检查本机服务进程失败：{error}"))?
+                    .is_none();
                 #[cfg(target_os = "windows")]
-                stop_server_process(child.id(), &self.executable(), false)?;
+                if running {
+                    // This PID comes from the live Child handle owned by this
+                    // manager, so killing its process tree cannot target a stale
+                    // reused PID. Fall back to Child::kill if taskkill fails.
+                    if let Err(tree_error) = stop_process_tree(child.id()) {
+                        child.kill().map_err(|kill_error| {
+                            format!(
+                                "结束本机服务进程树失败（{tree_error}），备用回收也失败：{kill_error}"
+                            )
+                        })?;
+                    }
+                }
                 #[cfg(not(target_os = "windows"))]
-                let _ = child.kill();
+                if running {
+                    let _ = child.kill();
+                }
                 let _ = child.wait();
                 let _ = std::fs::remove_file(self.pid_path());
                 *guard = None;
@@ -562,6 +600,13 @@ impl LocalServerManager {
         stop_recorded_server(&self.pid_path(), &self.executable(), &self.root)?;
         let _ = std::fs::remove_file(self.pid_path());
         Ok(())
+    }
+
+    /// Stop the managed Python service and permanently block respawn in this
+    /// desktop process. A newly launched desktop process creates a fresh manager.
+    pub fn shutdown(&self) -> Result<(), String> {
+        self.shutting_down.store(true, Ordering::SeqCst);
+        self.stop_server()
     }
 }
 
@@ -581,7 +626,7 @@ fn powershell_compatible_path(path: &Path) -> OsString {
 
 impl Drop for LocalServerManager {
     fn drop(&mut self) {
-        let _ = self.stop_server();
+        let _ = self.shutdown();
     }
 }
 
@@ -606,8 +651,8 @@ fn hide_console(_command: &mut Command) {}
 #[cfg(target_os = "windows")]
 fn stop_recorded_server(
     pid_path: &Path,
-    expected_executable: &Path,
-    _install_root: &Path,
+    _expected_executable: &Path,
+    install_root: &Path,
 ) -> Result<(), String> {
     let Ok(raw_pid) = std::fs::read_to_string(pid_path) else {
         return Ok(());
@@ -618,19 +663,34 @@ fn stop_recorded_server(
         .map_err(|_| "本机服务 PID 文件已损坏".to_string())?;
     // PID 文件可能来自上次异常退出；若该 PID 已被别的程序复用，只清理陈旧
     // 记录，不结束无关进程，也不阻断本次重新安装/启动。
-    stop_server_process(pid, expected_executable, true)
+    stop_recorded_process_tree(pid, install_root)
 }
 
 #[cfg(target_os = "windows")]
-fn stop_server_process(
-    pid: u32,
-    expected_executable: &Path,
-    allow_stale_pid: bool,
-) -> Result<(), String> {
+fn stop_process_tree(pid: u32) -> Result<(), String> {
+    let mut command = Command::new("taskkill.exe");
+    command.args(["/PID", &pid.to_string(), "/T", "/F"]);
+    hide_console(&mut command);
+    let status = command
+        .status()
+        .map_err(|error| format!("无法回收本机服务进程树：{error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "回收本机服务进程树失败（退出码 {:?}）",
+            status.code()
+        ))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn stop_recorded_process_tree(pid: u32, install_root: &Path) -> Result<(), String> {
     let script = format!(
         "$p=Get-CimInstance Win32_Process -Filter 'ProcessId = {pid}'; \
          if (-not $p) {{ exit 0 }}; \
-         if ($p.ExecutablePath -ne $env:HUGAGENT_EXPECTED_EXE) {{ exit 3 }}; \
+         $root=[IO.Path]::GetFullPath($env:HUGAGENT_INSTALL_ROOT).TrimEnd('\\'); \
+         if (-not $p.ExecutablePath -or -not [IO.Path]::GetFullPath($p.ExecutablePath).StartsWith($root + '\\',[StringComparison]::OrdinalIgnoreCase)) {{ exit 3 }}; \
          & taskkill.exe /PID {pid} /T /F | Out-Null; exit $LASTEXITCODE"
     );
     let mut command = Command::new("powershell.exe");
@@ -642,15 +702,14 @@ fn stop_server_process(
             "-Command",
             &script,
         ])
-        .env("HUGAGENT_EXPECTED_EXE", expected_executable);
+        .env("HUGAGENT_INSTALL_ROOT", install_root);
     hide_console(&mut command);
     let status = command
         .status()
         .map_err(|error| format!("无法回收上次本机服务进程：{error}"))?;
     match status.code() {
         Some(0) => Ok(()),
-        Some(3) if allow_stale_pid => Ok(()),
-        Some(3) => Err("检测到 PID 已被其他程序复用；为避免误杀，未自动结束该进程".to_string()),
+        Some(3) => Ok(()),
         code => Err(format!("回收上次本机服务进程失败（退出码 {code:?}）")),
     }
 }
@@ -794,6 +853,25 @@ mod tests {
 
         std::fs::write(manager.bundle_dir.join("desktop-bundle.json"), "new\n").unwrap();
         assert!(manager.needs_install());
+    }
+
+    #[test]
+    fn shutdown_prevents_the_local_service_from_restarting() {
+        let manager = manager("shutdown");
+
+        manager.shutdown().unwrap();
+
+        assert!(!manager.prepare_in_background());
+        assert!(manager.shutting_down.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn windows_uninstaller_stops_and_removes_the_managed_local_server() {
+        let hooks = include_str!("../installer-hooks.nsh");
+
+        assert!(hooks.contains("NSIS_HOOK_PREUNINSTALL"));
+        assert!(hooks.contains("taskkill.exe /PID"));
+        assert!(hooks.contains("RMDir /r \"$LOCALAPPDATA\\com.hugagent.desktop\\local-server\""));
     }
 
     #[test]

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -248,26 +248,27 @@ fn html_escape(s: &str) -> String {
 
 // ── 一体化桌面标题栏 ───────────────────────────────────────────────────────
 //
-// 主窗口关闭系统 decorations，避免「系统标题栏 + 原生菜单栏」占两行。这里把产品名、
+// 主窗口关闭系统 decorations，避免「系统标题栏 + 原生菜单栏」占两行。这里把产品图标、
 // 文件/编辑/视图/帮助和窗口控制放进同一行。全部动作走导航哨兵，由 lib.rs 拦截执行，
 // 不依赖远程源下不稳定的 Tauri IPC。
 
 const TITLEBAR_HEIGHT: u8 = 36;
 const TB_OFFSET_SPA: &str =
-    "body{box-sizing:border-box!important;padding-top:36px!important}.jx-appLoading{height:100%!important}";
-const TB_OFFSET_PAGE: &str = "body{box-sizing:border-box!important;padding-top:36px!important}";
+    ":root{--hugagent-desktop-titlebar-height:36px}body{box-sizing:border-box!important;padding-top:36px!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
+const TB_OFFSET_PAGE: &str =
+    ":root{--hugagent-desktop-titlebar-height:36px}body{box-sizing:border-box!important;padding-top:36px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
 const MAC_TITLEBAR_HEIGHT: u8 = 38;
 const MAC_OFFSET_SPA: &str =
-    "body{box-sizing:border-box!important;padding-top:38px!important}.jx-appLoading{height:100%!important}";
-const MAC_OFFSET_PAGE: &str = "body{box-sizing:border-box!important;padding-top:38px!important}";
+    ":root{--hugagent-desktop-titlebar-height:38px}body{box-sizing:border-box!important;padding-top:38px!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
+const MAC_OFFSET_PAGE: &str =
+    ":root{--hugagent-desktop-titlebar-height:38px}body{box-sizing:border-box!important;padding-top:38px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
 const TB_CSS: &str = r##"
 #hugagent-titlebar{position:fixed;inset:0 0 auto 0;height:36px;z-index:2147483647;display:flex;align-items:center;background:#F7F8FA;border-bottom:1px solid #E5E9EF;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei",sans-serif;color:#30343B}
 #hugagent-titlebar *{box-sizing:border-box}
-#hugagent-titlebar .tb-left{display:flex;align-items:center;height:100%;min-width:0;padding-left:10px}
-#hugagent-titlebar .tb-logo{width:17px;height:17px;border-radius:4px;margin-right:7px;object-fit:cover}
-#hugagent-titlebar .tb-name{font-size:12.5px;font-weight:650;white-space:nowrap;margin-right:5px;-webkit-user-select:none;user-select:none}
+#hugagent-titlebar .tb-left{display:flex;align-items:center;height:100%;min-width:0;padding-left:8px}
+#hugagent-titlebar .tb-logo{width:17px;height:17px;border-radius:4px;margin-right:5px;object-fit:cover}
 #hugagent-titlebar .tb-spacer{flex:1;height:100%;min-width:30px}
 #hugagent-titlebar .tb-menu{display:flex;align-items:stretch;height:100%}
 #hugagent-titlebar .tb-menuGroup{position:relative;height:100%;display:flex;align-items:stretch}
@@ -381,13 +382,12 @@ fn titlebar_block(offset_css: &str) -> String {
     format!(
         "<style id=\"hugagent-titlebar-style\">{css}{offset}</style>\
 <header id=\"hugagent-titlebar\" data-height=\"{height}\">\
-<div class=\"tb-left\"><img class=\"tb-logo\" src=\"{logo}\" alt=\"\" onerror=\"this.style.display='none'\"/><span class=\"tb-name\">{name}</span>{menu}</div>\
+<div class=\"tb-left\"><img class=\"tb-logo\" src=\"{logo}\" alt=\"\" onerror=\"this.style.display='none'\"/>{menu}</div>\
 <div class=\"tb-spacer\"></div>{controls}</header><script>{script}</script>",
         css = TB_CSS,
         offset = offset_css,
         height = TITLEBAR_HEIGHT,
         logo = brand::LOGIN_LOGO_URL,
-        name = brand::NAME,
         menu = TB_MENU,
         controls = TB_CONTROLS,
         script = TB_JS,
@@ -820,9 +820,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn windows_titlebar_keeps_product_and_four_menus_on_one_row() {
+    fn windows_titlebar_keeps_icon_and_four_menus_on_one_row() {
         let block = titlebar_block(TB_OFFSET_SPA);
-        assert!(block.contains("tb-name"));
+        assert!(block.contains("tb-logo"));
+        assert!(!block.contains("tb-name"));
+        assert!(!block.contains(&format!(">{}<", brand::NAME)));
         for label in ["文件", "编辑", "视图", "帮助"] {
             assert!(block.contains(label));
         }
@@ -843,6 +845,27 @@ mod tests {
         assert!(!block.contains("data-win=\"minimize\""));
         assert!(!block.contains("data-win=\"close\""));
         assert!(!block.contains("tb-menuLabel"));
+    }
+
+    #[test]
+    fn desktop_titlebar_offsets_fixed_feedback_overlays() {
+        for block in [
+            titlebar_block(TB_OFFSET_SPA),
+            titlebar_block(TB_OFFSET_PAGE),
+            mac_titlebar_block(MAC_OFFSET_SPA),
+            mac_titlebar_block(MAC_OFFSET_PAGE),
+        ] {
+            assert!(block.contains(
+                ".ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}"
+            ));
+            assert!(block.contains(
+                ".ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight"
+            ));
+        }
+        assert!(titlebar_block(TB_OFFSET_SPA).contains("--hugagent-desktop-titlebar-height:36px"));
+        assert!(
+            mac_titlebar_block(MAC_OFFSET_SPA).contains("--hugagent-desktop-titlebar-height:38px")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

- Remove the visible product-name text from the Windows desktop titlebar, keep the icon, and move the File/Edit/View/Help menus left.
- Stop the managed local Python process tree when the desktop app truly exits, while preserving the existing minimize-to-tray behavior.
- Stop the managed service and remove its local-server directory (venv, service data, caches, and logs) during Windows uninstall.
- Prevent background install/start work from respawning the local service after shutdown begins.

Root cause: shutdown previously depended on manager destruction and matched only the launcher executable, while the running process may be the venv Python executable and asynchronous owners may outlive Tauri runtime teardown.

User impact: the local service now follows the desktop lifecycle, and uninstall no longer leaves the app-managed virtual environment or service data behind.

Maintainer CE synchronization generated from upstream FULL commit `170b17b2`.

Validation:
- CE generation, brand scan, required-runtime gate, forbidden-artifact gate, and license gate
- CE frontend production build
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` (19 passed)
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `git diff --check`

## Related issue / 关联 Issue

N/A

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): Maintainer CE synchronization of generated desktop runtime code.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
- [ ] Links and code snippets were verified. 链接与代码片段已验证。
- [ ] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。
