### PR TITLE
refactor(desktop): brand-configurable local-server readiness service name

### DIFF
--- a/desktop/src-tauri/src/brand.rs
+++ b/desktop/src-tauri/src/brand.rs
@@ -43,6 +43,14 @@ pub const DESKTOP_UPDATE_BASE: &str = match option_env!("JX_DESKTOP_UPDATE_BASE"
     None => "",
 };
 
+/// 本机服务 `/health` 返回的 `service` 标识（backend `api/health.py`）。就绪判定
+/// 靠它确认端口上跑的是我们的后端——两侧必须一致，否则健康检查 200 也永远
+/// 不算就绪，本机模式卡在「启动超时」（iChain 分支实测踩坑）。
+pub const LOCAL_SERVICE_NAME: &str = match option_env!("JX_LOCAL_SERVICE_NAME") {
+    Some(v) => v,
+    None => "hugagent",
+};
+
 /// 登录卡片上展示的 logo（走本地反代的静态路径，或可访问的绝对 URL）。
 pub const LOGIN_LOGO_URL: &str = match option_env!("JX_BRAND_LOGO_URL") {
     Some(v) => v,

--- a/desktop/src-tauri/src/local_server.rs
+++ b/desktop/src-tauri/src/local_server.rs
@@ -339,7 +339,7 @@ impl LocalServerManager {
                     .map(str::to_owned)
             })
             .as_deref()
-            == Some("hugagent")
+            == Some(crate::brand::LOCAL_SERVICE_NAME)
     }
 
     /// 后台启动已安装的本机服务；重复调用是幂等的。


### PR DESCRIPTION
## What

The local-server readiness probe hardcoded `service == "hugagent"` when checking `/health`. A downstream brand whose backend reports a different service id never passes readiness — the local mode setup hangs at 99% and times out even though the backend is healthy (hit in practice on a downstream branch).

- Move the expected id to `brand.rs` as `LOCAL_SERVICE_NAME`, overridable at build time via `JX_LOCAL_SERVICE_NAME`.
- No behavior change for this repository (default stays `hugagent`).

## Testing
- `cargo test --lib` in `desktop/src-tauri` — 33/33 pass