### PR TITLE
fix(desktop): repair local publishing and CE API keys

### DIFF
--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -66,9 +66,16 @@ pub async fn serve(state: ProxyState, web_dir: PathBuf) -> std::io::Result<u16> 
         .route("/__desktop/setup/install", post(start_local_install))
         .route("/api", any(proxy_handler))
         .route("/api/*rest", any(proxy_handler))
-        // 后端提供的上传资产（页面配置 logo/favicon、操作手册 PDF 等）也在后端、不在前端
-        // dist 里——必须像 nginx 一样转发到后端，否则桌面端这些图片/文件 404 → 图裂。
-        // 前端 dist 下没有 /docs 目录，转发不会抢占前端静态资源。
+        // nginx-free desktop mode still needs the backend-owned public paths:
+        // generated artifacts (/files) and hosted sites (/site).  Without
+        // these routes, links returned by the agent fall through to the SPA
+        // index instead of reaching FastAPI.
+        .route("/files", any(proxy_handler))
+        .route("/files/*rest", any(proxy_handler))
+        .route("/site", any(proxy_handler))
+        .route("/site/*rest", any(proxy_handler))
+        // Page-config assets and manuals also live on the backend, not in the
+        // frontend dist.  Forward them with the same streaming proxy.
         .route("/docs/*rest", any(proxy_handler))
         .route_service("/", ServeFile::new(&spa_index))
         .fallback_service(serve_dir)
@@ -260,7 +267,7 @@ const TB_OFFSET_PAGE: &str =
 
 const MAC_TITLEBAR_HEIGHT: u8 = 38;
 const MAC_OFFSET_SPA: &str =
-    ":root{--hugagent-desktop-titlebar-height:38px}body{box-sizing:border-box!important;padding-top:38px!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
+    ":root{--hugagent-desktop-titlebar-height:38px;--hugagent-desktop-sidebar-width:0px}body{box-sizing:border-box!important;padding-top:38px!important;background:linear-gradient(90deg,#F5F6F7 0 var(--hugagent-desktop-sidebar-width),#FFFFFF var(--hugagent-desktop-sidebar-width) 100%)!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 const MAC_OFFSET_PAGE: &str =
     ":root{--hugagent-desktop-titlebar-height:38px}body{box-sizing:border-box!important;padding-top:38px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
@@ -369,6 +376,20 @@ var bar=document.getElementById('hugagent-mac-titlebar');if(!bar)return;
 if(new URLSearchParams(location.search).get('quickask')==='1'){
   bar.remove();var style=document.getElementById('hugagent-titlebar-style');if(style)style.remove();return;
 }
