### PR TITLE
fix(desktop): relocate macOS data and compact titlebar

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -256,8 +256,9 @@ npm run build
   Node.js 20+ 缺失时也会尝试通过 `winget` 补齐；这一步失败不阻断核心服务，但 React 建站和高级
   PDF 渲染会保持降级状态。
 - macOS 本机服务首次安装会在应用数据目录下载独立的 `uv` 和 Python 3.11，不修改系统 Python
-  或 shell 配置。安装仍需联网下载 Python wheels；Node.js 20+ 仅影响可选的建站和高级文档能力，
-  缺失时不阻断核心服务启动。
+  或 shell 配置。账号、对话、上传文件和工作区统一写入 `~/.hugagent`，与命令行一键安装使用
+  同一数据路径，也避免 `Application Support` 中的空格影响本机命令。安装仍需联网下载 Python
+  wheels；Node.js 20+ 仅影响可选的建站和高级文档能力，缺失时不阻断核心服务启动。
 - 安装包只携带一个 `server-ce.zip`，首次安装或版本升级时才解压。Windows 把可删除的
   `source`、`venv` 和 `node` 放在
   `%LOCALAPPDATA%\com.hugagent.desktop\local-server\runtime`，把账号、对话、上传文件和工作区放在
@@ -265,11 +266,13 @@ npm run build
   `data`。选择“是”时，卸载器先停止本机服务，把目录原子改名，再让隐藏的系统进程在后台清理，
   卸载界面不等待逐文件
   删除。软件分发系统可向卸载器传入 `/HUGAGENT_DELETE_DATA` 明确请求删除数据。
-- macOS 的持久数据位于
-  `~/Library/Application Support/com.hugagent.desktop/local-server/data`；源码、venv、Node 依赖和
-  版本目录与它分开。DMG 中同样只携带一个 `server-ce.zip`，旧运行版本会先原子移走再后台删除。
-  macOS 把 App 拖入废纸篓不会执行卸载钩子，因此默认不会删除 Application Support 下的数据或
-  运行环境；确认不再需要后可手动删除 `local-server`。
+- macOS 的持久数据位于 `~/.hugagent`；源码、venv、Node 依赖和版本目录仍位于
+  `~/Library/Application Support/com.hugagent.desktop/local-server`。从旧版升级时，如果
+  `~/.hugagent` 不存在或为空，客户端会把旧 `local-server/data` 原子迁入该目录；如果目录已有
+  命令行版数据，则直接沿用并保留旧目录作为备份，不覆盖任何文件。DMG 中同样只携带一个
+  `server-ce.zip`，旧运行版本会先原子移走再后台删除。macOS 把 App 拖入废纸篓不会执行卸载钩子，
+  因此默认不会删除 `~/.hugagent` 或 Application Support 下的运行环境；确认不再需要后可分别
+  手动删除。
 - Linux 当前是远程服务器瘦客户端，不携带 CE 服务载荷，也不创建 `local-server`，因此没有大量本机
   服务文件的卸载清理问题。
 - Linux 托盘依赖 libayatana-appindicator；Wayland 下全局快捷键（Ctrl+Shift+Space）兼容性因桌面

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugagent-desktop",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS 无 Docker 本机服务）",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hugagent-desktop"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "axum",
  "bytes",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugagent-desktop"
