### PR TITLE
fix(desktop): support macOS workspace paths in site publishing

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugagent-desktop",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS 无 Docker 本机服务）",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hugagent-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "axum",
  "bytes",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugagent-desktop"
-version = "0.2.2"
+version = "0.2.3"
 description = "HugAgentOS桌面客户端"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HugAgentOS",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.hugagent.desktop",
   "build": {
     "frontendDist": "../../src/frontend/dist",

--- a/src/backend/api/routes/v1/internal_sites.py
+++ b/src/backend/api/routes/v1/internal_sites.py
@@ -321,7 +321,10 @@ async def _pack_and_fetch_dir(
     tar_cmd = (
         f"cd {shell_quote(src)} && "
         f"tar {exclude_args} -czf {shell_quote(pack)} . && "
-        f"du -b {shell_quote(pack)} | cut -f1"
+        # ``du -b`` is a GNU extension and is unavailable on macOS/BSD.  The
+        # local desktop profile runs this command on the host, so use POSIX
+        # ``wc -c`` and strip its padding when parsing below.
+        f"wc -c < {shell_quote(pack)}"
     )
     exit_code, stdout, stderr = await sandbox_exec_bash(tar_cmd, chat_id=_sess, timeout=60)
     if exit_code != 0:

--- a/src/backend/services/script_runner_service/server.py
+++ b/src/backend/services/script_runner_service/server.py
@@ -13,8 +13,9 @@ import logging
 import mimetypes
 import os
 import re
-import signal
+import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -63,6 +64,62 @@ def _rewrite_workspace_refs(value: str, workspace_root: str = WORKSPACE_ROOT) ->
     return _WS_PATH_RE.sub(lambda _match: replacement, value)
 
 
+def _bash_quote_state(value: str, end: int) -> Optional[str]:
+    """Return the shell quote containing ``value[end]`` (single/double/None).
+
+    The local desktop workspace commonly lives below macOS ``Application
+    Support``.  A blind ``/workspace`` replacement therefore turns a valid
+    unquoted command into several shell words.  We only need enough shell
+    awareness to preserve existing quotes and safely quote unquoted path
+    prefixes; Bash remains responsible for parsing the full script.
+    """
+    state: Optional[str] = None
+    escaped = False
+    for char in value[:end]:
+        if state == "single":
+            if char == "'":
+                state = None
+            continue
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+        elif state == "double":
+            if char == '"':
+                state = None
+        elif char == "'":
+            state = "single"
+        elif char == '"':
+            state = "double"
+    return state
+
+
+def _rewrite_bash_workspace_refs(value: str, workspace_root: str) -> str:
+    """Map canonical workspace paths without breaking paths that contain spaces."""
+    if not isinstance(value, str) or workspace_root == "/workspace":
+        return value
+    replacement = workspace_root.rstrip("/\\")
+
+    def _replace(match: re.Match[str]) -> str:
+        quote_state = _bash_quote_state(value, match.start())
+        if quote_state == "single":
+            return replacement.replace("'", "'\"'\"'")
+        if quote_state == "double":
+            return (
+                replacement.replace("\\", "\\\\")
+                .replace('"', '\\"')
+                .replace("$", "\\$")
+                .replace("`", "\\`")
+            )
+        # Quoting only the rewritten prefix is valid shell concatenation:
+        # '/Users/.../workspace'/site resolves as one path while the suffix
+        # remains visible to the boundary-matching regex.
+        return shlex.quote(replacement)
+
+    return _WS_PATH_RE.sub(_replace, value)
+
+
 def _execution_workspace_root(
     language: str,
     workspace_root: str = WORKSPACE_ROOT,
@@ -83,6 +140,8 @@ def _rewrite_execution_paths(value: str, language: str) -> str:
     if target_root != WORKSPACE_ROOT:
         # File tools may already have expanded /workspace to the native root.
         value = value.replace(WORKSPACE_ROOT, target_root)
+    if language == "bash":
+        return _rewrite_bash_workspace_refs(value, target_root)
     return _rewrite_workspace_refs(value, target_root)
 
 

--- a/src/backend/tests/test_ce_runtime_contracts.py
+++ b/src/backend/tests/test_ce_runtime_contracts.py
@@ -369,6 +369,16 @@ def test_ce_site_publish_tool_has_no_organization_parameter():
     assert "team_id" not in inspect.signature(publish_site).parameters
 
 
+def test_ce_site_publish_callback_uses_desktop_listener(monkeypatch):
+    from mcp_servers.site_publish_mcp import impl
+
+    monkeypatch.delenv("BACKEND_INTERNAL_URL", raising=False)
+    monkeypatch.delenv("BACKEND_PORT", raising=False)
+    monkeypatch.setenv("PORT", "32101")
+
+    assert impl._backend_url() == "http://127.0.0.1:32101"
+
+
 def test_ce_registers_native_api_key_routes():
     from api.app import app
 

--- a/src/backend/tests/test_local_profile.py
+++ b/src/backend/tests/test_local_profile.py
@@ -503,14 +503,23 @@ def test_runner_canon_ws_and_bash_rewrite(monkeypatch):
     the bash/python it executes, so model-written /workspace paths resolve locally."""
     import services.script_runner_service.server as srv
 
-    monkeypatch.setattr(srv, "WORKSPACE_ROOT", "/home/u/.hugagent/workspace")
-    assert srv._canon_ws("/workspace") == "/home/u/.hugagent/workspace"
-    assert srv._canon_ws("/workspace/a.txt") == "/home/u/.hugagent/workspace/a.txt"
+    local_root = "/Users/test/Library/Application Support/HugAgentOS/workspace"
+    monkeypatch.setattr(srv, "WORKSPACE_ROOT", local_root)
+    assert srv._canon_ws("/workspace") == local_root
+    assert srv._canon_ws("/workspace/a.txt") == f"{local_root}/a.txt"
     assert srv._canon_ws("/workspaces/x") == "/workspaces/x"
 
-    # The bash-command regex rewrites path-boundary /workspace but not /workspaces.
-    ws_re = __import__("re").compile(r'/workspace(?=/|$|["\'\s:;)&|])')
-    out = ws_re.sub(
-        "/home/u/.hugagent/workspace", "cd /workspace && npm run build; echo /workspaces"
+    # Existing quotes remain intact, while an unquoted canonical path gains a
+    # safely quoted prefix when the macOS Application Support mapping adds
+    # spaces. /workspaces is only a lookalike and must remain untouched.
+    out = srv._rewrite_bash_workspace_refs(
+        "cd '/workspace/site' && tar -czf '/workspace/site.tgz' .; echo /workspaces",
+        local_root,
     )
-    assert out == "cd /home/u/.hugagent/workspace && npm run build; echo /workspaces"
+    assert out == (
+        f"cd '{local_root}/site' && tar -czf '{local_root}/site.tgz' .; echo /workspaces"
+    )
+    assert srv._rewrite_bash_workspace_refs(
+        "cd /workspace/site && tar -czf /workspace/site.tgz .",
+        local_root,
+    ) == (f"cd '{local_root}'/site && tar -czf '{local_root}'/site.tgz .")

--- a/src/backend/tests/test_local_subprocess.py
+++ b/src/backend/tests/test_local_subprocess.py
@@ -1,5 +1,7 @@
 """Local/desktop sidecar startup contracts."""
 
+import io
+import tarfile
 from types import SimpleNamespace
 
 import pytest
@@ -25,6 +27,45 @@ def test_site_publish_callback_uses_local_listener_port(monkeypatch):
     monkeypatch.setenv("PORT", "32101")
 
     assert impl._backend_url() == "http://127.0.0.1:32101"
+
+
+@pytest.mark.asyncio
+async def test_local_site_pack_uses_macos_portable_size_probe(monkeypatch):
+    import core.sandbox as sandbox
+    from api.routes.v1 import internal_sites
+    from core.llm.tools import _common
+
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as tf:
+        content = b"<h1>desktop site</h1>"
+        info = tarfile.TarInfo("./index.html")
+        info.size = len(content)
+        tf.addfile(info, io.BytesIO(content))
+
+    commands = []
+
+    async def fake_exec(command, *, chat_id, timeout=30):
+        commands.append(command)
+        if command.startswith("rm -f "):
+            return 0, "", ""
+        return 0, f"  {len(archive.getvalue())}\n", ""
+
+    class FakeProvider:
+        async def get_file(self, session_id, path, user_id=None):
+            return archive.getvalue()
+
+    monkeypatch.setattr(_common, "sandbox_exec_bash", fake_exec)
+    monkeypatch.setattr(sandbox, "get_sandbox_provider", lambda: FakeProvider())
+
+    files, error = await internal_sites._pack_and_fetch_dir(
+        "/workspace/site with spaces", "chat-local", "user-local"
+    )
+
+    assert error is None
+    assert files == [("index.html", b"<h1>desktop site</h1>")]
+    assert "wc -c <" in commands[0]
+    assert "du -b" not in commands[0]
+    assert "'/workspace/site with spaces'" in commands[0]
 
 
 def test_streamable_http_bind_host_defaults_to_compose_and_supports_local(monkeypatch):


### PR DESCRIPTION
## Summary / 概述

- Fix local sidecar command rewriting when the macOS workspace path contains spaces (for example, under `Application Support`).
- Preserve Bash quoting context while mapping `/workspace` to the real local path, so publishing archives are created and read as single path arguments.
- Replace GNU-only `du -b` usage with portable `wc -c`, add CE regression coverage, and bump the desktop client to `0.2.3`.

This is a maintainer CE sync generated from upstream commit `b0883fd3` with `scripts/build_ce.py`.

## Related issue / 关联 Issue

N/A — follows up on the macOS desktop local-site publishing failure reported during release verification.

## Type of change / 变更类型

- [ ] Documentation / 文档
- [ ] Example / 示例
- [ ] Repo meta / 仓库元信息
- [x] Other / 其他 — upstream-generated CE runtime and desktop fix

## Validation / 验证

- CE generation gates: brand scan, forbidden-artifact scan, import/OpenAPI/ORM checks, and release regression suite
- `PYTHONPATH=src/backend pytest -q src/backend/tests/test_ce_runtime_contracts.py src/backend/tests/test_local_profile.py src/backend/tests/test_local_subprocess.py` — 44 passed, 1 skipped
- `npm run test:scripts` in `desktop/` — 16 passed
- End-to-end local sidecar archive transfer with a workspace path containing spaces
- `git diff --check`

## Checklist / 检查项

- [ ] My change only touches non-generated paths — maintainer upstream sync; generated CE paths are intentionally updated
- [x] Links and code snippets have been verified where applicable
- [x] I updated documentation in both languages where applicable (not applicable: no documentation changed in this PR)
- [x] I have read `CONTRIBUTING.md`