+var observedSidebar=null;
+var sidebarResizeObserver=typeof ResizeObserver==='function'?new ResizeObserver(syncSidebarWidth):null;
+function syncSidebarWidth(){
+  var sidebar=document.querySelector('.jx-sider,.jx-appLoading-sidebar');
+  if(sidebarResizeObserver&&sidebar&&sidebar!==observedSidebar){
+    if(observedSidebar)sidebarResizeObserver.unobserve(observedSidebar);
+    observedSidebar=sidebar;sidebarResizeObserver.observe(sidebar);
+  }
+  var width=sidebar?Math.max(0,Math.round(sidebar.getBoundingClientRect().width)):0;
+  document.documentElement.style.setProperty('--hugagent-desktop-sidebar-width',width+'px');
+}
+syncSidebarWidth();
+new MutationObserver(syncSidebarWidth).observe(document.body,{childList:true,subtree:true,attributes:true,attributeFilter:['class','style']});
+window.addEventListener('resize',syncSidebarWidth);
 bar.addEventListener('mousedown',function(event){
   if(event.button!==0)return;
   window.location.href='/__desktop/win?action=drag';
@@ -845,6 +866,9 @@ mod tests {
         assert!(!block.contains("data-win=\"minimize\""));
         assert!(!block.contains("data-win=\"close\""));
         assert!(!block.contains("tb-menuLabel"));
+        assert!(block.contains("--hugagent-desktop-sidebar-width"));
+        assert!(block.contains("linear-gradient(90deg,#F5F6F7"));
+        assert!(block.contains("ResizeObserver"));
     }
 
     #[test]

--- a/src/backend/api/routes/v1/__init__.py
+++ b/src/backend/api/routes/v1/__init__.py
@@ -34,6 +34,7 @@ CE_ROUTERS: tuple[tuple[str, str], ...] = (
     ("internal_batch", "router"),
     ("internal_sites", "router"),
     ("projects", "router"),
+    ("api_keys", "router"),
     ("me_capabilities", "router"),
     ("marketplace", "router"),
     ("agent_marketplace", "router"),

--- a/src/backend/api/routes/v1/api_keys.py
+++ b/src/backend/api/routes/v1/api_keys.py
@@ -1,0 +1,142 @@
+"""Community-edition per-user API-Key management routes.
+
+The enterprise route with the same public contract also integrates with the
+optional model gateway.  CE keeps the native agent-call key lifecycle here so
+the derived tree has no import or entitlement dependency on ``edition_ee``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from core.auth.backend import UserContext, get_current_user
+from core.auth.capabilities import resolve_user_capabilities
+from core.db.engine import get_db
+from core.infra.exceptions import AccessDeniedError, BadRequestError, ResourceNotFoundError
+from core.infra.responses import created_response, success_response
+from core.services import ApiKeyService
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/v1/me/api-keys", tags=["API Keys"])
+
+ALLOWED_EXPIRY_DAYS = {7, 30, 90, 180, 365}
+
+
+class CreateApiKeyRequest(BaseModel):
+    name: str = Field("API Key", max_length=128, description="便于识别的名称")
+    expires_in_days: Optional[int] = Field(
+        None,
+        description="过期天数，留空=永不过期；允许 7/30/90/180/365",
+    )
+
+
+class ToggleApiKeyRequest(BaseModel):
+    enabled: bool
+
+
+def _require_api_key_permission(user_id: str, db: Session) -> None:
+    if not resolve_user_capabilities(db, user_id)["can_use_api_key"]:
+        raise AccessDeniedError(
+            message="管理员未开放 API-Key 功能",
+            reason="api_key_disabled",
+        )
+
+
+def _key_to_dict(row, *, plaintext: Optional[str] = None) -> dict:
+    return {
+        "id": row.id,
+        "name": row.name,
+        "key_prefix": row.key_prefix,
+        "enabled": row.enabled,
+        "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+        "last_used_at": row.last_used_at.isoformat() if row.last_used_at else None,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "revealable": bool(getattr(row, "key_enc", None)),
+        "api_key": plaintext,
+    }
+
+
+@router.get("", summary="API-Key 列表")
+async def list_api_keys(
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _require_api_key_permission(str(user.user_id), db)
+    rows = ApiKeyService(db).list_keys(str(user.user_id))
+    return success_response(data={"items": [_key_to_dict(row) for row in rows]})
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, summary="新建 API-Key")
+async def create_api_key(
+    body: CreateApiKeyRequest,
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _require_api_key_permission(str(user.user_id), db)
+    if body.expires_in_days is not None and body.expires_in_days not in ALLOWED_EXPIRY_DAYS:
+        raise BadRequestError(
+            message="无效的过期天数",
+            data={"allowed": sorted(ALLOWED_EXPIRY_DAYS)},
+        )
+
+    row, raw = ApiKeyService(db).create_key(
+        user_id=str(user.user_id),
+        name=body.name,
+        expires_in_days=body.expires_in_days,
+    )
+    return created_response(data=_key_to_dict(row, plaintext=raw))
+
+
+@router.get("/{key_id}/reveal", summary="再次取回 API-Key 明文")
+async def reveal_api_key(
+    key_id: str,
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _require_api_key_permission(str(user.user_id), db)
+    row = ApiKeyService(db).get_key(str(user.user_id), key_id)
+    if not row:
+        raise ResourceNotFoundError("api_key", key_id)
+    if not row.key_enc:
+        raise BadRequestError(
+            message="该密钥创建于「再次复制」功能上线前，明文无法找回，请撤销后新建",
+            data={"reason": "api_key_not_revealable"},
+        )
+
+    from core.infra.crypto import decrypt_secret
+
+    plaintext = decrypt_secret(row.key_enc)
+    if not plaintext:
+        raise BadRequestError(
+            message="密钥明文解密失败（部署密钥可能已变更），请撤销后新建",
+            data={"reason": "api_key_decrypt_failed"},
+        )
+    return success_response(data=_key_to_dict(row, plaintext=plaintext))
+
+
+@router.patch("/{key_id}", summary="启用/禁用 API-Key")
+async def toggle_api_key(
+    key_id: str,
+    body: ToggleApiKeyRequest,
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _require_api_key_permission(str(user.user_id), db)
+    row = ApiKeyService(db).set_enabled(str(user.user_id), key_id, body.enabled)
+    if not row:
+        raise ResourceNotFoundError("api_key", key_id)
+    return success_response(data=_key_to_dict(row))
+
+
+@router.delete("/{key_id}", summary="撤销 API-Key")
+async def revoke_api_key(
+    key_id: str,
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _require_api_key_permission(str(user.user_id), db)
+    if not ApiKeyService(db).revoke_key(str(user.user_id), key_id):
+        raise ResourceNotFoundError("api_key", key_id)
+    return success_response(data={"id": key_id, "revoked": True})

--- a/src/backend/cli.py
+++ b/src/backend/cli.py
@@ -106,6 +106,12 @@ def apply_local_env(port: int) -> dict:
         "PLAYWRIGHT_BROWSERS_PATH": str(dd / "node" / "browsers"),
         "JX_FONT_DIR": str(dd / "fonts"),
         "MCP_HOST": "127.0.0.1",
+        # Internal MCP callbacks (site publish / batch runner) execute in child
+        # processes in the local profile.  Point them back at this exact
+        # uvicorn instance instead of letting them fall back to the compose
+        # default port (3001).  The desktop-managed server listens on 32101.
+        "BACKEND_INTERNAL_URL": f"http://127.0.0.1:{port}",
+        "BACKEND_PORT": str(port),
         # A local/desktop install is expected to be useful immediately after a
         # zero-state boot.  Keep the three credential-free first-party plugins
         # as the local-profile default even when the caller is plain

--- a/src/backend/mcp_servers/site_publish_mcp/impl.py
+++ b/src/backend/mcp_servers/site_publish_mcp/impl.py
@@ -12,7 +12,9 @@ def _backend_url() -> str:
     explicit = os.environ.get("BACKEND_INTERNAL_URL", "").strip()
     if explicit:
         return explicit.rstrip("/")
-    port = (os.environ.get("BACKEND_PORT") or "3001").strip() or "3001"
+    # Desktop/local mode has no nginx or compose service name.  Its MCP child
+    # inherits the backend listener through PORT (32101 by default).
+    port = (os.environ.get("BACKEND_PORT") or os.environ.get("PORT") or "3001").strip() or "3001"
     return f"http://127.0.0.1:{port}"
 
 

--- a/src/backend/tests/ce_release/test_ce_release_regressions.py
+++ b/src/backend/tests/ce_release/test_ce_release_regressions.py
@@ -50,6 +50,50 @@ def test_ce_login_ticket_exchange_and_session_check(initialized_ce_database):
         assert session.json()["data"]["username"] == "admin"
 
 
+def test_ce_api_key_crud_is_reachable_from_personal_settings(initialized_ce_database):
+    from api.app import app
+
+    with TestClient(app) as client:
+        login = client.post(
+            "/login",
+            data={"username": "admin", "password": "admin", "redirect": "/"},
+            follow_redirects=False,
+        )
+        assert login.status_code == 303, login.text
+        ticket = parse_qs(urlparse(login.headers["location"]).query)["ticket"][0]
+        exchange = client.post("/v1/auth/ticket/exchange", json={"code": ticket})
+        assert exchange.status_code == 200, exchange.text
+
+        empty_or_existing = client.get("/v1/me/api-keys")
+        assert empty_or_existing.status_code == 200, empty_or_existing.text
+
+        created = client.post(
+            "/v1/me/api-keys",
+            json={
+                "name": "desktop-test",
+                "expires_in_days": 30,
+                # The shared frontend always sends this field. CE intentionally
+                # ignores it because it has no enterprise model gateway.
+                "for_gateway": False,
+            },
+        )
+        assert created.status_code == 201, created.text
+        created_data = created.json()["data"]
+        key_id = created_data["id"]
+        assert created_data["api_key"].startswith("sk-jx-")
+
+        revealed = client.get(f"/v1/me/api-keys/{key_id}/reveal")
+        assert revealed.status_code == 200, revealed.text
+        assert revealed.json()["data"]["api_key"] == created_data["api_key"]
+
+        disabled = client.patch(f"/v1/me/api-keys/{key_id}", json={"enabled": False})
+        assert disabled.status_code == 200, disabled.text
+        assert disabled.json()["data"]["enabled"] is False
+
+        revoked = client.delete(f"/v1/me/api-keys/{key_id}")
+        assert revoked.status_code == 200, revoked.text
+
+
 def test_ce_registers_all_local_auth_routes():
     from api.app import app
 

--- a/src/backend/tests/test_ce_runtime_contracts.py
+++ b/src/backend/tests/test_ce_runtime_contracts.py
@@ -367,3 +367,12 @@ def test_ce_site_publish_tool_has_no_organization_parameter():
     from mcp_servers.site_publish_mcp.server import publish_site
 
     assert "team_id" not in inspect.signature(publish_site).parameters
+
+
+def test_ce_registers_native_api_key_routes():
+    from api.app import app
+
+    paths = app.openapi()["paths"]
+    assert {"get", "post"} <= set(paths["/v1/me/api-keys"])
+    assert "get" in paths["/v1/me/api-keys/{key_id}/reveal"]
+    assert {"patch", "delete"} <= set(paths["/v1/me/api-keys/{key_id}"])

--- a/src/backend/tests/test_local_memory_defaults.py
+++ b/src/backend/tests/test_local_memory_defaults.py
@@ -13,11 +13,15 @@ def test_local_profile_enables_memory_runtime_by_default(tmp_path, monkeypatch):
     monkeypatch.setenv("HUGAGENT_HOME", str(tmp_path / "hugagent-home"))
     monkeypatch.delenv("MEM0_ENABLED", raising=False)
     monkeypatch.delenv("HUGAGENT_BOOTSTRAP_DEFAULT_PLUGINS", raising=False)
+    monkeypatch.delenv("BACKEND_INTERNAL_URL", raising=False)
+    monkeypatch.delenv("BACKEND_PORT", raising=False)
 
     defaults = cli.apply_local_env(port=18000)
 
     assert defaults["MEM0_ENABLED"] == "true"
     assert defaults["HUGAGENT_BOOTSTRAP_DEFAULT_PLUGINS"] == "1"
+    assert defaults["BACKEND_INTERNAL_URL"] == "http://127.0.0.1:18000"
+    assert defaults["BACKEND_PORT"] == "18000"
     assert os.environ["HUGAGENT_BOOTSTRAP_DEFAULT_PLUGINS"] == "1"
 
 

--- a/src/backend/tests/test_local_subprocess.py
+++ b/src/backend/tests/test_local_subprocess.py
@@ -17,6 +17,16 @@ def test_child_env_binds_local_mcp_to_loopback(monkeypatch):
     assert env["MCP_BIND_HOST"] == "127.0.0.1"
 
 
+def test_site_publish_callback_uses_local_listener_port(monkeypatch):
+    from mcp_servers.site_publish_mcp import impl
+
+    monkeypatch.delenv("BACKEND_INTERNAL_URL", raising=False)
+    monkeypatch.delenv("BACKEND_PORT", raising=False)
+    monkeypatch.setenv("PORT", "32101")
+
+    assert impl._backend_url() == "http://127.0.0.1:32101"
+
+
 def test_streamable_http_bind_host_defaults_to_compose_and_supports_local(monkeypatch):
     monkeypatch.delenv("MCP_BIND_HOST", raising=False)
     assert _serve._streamable_http_bind_host() == "0.0.0.0"


### PR DESCRIPTION
## Summary / 概述

This maintainer CE synchronization publishes the desktop and Community Edition fixes from upstream commit `2468c460`.

### What changed

- Route local MCP publishing callbacks back to the active desktop backend listener instead of falling back to the Docker-oriented port.
- Proxy backend-owned `/site/**` and `/files/**` paths through the desktop same-origin server so published sites and generated downloads no longer fall through to the SPA.
- Add a CE-native API-Key route set for list, create, reveal, enable/disable, and revoke operations without importing enterprise licensing or gateway modules.
- Blend the transparent macOS drag region into the live sidebar and content backgrounds, including dynamic sidebar collapse/resize tracking.
- Add API-Key CRUD, route registration, local callback, and macOS titlebar regression coverage.

### Why

The desktop local profile intentionally runs without nginx. Its site-publishing MCP child inherited the desktop listener through `PORT`, but the callback helper only recognized `BACKEND_INTERNAL_URL` and `BACKEND_PORT`; it therefore contacted port 3001 instead of the desktop server on 32101. The desktop proxy also forwarded `/api/**` but not the public site and file paths returned by the backend.

The shared settings UI called `/v1/me/api-keys`, while the generated CE tree physically excludes the enterprise route that previously owned that contract. This produced GET 404 and POST 405 responses in CE.

On macOS, the transparent native drag region reserved a full-width white body strip above the application, visually separating the window chrome from the sidebar and main content.

### User and developer impact

- Desktop-local site generation can publish through the active backend without nginx.
- Published site URLs and generated file downloads open through the desktop application correctly.
- CE users can manage personal API keys from Settings.
- The macOS title region visually continues the application layout instead of appearing as a detached white module.
- The CE implementation remains free of enterprise imports and gateway behavior.

## Related issue / 关联 Issue

N/A

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): Maintainer synchronization of generated CE backend and desktop bug fixes.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
- [x] Links and code snippets were verified. 链接与代码片段已验证。
- [ ] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。

Validation:

- `HUGAGENT_RELEASE_BUILD=1 python scripts/build_ce.py --import-check --pytest-check --frontend-check`
  - required-runtime, forbidden-artifact, binary allowlist, brand/path, and License gates passed
  - CE import, OpenAPI, ORM, release regressions, and frontend production build passed
- CE release regressions with the release environment: 6 passed
- Local callback and CE runtime contracts: 39 passed
- Desktop Rust library tests: 20 passed
- Desktop script tests: 16 passed
- `git diff --check` passed
- The repository has no root `package.json` or `npm run preflight` target; the repository-native CE release gates above were used instead
