### PR TITLE
fix(desktop): blend macOS titlebar into sidebar

### DIFF
--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -266,8 +266,11 @@ const TB_OFFSET_PAGE: &str =
     ":root{--hugagent-desktop-titlebar-height:36px}body{box-sizing:border-box!important;padding-top:36px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
 const MAC_TITLEBAR_HEIGHT: u8 = 38;
+// The left half of the macOS safe area reuses the sidebar's first translucent
+// blue gradient stop over its #F5F6F7 base.  The traffic lights therefore sit
+// on a true visual continuation of the sidebar instead of a detached grey bar.
 const MAC_OFFSET_SPA: &str =
-    ":root{--hugagent-desktop-titlebar-height:38px;--hugagent-desktop-sidebar-width:0px}body{box-sizing:border-box!important;padding-top:38px!important;background:linear-gradient(90deg,#F5F6F7 0 var(--hugagent-desktop-sidebar-width),#FFFFFF var(--hugagent-desktop-sidebar-width) 100%)!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
+    ":root{--hugagent-desktop-titlebar-height:38px;--hugagent-desktop-sidebar-width:0px}body{box-sizing:border-box!important;padding-top:38px!important;background:linear-gradient(90deg,rgba(203,223,255,.38) 0 var(--hugagent-desktop-sidebar-width),#FFFFFF var(--hugagent-desktop-sidebar-width) 100%),#F5F6F7!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 const MAC_OFFSET_PAGE: &str =
     ":root{--hugagent-desktop-titlebar-height:38px}body{box-sizing:border-box!important;padding-top:38px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
@@ -867,7 +870,8 @@ mod tests {
         assert!(!block.contains("data-win=\"close\""));
         assert!(!block.contains("tb-menuLabel"));
         assert!(block.contains("--hugagent-desktop-sidebar-width"));
-        assert!(block.contains("linear-gradient(90deg,#F5F6F7"));
+        assert!(block.contains("linear-gradient(90deg,rgba(203,223,255,.38)"));
+        assert!(block.contains("#F5F6F7!important"));
         assert!(block.contains("ResizeObserver"));
     }
 


### PR DESCRIPTION
## Summary / 概述

Follow-up to #21 after the original PR was merged.

The macOS traffic-light safe area used a flat `#F5F6F7` background while the sidebar below it renders a translucent blue gradient over the same base. This left a visible gray block above the sidebar.

This change reuses the sidebar's exact first gradient layer in the safe area and keeps the existing dynamic sidebar-width tracking, so the titlebar remains visually continuous in both expanded and collapsed sidebar states. Layout and interaction behavior are unchanged.

## Related issue / 关联 Issue

Follow-up to #21.

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): Maintainer-generated desktop shell fix synchronized from the upstream source repository.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
- [x] Links and code snippets were verified. 链接与代码片段已验证。
- [ ] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。

## Validation / 验证

- `cargo fmt --all -- --check`
- `cargo test proxy::tests --lib` — 7 passed
- `cargo test --lib` — 20 passed
- `git diff --check`
- `HUGAGENT_RELEASE_BUILD=1 python scripts/build_ce.py --import-check --pytest-check --frontend-check`

The repository root has no `package.json`, so the generic `npm run preflight` command is not available; the repository's formal CE release checks above completed successfully, including the frontend production build.
