### PR TITLE
fix(chat): remove the file-type whitelist from chat attachment uploads

### DIFF
--- a/src/frontend/src/components/chat/InputArea.tsx
+++ b/src/frontend/src/components/chat/InputArea.tsx
@@ -608,7 +608,6 @@ export function InputArea({
         />
 
         <input ref={fileInputRef} type="file" multiple style={{ display: 'none' }}
-          accept=".pdf,.docx,.doc,.wps,.txt,.xlsx,.xls,.csv"
           onChange={(e) => handleFileSelect(e, fileInputRef)} />
         <input ref={imageInputRef} type="file" multiple style={{ display: 'none' }}
           accept="image/png,image/jpeg,image/gif,image/webp,image/bmp,image/svg+xml"


### PR DESCRIPTION
## Problem

The document-upload button in the chat input limited the file picker to `.pdf/.docx/.doc/.wps/.txt/.xlsx/.xls/.csv` through the hidden input's `accept` attribute. Other formats such as `.pptx` could not be selected at all, even though the backend accepts them.

## Change

Drop the `accept` whitelist from the document upload input so any file type can be selected — consistent with the My Space upload flow, which applies no type whitelist (the folder picker alone distinguishes files from folders). The image upload input keeps its image-only `accept` unchanged.

## Testing

Manually verified in the chat input: the attachment picker now offers all file types, and image upload behaviour is unchanged.