### PR TITLE
fix(frontend): add an auth-headers input to the self-service MCP add form

### DIFF
--- a/src/frontend/src/components/catalog/McpPage.tsx
+++ b/src/frontend/src/components/catalog/McpPage.tsx
@@ -60,11 +60,20 @@ export function McpPage({ embedded = false, onDetailChange }: { embedded?: boole
     const values = await form.validateFields();
     setAdding(true);
     try {
+      // Parse headers from key=value lines (auth header for protected remote MCPs)
+      const headers: Record<string, string> = {};
+      if (typeof values.headers_text === 'string') {
+        values.headers_text.split('\n').forEach((line: string) => {
+          const idx = line.indexOf('=');
+          if (idx > 0) headers[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+        });
+      }
       await createMyMcpServer({
         display_name: values.display_name,
         transport: values.transport,
         url: values.url,
         description: values.description || '',
+        headers,
       });
       message.success(t('已添加'));
       setAddOpen(false);
@@ -343,6 +352,13 @@ export function McpPage({ embedded = false, onDetailChange }: { embedded?: boole
           </Form.Item>
           <Form.Item name="description" label={t('描述（可选）')}>
             <Input.TextArea rows={2} maxLength={2000} placeholder={t('简单说明这个工具的用途')} />
+          </Form.Item>
+          <Form.Item
+            name="headers_text"
+            label={t('请求头（可选）')}
+            help={t('每行一个：Key=Value。需要鉴权的服务在此填认证头，如 Authorization=Bearer xxx')}
+          >
+            <Input.TextArea rows={2} placeholder="Authorization=Bearer xxx" />
           </Form.Item>
         </Form>
       </Modal>

--- a/src/frontend/src/i18n/en/catalog.ts
+++ b/src/frontend/src/i18n/en/catalog.ts
@@ -252,6 +252,9 @@ export const CATALOG_DICT: Record<string, string> = {
   '请输入 URL': 'Please enter a URL',
   '描述（可选）': 'Description (optional)',
   '简单说明这个工具的用途': 'Briefly describe what this tool does',
+  '请求头（可选）': 'Headers (optional)',
+  '每行一个：Key=Value。需要鉴权的服务在此填认证头，如 Authorization=Bearer xxx':
+    'One per line: Key=Value. For services requiring auth, put the auth header here, e.g. Authorization=Bearer xxx',
   '已添加': 'Added',
   '添加失败': 'Add failed',
 


### PR DESCRIPTION
## Problem

The self-service "Add MCP Tool" modal has no way to supply HTTP request headers. Since the backend probes connectivity before persisting a new MCP server, any Bearer-protected remote MCP fails the probe with `401 Unauthorized` and can never be added. Worse, the 401 gets swallowed by the anyio cancel scope inside the MCP client, so the user-facing error is an opaque `CancelledError: Cancelled via cancel scope ...` that gives no hint about the real cause.

## Fix

- Add an optional **Headers** field (one `Key=Value` per line, e.g. `Authorization=Bearer xxx`) to the add-MCP modal in `McpPage.tsx`.
- Parse the lines into a headers map on submit and pass it to `createMyMcpServer` — the backend `POST /v1/me/mcp-servers` endpoint already accepts `headers`, so this is a pure frontend gap.
- Add the two new i18n dictionary entries.

## Testing

- `npm run build` passes (i18n gate + tsc + vite).
- Verified against a live Bearer-protected streamable-http MCP endpoint: without headers the probe fails with 401; with the auth header filled in, the probe succeeds and the tool is added.