### PR TITLE
build(docker): support arm64 image builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,8 +63,9 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
 # dws（DingTalk Workspace CLI）—— 后端以子进程跑 per-user 设备流 OAuth 登录
 # （进程稳定存活，不受沙箱杀后台进程影响；每用户独立 HOME 隔离）。单 Go 二进制。
 ARG DWS_VERSION=v1.0.37
+ARG TARGETARCH
 RUN if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 30 \
-        "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/${DWS_VERSION}/dws-linux-amd64.tar.gz" \
+        "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/${DWS_VERSION}/dws-linux-${TARGETARCH:-amd64}.tar.gz" \
         -o /tmp/dws.tar.gz; then \
       tar -xzf /tmp/dws.tar.gz -C /usr/local/bin dws && \
       chmod +x /usr/local/bin/dws && dws --version; \
@@ -78,7 +79,7 @@ RUN if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout
 # ——沙箱镜像才用 npm 全局装。凭据落 $STORAGE/lark_cache/{uid}/，bind-mount 进沙盒。
 ARG LARK_CLI_VERSION=1.0.34
 RUN if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 30 \
-        "https://github.com/larksuite/cli/releases/download/v${LARK_CLI_VERSION}/lark-cli-${LARK_CLI_VERSION}-linux-amd64.tar.gz" \
+        "https://github.com/larksuite/cli/releases/download/v${LARK_CLI_VERSION}/lark-cli-${LARK_CLI_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz" \
         -o /tmp/lark-cli.tar.gz; then \
       tar -xzf /tmp/lark-cli.tar.gz -C /tmp && \
       find /tmp -maxdepth 2 -name lark-cli -type f -exec mv {} /usr/local/bin/lark-cli \; && \
@@ -91,8 +92,9 @@ RUN if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout
 # （himalaya folder list）。静态二进制（musl，static-pie），无运行时依赖。凭据是用户
 # 自填的 config.toml，落 $STORAGE/email_cache/{uid}/，bind-mount 进沙盒。
 ARG HIMALAYA_VERSION=1.2.0
-RUN if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 30 \
-        "https://github.com/pimalaya/himalaya/releases/download/v${HIMALAYA_VERSION}/himalaya.x86_64-linux.tgz" \
+RUN HIMALAYA_ARCH="$([ "${TARGETARCH:-amd64}" = "arm64" ] && echo aarch64 || echo x86_64)" && \
+    if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 30 \
+        "https://github.com/pimalaya/himalaya/releases/download/v${HIMALAYA_VERSION}/himalaya.${HIMALAYA_ARCH}-linux.tgz" \
         -o /tmp/himalaya.tgz; then \
       tar -xzf /tmp/himalaya.tgz -C /usr/local/bin himalaya && \
       chmod +x /usr/local/bin/himalaya && himalaya --version; \

--- a/docker/Dockerfile.mcp
+++ b/docker/Dockerfile.mcp
@@ -24,6 +24,7 @@ ENV PIP_DEFAULT_TIMEOUT=180 \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
+    libc6-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install backend deps + the few office/chart deps the MCP servers still use.

--- a/docker/Dockerfile.script-runner
+++ b/docker/Dockerfile.script-runner
@@ -82,8 +82,10 @@ RUN npm install -g openyida@2026.7.12-1
 # himalaya（电子邮箱 CLI）——email 插件的 email 技能靠它运行（Bash(himalaya *)）。
 # 静态二进制，无运行时依赖。凭据是用户自填的 config.toml，不烤进镜像。
 ARG HIMALAYA_VERSION=1.2.0
-RUN if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 30 \
-        "https://github.com/pimalaya/himalaya/releases/download/v${HIMALAYA_VERSION}/himalaya.x86_64-linux.tgz" \
+ARG TARGETARCH
+RUN HIMALAYA_ARCH="$([ "${TARGETARCH:-amd64}" = "arm64" ] && echo aarch64 || echo x86_64)" && \
+    if curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 30 \
+        "https://github.com/pimalaya/himalaya/releases/download/v${HIMALAYA_VERSION}/himalaya.${HIMALAYA_ARCH}-linux.tgz" \
         -o /tmp/himalaya.tgz; then \
       tar -xzf /tmp/himalaya.tgz -C /usr/local/bin himalaya && \
       chmod +x /usr/local/bin/himalaya && himalaya --version; \


### PR DESCRIPTION
## Summary

Docker images can now be built natively on arm64 hosts (e.g. Apple Silicon, ARM cloud instances). Previously several third-party CLI binaries were downloaded with hardcoded amd64/x86_64 asset names, which broke builds or installed wrong-architecture binaries on ARM.

## Changes

- **docker/Dockerfile**: download dws, lark-cli and himalaya by `TARGETARCH` (with an arm64 → aarch64 mapping for himalaya) instead of hardcoded amd64/x86_64 asset names
- **docker/Dockerfile.script-runner**: same TARGETARCH-based selection for himalaya
- **docker/Dockerfile.mcp**: add `libc6-dev` so Python C extensions compile on arm64

## Verification

- arm64 release assets for all three CLIs were verified to exist upstream (HTTP 200)
- All base images used by the compose stack are multi-arch (python:3.11-slim, dotnet/sdk:8.0, postgres, redis, milvus, neo4j, etcd, minio)
- The full stack was built and is running natively as arm64 containers on an Apple Silicon host