-version = "0.2.3"
+version = "0.2.4"
 description = "HugAgentOS桌面客户端"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -275,13 +275,20 @@ pub fn run() {
                 .path()
                 .app_local_data_dir()
                 .unwrap_or_else(|_| config_dir.clone());
+            let local_server_root = local_data_dir.join("local-server");
+            let home_dir = app.path().home_dir().ok();
+            let local_server_data_dir = local_server::resolve_local_server_data_dir(
+                &local_server_root,
+                home_dir.as_deref(),
+            );
             let installer_name = if cfg!(target_os = "macos") {
                 "install-local-server.sh"
             } else {
                 "install-local-server.ps1"
             };
             let local_server = local_server::LocalServerManager::new(
-                local_data_dir.join("local-server"),
+                local_server_root,
+                local_server_data_dir,
                 resource_dir.join("server-ce.zip"),
                 resource_dir.join("server-ce-manifest.json"),
                 resource_dir.join("server-bootstrap").join(installer_name),

--- a/desktop/src-tauri/src/local_server.rs
+++ b/desktop/src-tauri/src/local_server.rs
@@ -2,7 +2,8 @@
 //!
 //! Windows 与 macOS 安装包携带同版本 CE 派生树。这里负责调用平台引导脚本创建
 //! 独立 Python 环境、启动 `hugagent serve`、轮询健康状态，并在桌面进程退出时
-//! 回收子进程。业务数据和 Python 环境都在应用本地数据目录，不写安装目录。
+//! 回收子进程。Python 运行环境位于应用本地数据目录；macOS 业务数据统一放在
+//! ``~/.hugagent``，避免工作区路径中的空格传入命令行工具。
 
 use serde::Serialize;
 use std::collections::VecDeque;
@@ -20,6 +21,73 @@ use tokio::sync::RwLock;
 pub const LOCAL_SERVER_PORT: u16 = 32101;
 pub const LOCAL_SERVER_BASE: &str = "http://127.0.0.1:32101";
 const MAX_LOG_LINES: usize = 80;
+
+/// Resolve the business-data directory independently from the managed runtime.
+///
+/// The Tauri application-data root is still the right place for the bundled
+/// Python/runtime payload. On macOS it contains ``Application Support``, though,
+/// which is a poor workspace path for model-generated shell commands. Keep only
+/// the runtime there and use the same ``~/.hugagent`` data root as the standalone
+/// local installer. Existing desktop data is moved on first launch when that can
+/// be done without overwriting an existing standalone installation.
+pub fn resolve_local_server_data_dir(runtime_root: &Path, home_dir: Option<&Path>) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let legacy = runtime_root.join("data");
+        let Some(home_dir) = home_dir else {
+            return legacy;
+        };
+        let preferred = home_dir.join(".hugagent");
+        if let Err(error) = migrate_legacy_data_dir(&legacy, &preferred) {
+            eprintln!("[local-server] 迁移 macOS 数据目录失败，继续使用旧目录：{error}");
+            return legacy;
+        }
+        preferred
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = home_dir;
+        runtime_root.join("data")
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn migrate_legacy_data_dir(legacy: &Path, preferred: &Path) -> Result<(), String> {
+    if !legacy.exists() || legacy == preferred {
+        return Ok(());
+    }
+    let parent = preferred
+        .parent()
+        .ok_or_else(|| format!("目标目录没有父目录：{}", preferred.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("创建 {} 失败：{error}", parent.display()))?;
+
+    if preferred.exists() {
+        let is_empty = preferred
+            .read_dir()
+            .map_err(|error| format!("读取 {} 失败：{error}", preferred.display()))?
+            .next()
+            .is_none();
+        if !is_empty {
+            eprintln!(
+                "[local-server] {} 已有数据，将其作为统一数据目录；旧目录 {} 保留为备份",
+                preferred.display(),
+                legacy.display()
+            );
+            return Ok(());
+        }
+        std::fs::remove_dir(preferred)
+            .map_err(|error| format!("移除空目录 {} 失败：{error}", preferred.display()))?;
+    }
+
+    std::fs::rename(legacy, preferred).map_err(|error| {
+        format!(
+            "无法把 {} 移到 {}：{error}",
+            legacy.display(),
+            preferred.display()
+        )
+    })
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct LocalServerStatus {
@@ -50,6 +118,7 @@ impl Default for LocalServerStatus {
 
 pub struct LocalServerManager {
     root: PathBuf,
+    data_root: PathBuf,
     bundle_archive: PathBuf,
     bundle_manifest: PathBuf,
     installer_script: PathBuf,
@@ -63,6 +132,7 @@ pub struct LocalServerManager {
 impl LocalServerManager {
     pub fn new(
         root: PathBuf,
+        data_root: PathBuf,
         bundle_archive: PathBuf,
         bundle_manifest: PathBuf,
         installer_script: PathBuf,
@@ -74,6 +144,7 @@ impl LocalServerManager {
         };
         Arc::new(Self {
             root,
+            data_root,
             bundle_archive,
             bundle_manifest,
             installer_script,
@@ -100,7 +171,7 @@ impl LocalServerManager {
     }
 
     fn data_dir(&self) -> PathBuf {
-        self.root.join("data")
+        self.data_root.clone()
     }
 
     #[cfg(target_os = "windows")]
@@ -901,6 +972,7 @@ mod tests {
         std::fs::write(&script, "# test").unwrap();
         LocalServerManager::new(
             root,
+            base.join("data"),
             bundle_archive,
             bundle_manifest,
             script,
@@ -975,6 +1047,55 @@ mod tests {
         std::fs::write(&log, "one\ntwo\nthree\n").unwrap();
 
         assert_eq!(tail_file(&log, 2), vec!["two", "three"]);
+    }
+
+    #[test]
+    fn legacy_macos_data_moves_to_dot_hugagent_without_copying() {
+        let base = std::env::temp_dir().join(format!(
+            "hugagent-desktop-data-migration-{}",
+            std::process::id()
+        ));
+        let legacy = base
+            .join("Library")
+            .join("Application Support")
+            .join("data");
+        let preferred = base.join("home").join(".hugagent");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(legacy.join("workspace").join("site")).unwrap();
+        std::fs::write(legacy.join("data.db"), "desktop data").unwrap();
+
+        migrate_legacy_data_dir(&legacy, &preferred).unwrap();
+
+        assert!(!legacy.exists());
+        assert_eq!(
+            std::fs::read_to_string(preferred.join("data.db")).unwrap(),
+            "desktop data"
+        );
+        assert!(preferred.join("workspace").join("site").is_dir());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn existing_dot_hugagent_wins_without_overwriting_or_deleting_legacy_data() {
+        let base = std::env::temp_dir().join(format!(
+            "hugagent-desktop-data-conflict-{}",
+            std::process::id()
+        ));
+        let legacy = base.join("legacy");
+        let preferred = base.join("home").join(".hugagent");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::create_dir_all(&preferred).unwrap();
+        std::fs::write(legacy.join("data.db"), "desktop data").unwrap();
+        std::fs::write(preferred.join("data.db"), "standalone data").unwrap();
+
+        migrate_legacy_data_dir(&legacy, &preferred).unwrap();
+        assert!(legacy.join("data.db").is_file());
+        assert_eq!(
+            std::fs::read_to_string(preferred.join("data.db")).unwrap(),
+            "standalone data"
+        );
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -265,14 +265,17 @@ const TB_OFFSET_SPA: &str =
 const TB_OFFSET_PAGE: &str =
     ":root{--hugagent-desktop-titlebar-height:36px}body{box-sizing:border-box!important;padding-top:36px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
-const MAC_TITLEBAR_HEIGHT: u8 = 38;
+// The traffic lights start at y=13 and occupy about 14px. A 28px overlay keeps
+// their hit area clear without stacking a second, visibly empty toolbar above
+// the application's own brand row.
+const MAC_TITLEBAR_HEIGHT: u8 = 28;
 // The left half of the macOS safe area reuses the sidebar's first translucent
 // blue gradient stop over its #F5F6F7 base.  The traffic lights therefore sit
 // on a true visual continuation of the sidebar instead of a detached grey bar.
 const MAC_OFFSET_SPA: &str =
-    ":root{--hugagent-desktop-titlebar-height:38px;--hugagent-desktop-sidebar-width:0px}body{box-sizing:border-box!important;padding-top:38px!important;background:linear-gradient(90deg,rgba(203,223,255,.38) 0 var(--hugagent-desktop-sidebar-width),#FFFFFF var(--hugagent-desktop-sidebar-width) 100%),#F5F6F7!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
+    ":root{--hugagent-desktop-titlebar-height:28px;--hugagent-desktop-sidebar-width:0px}body{box-sizing:border-box!important;padding-top:28px!important;background:linear-gradient(90deg,rgba(203,223,255,.38) 0 var(--hugagent-desktop-sidebar-width),#FFFFFF var(--hugagent-desktop-sidebar-width) 100%),#F5F6F7!important}.jx-brandRow,.jx-miniRail{padding-top:0!important}.jx-appLoading{height:100%!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 const MAC_OFFSET_PAGE: &str =
-    ":root{--hugagent-desktop-titlebar-height:38px}body{box-sizing:border-box!important;padding-top:38px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
+    ":root{--hugagent-desktop-titlebar-height:28px}body{box-sizing:border-box!important;padding-top:28px!important}.ant-message{top:calc(var(--hugagent-desktop-titlebar-height) + 8px)!important}.ant-notification-top,.ant-notification-topLeft,.ant-notification-topRight{top:calc(var(--hugagent-desktop-titlebar-height) + 24px)!important}";
 
 const TB_CSS: &str = r##"
 #hugagent-titlebar{position:fixed;inset:0 0 auto 0;height:36px;z-index:2147483647;display:flex;align-items:center;background:#F7F8FA;border-bottom:1px solid #E5E9EF;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei",sans-serif;color:#30343B}
@@ -370,7 +373,7 @@ bar.addEventListener('dblclick',function(event){if(isControl(event.target))retur
 // we only reserve a compact draggable title region for the traffic lights; a
 // second branded toolbar would duplicate the native chrome and waste space.
 const MAC_TB_CSS: &str = r##"
-#hugagent-mac-titlebar{position:fixed;inset:0 0 auto 0;height:38px;z-index:2147483647;background:transparent;border:0;box-shadow:none;-webkit-user-select:none;user-select:none}
+#hugagent-mac-titlebar{position:fixed;inset:0 0 auto 0;height:28px;z-index:2147483647;background:transparent;border:0;box-shadow:none;-webkit-user-select:none;user-select:none}
 #hugagent-mac-titlebar *{box-sizing:border-box}
 "##;
 
@@ -860,7 +863,7 @@ mod tests {
     fn mac_titlebar_is_a_compact_drag_region_without_duplicate_actions() {
         let block = mac_titlebar_block(MAC_OFFSET_SPA);
         assert!(block.contains("hugagent-mac-titlebar"));
-        assert!(block.contains("height:38px"));
+        assert!(block.contains("height:28px"));
         assert!(block.contains("background:transparent"));
         assert!(!block.contains("border-bottom"));
         assert!(!block.contains("backdrop-filter"));
@@ -872,6 +875,7 @@ mod tests {
         assert!(block.contains("--hugagent-desktop-sidebar-width"));
         assert!(block.contains("linear-gradient(90deg,rgba(203,223,255,.38)"));
         assert!(block.contains("#F5F6F7!important"));
+        assert!(block.contains(".jx-brandRow,.jx-miniRail{padding-top:0!important}"));
         assert!(block.contains("ResizeObserver"));
     }
 
@@ -892,7 +896,7 @@ mod tests {
         }
         assert!(titlebar_block(TB_OFFSET_SPA).contains("--hugagent-desktop-titlebar-height:36px"));
         assert!(
-            mac_titlebar_block(MAC_OFFSET_SPA).contains("--hugagent-desktop-titlebar-height:38px")
+            mac_titlebar_block(MAC_OFFSET_SPA).contains("--hugagent-desktop-titlebar-height:28px")
         );
     }
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HugAgentOS",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "com.hugagent.desktop",
   "build": {
     "frontendDist": "../../src/frontend/dist",

--- a/src/backend/services/script_runner_service/server.py
+++ b/src/backend/services/script_runner_service/server.py
@@ -95,11 +95,12 @@ def _bash_quote_state(value: str, end: int) -> Optional[str]:
     return state
 
 
-def _rewrite_bash_workspace_refs(value: str, workspace_root: str) -> str:
-    """Map canonical workspace paths without breaking paths that contain spaces."""
-    if not isinstance(value, str) or workspace_root == "/workspace":
-        return value
-    replacement = workspace_root.rstrip("/\\")
+def _quote_bash_path_refs(
+    value: str,
+    pattern: re.Pattern[str],
+    replacement: str,
+) -> str:
+    """Replace path prefixes while preserving or adding shell-safe quoting."""
 
     def _replace(match: re.Match[str]) -> str:
         quote_state = _bash_quote_state(value, match.start())
@@ -117,7 +118,26 @@ def _rewrite_bash_workspace_refs(value: str, workspace_root: str) -> str:
         # remains visible to the boundary-matching regex.
         return shlex.quote(replacement)
 
-    return _WS_PATH_RE.sub(_replace, value)
+    return pattern.sub(_replace, value)
+
+
+def _rewrite_bash_workspace_refs(value: str, workspace_root: str) -> str:
+    """Map canonical and expanded workspace paths without breaking spaces.
+
+    File tools return both the logical ``/workspace/...`` path and the expanded
+    host path.  A later Bash call may therefore contain either spelling.  Quote
+    the expanded spelling first, then map the canonical spelling, so both stay
+    one shell word when the local data directory contains spaces.
+    """
+    if not isinstance(value, str) or workspace_root == "/workspace":
+        return value
+    replacement = workspace_root.rstrip("/\\")
+    expanded_re = re.compile(
+        rf"(?<![A-Za-z0-9_.\\/\-]){re.escape(replacement)}"
+        r"(?=/|$|[\"'\s:;)&|])"
+    )
+    value = _quote_bash_path_refs(value, expanded_re, replacement)
+    return _quote_bash_path_refs(value, _WS_PATH_RE, replacement)
 
 
 def _execution_workspace_root(

--- a/src/backend/tests/test_local_profile.py
+++ b/src/backend/tests/test_local_profile.py
@@ -523,3 +523,15 @@ def test_runner_canon_ws_and_bash_rewrite(monkeypatch):
         "cd /workspace/site && tar -czf /workspace/site.tgz .",
         local_root,
     ) == (f"cd '{local_root}'/site && tar -czf '{local_root}'/site.tgz .")
+    # File tools also return the expanded physical_path.  If the model feeds it
+    # into Bash verbatim, protect it exactly like the canonical /workspace form.
+    assert srv._rewrite_bash_workspace_refs(
+        f"ls {local_root}/site && test -f {local_root}/site/index.html",
+        local_root,
+    ) == (
+        f"ls '{local_root}'/site && test -f '{local_root}'/site/index.html"
+    )
+    assert srv._rewrite_bash_workspace_refs(
+        f"ls '{local_root}/site'",
+        local_root,
+    ) == f"ls '{local_root}/site'"


### PR DESCRIPTION
## Summary / 概述

Maintainer CE sync derived from upstream commit `127dac58` with `scripts/build_ce.py`.

This fixes two macOS desktop issues:

- Store persistent HugAgentOS data under `~/.hugagent`, while keeping Tauri runtime files under Application Support. Existing desktop data is migrated safely, and legacy data is preserved when the destination already contains data.
- Quote both `/workspace/...` paths and already-expanded physical workspace paths before local Bash execution, so paths containing `Application Support` are not split and `publish_site` can find generated sites.
- Reduce the macOS titlebar height and remove duplicate brand/mini-rail top padding.
- Bump the desktop version to `0.2.4` and update desktop documentation and regression coverage.

## Related issue / 关联 Issue

No public issue. This is a maintainer sync for a reproduced macOS desktop regression.

## Type of change / 变更类型

- [x] Documentation (`document/**`, `README*.md`)
- [ ] Example (`examples/**`)
- [ ] Repository metadata (Issue / PR templates, workflows)
- [x] Other: maintainer CE runtime and desktop fix generated from the upstream full repository

## Validation / 验证

- `python scripts/build_ce.py --import-check --pytest-check --frontend-check`
- `npm --prefix src/frontend run build`
- `npm --prefix desktop run test:scripts` — 16 passed
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` — 22 passed
- Targeted backend local-profile and process tests — 18 passed
- `git diff --check`

The generic root `npm run preflight` command is not available because the repository root has no `package.json`; the repository-native CE release checks above were used instead.

## Checklist / 检查项

- [x] I have read `CONTRIBUTING.md`.
- [x] This change follows the maintainer CE derivation path for generated runtime files.
- [x] Documentation links and command snippets touched by this change have been checked.
- [x] No credentials, private endpoints, or internal deployment details are included.
- [ ] Bilingual public product documentation updated — not applicable; no `document/zh-CN` or `document/en` behavior page is changed.
