### PR TITLE
fix(desktop): prevent Windows CE bootstrap encoding crash

### DIFF
--- a/desktop/src-tauri/src/local_server.rs
+++ b/desktop/src-tauri/src/local_server.rs
@@ -305,6 +305,8 @@ impl LocalServerManager {
                     .arg("--no-browser")
                     .current_dir(self.source_dir())
                     .env("HUGAGENT_HOME", self.data_dir())
+                    .env("PYTHONUTF8", "1")
+                    .env("PYTHONIOENCODING", "utf-8")
                     .env("HUGAGENT_BOOTSTRAP_DEFAULT_PLUGINS", "1")
                     .env(
                         "FRONTEND_DIST_DIR",

--- a/src/backend/cli.py
+++ b/src/backend/cli.py
@@ -27,6 +27,36 @@ import time
 from pathlib import Path
 from typing import Optional
 
+
+def _configure_standard_streams() -> None:
+    """Keep redirected desktop logs UTF-8 and tolerant of status symbols."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (LookupError, OSError, ValueError):
+            try:
+                reconfigure(errors="replace")
+            except (LookupError, OSError, ValueError):
+                pass
+
+
+def _status(message: str, *, file=None, **kwargs) -> None:
+    """Print CLI status without letting a legacy code page break startup."""
+    stream = file or sys.stdout
+    try:
+        print(message, file=stream, **kwargs)
+    except UnicodeEncodeError:
+        encoding = getattr(stream, "encoding", None) or "ascii"
+        try:
+            safe_message = message.encode(encoding, errors="replace").decode(encoding)
+        except LookupError:
+            safe_message = message.encode("ascii", errors="replace").decode("ascii")
+        print(safe_message, file=stream, **kwargs)
+
+
 # ── Data dir & environment ────────────────────────────────────────────────────
 
 
@@ -310,10 +340,11 @@ def install_plugins(slugs: list) -> list:
         for slug in slugs:
             try:
                 plugin_service.install_plugin(db, slug, owner_user_id=None, created_by="onboard")
-                done.append(slug)
-                print(f"  ✓ 已安装插件：{slug}")
             except Exception as exc:  # noqa: BLE001
-                print(f"  ! 插件 {slug} 安装失败：{exc}", file=sys.stderr)
+                _status(f"  ! 插件 {slug} 安装失败：{exc}", file=sys.stderr)
+            else:
+                done.append(slug)
+                _status(f"  ✓ 已安装插件：{slug}")
     finally:
         db.close()
     return done
@@ -456,7 +487,7 @@ def provision_site_template(verbose: bool = False) -> bool:
     home = Path(os.environ.get("SITE_TEMPLATE_HOME", str(data_dir() / "site-template")))
     if src is None:
         if verbose:
-            print("  ! 未找到站点模板（docker/site-template/），React 建站不可用")
+            _status("  ! 未找到站点模板（docker/site-template/），React 建站不可用")
         return False
     try:
         # Lay down the react-vite template WITHOUT node_modules (init script runs
@@ -472,20 +503,20 @@ def provision_site_template(verbose: bool = False) -> bool:
             )
         shutil.copy2(src / "init-react-site.sh", home / "init-react-site.sh")
         os.chmod(home / "init-react-site.sh", 0o755)
-        if verbose:
-            tools = _probe_host_tools()
-            if tools["node"] and tools["npm"]:
-                print(f"  ✓ React 建站模板已就绪：{home}")
-            else:
-                print(
-                    f"  ✓ React 建站模板已铺入：{home}"
-                    "（缺 Node/npm，装 Node ≥ 20 后首次建站会自动装依赖）"
-                )
-        return True
     except Exception as exc:  # noqa: BLE001
         if verbose:
-            print(f"  ! 站点模板铺入失败：{exc}", file=sys.stderr)
+            _status(f"  ! 站点模板铺入失败：{exc}", file=sys.stderr)
         return False
+    if verbose:
+        tools = _probe_host_tools()
+        if tools["node"] and tools["npm"]:
+            _status(f"  ✓ React 建站模板已就绪：{home}")
+        else:
+            _status(
+                f"  ✓ React 建站模板已铺入：{home}"
+                "（缺 Node/npm，装 Node ≥ 20 后首次建站会自动装依赖）"
+            )
+    return True
 
 
 # ── Host tool capability probe ────────────────────────────────────────────────
@@ -733,13 +764,14 @@ def cmd_serve(args) -> int:
     _ensure_schema_and_seed()
     if os.getenv(_DEFAULT_PLUGIN_BOOTSTRAP_ENV) == "1":
         try:
-            if ensure_default_plugins_once():
-                print("✓ 默认插件已就绪：定时任务、技能管理、站点发布")
+            bootstrapped = ensure_default_plugins_once()
         except Exception as exc:  # noqa: BLE001
             # The desktop readiness endpoint must not go healthy with only a
             # partial default-plugin set. No marker is written on failure, so
             # the next installer-managed start will retry the full bootstrap.
             raise RuntimeError(f"默认插件初始化失败，下次启动将重试：{exc}") from exc
+        if bootstrapped:
+            _status("✓ 默认插件已就绪：定时任务、技能管理、站点发布")
     import uvicorn
     from api.app import app
 
@@ -883,6 +915,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Optional[list] = None) -> int:
+    _configure_standard_streams()
     parser = build_parser()
     args = parser.parse_args(argv)
     if not getattr(args, "command", None):

--- a/src/backend/tests/test_local_memory_defaults.py
+++ b/src/backend/tests/test_local_memory_defaults.py
@@ -1,5 +1,6 @@
 """Local one-command profile memory defaults."""
 
+import io
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -116,6 +117,39 @@ def test_desktop_local_server_bootstraps_default_plugins():
     )
 
     assert '.env("HUGAGENT_BOOTSTRAP_DEFAULT_PLUGINS", "1")' in launcher
+
+
+def test_desktop_local_server_forces_utf8_python_stdio():
+    repo_root = Path(__file__).resolve().parents[3]
+    launcher = (repo_root / "desktop" / "src-tauri" / "src" / "local_server.rs").read_text(
+        encoding="utf-8"
+    )
+
+    assert '.env("PYTHONUTF8", "1")' in launcher
+    assert '.env("PYTHONIOENCODING", "utf-8")' in launcher
+
+
+def test_status_output_does_not_fail_on_gbk_redirect(monkeypatch):
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="gbk", errors="strict")
+    monkeypatch.setattr(cli.sys, "stdout", stream)
+
+    cli._status("  ✓ 已安装插件：sites")
+    stream.flush()
+
+    assert "已安装插件：sites" in raw.getvalue().decode("gbk")
+
+
+def test_cli_reconfigures_redirected_gbk_stream_to_utf8(monkeypatch):
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="gbk", errors="strict")
+    monkeypatch.setattr(cli.sys, "stdout", stream)
+
+    cli._configure_standard_streams()
+    cli._status("✓ 默认插件已就绪")
+    stream.flush()
+
+    assert raw.getvalue().decode("utf-8") == "✓ 默认插件已就绪\n"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary / 概述

Fix packaged Windows CE desktop builds exiting during the first local-server
startup after the default-plugin readiness changes from #19.

The desktop launcher redirects Python stdout and stderr to `server.log`. On
Windows systems where the redirected stream selected GBK, printing the `✓`
status symbol raised `UnicodeEncodeError` inside the plugin and site-template
bootstrap `try` blocks. Successful work was consequently reported as failed,
and strict readiness terminated the backend before the desktop window became
usable.

This change:

- forces UTF-8 for the Python child process launched by the Tauri desktop shell;
- makes CLI status output safe on legacy code pages;
- separates status rendering from plugin and template operation results so a
  log encoding problem cannot change readiness state; and
- adds regression coverage for GBK-redirected output and the desktop launcher
  environment contract.

## Related issue / 关联 Issue

Follow-up to #19.

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): Windows CE desktop startup bug fix and regressions.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
- [x] Links and code snippets were verified. 链接与代码片段已验证。
- [ ] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。

Validation:

- strict CE derivation passed required-runtime, forbidden-artifact, binary,
  brand, license, import/OpenAPI/ORM, pytest-collection, and frontend-build gates;
- 17 local bootstrap and subprocess regressions passed;
- 6 CE desktop payload tests passed;
- Black, `cargo fmt`, and `git diff --check` passed; and
- a fresh derived CE tree was launched with the installed Windows Python runtime,
  redirected logs, and UTF-8 environment overrides deliberately removed. The
  service reached `/health`, and the resulting log decoded as UTF-8 with the
  completed default-plugin status present.
