### PR TITLE
fix(models): probe chat providers with streaming

### DIFF
--- a/src/backend/api/routes/v1/models.py
+++ b/src/backend/api/routes/v1/models.py
@@ -289,6 +289,9 @@ async def _ping_openai_compat(
             "model": model_name,
             "messages": [{"role": "user", "content": "hi"}],
             "max_tokens": 5,
+            # Match the agent runtime, which always consumes chat models as an SSE stream.
+            # Some Responses-backed OpenAI-compatible gateways reject non-streaming probes.
+            "stream": True,
         }
     elif provider_type == "embedding":
         url = f"{base_url}/embeddings"

--- a/src/backend/tests/api/test_model_connection_probe.py
+++ b/src/backend/tests/api/test_model_connection_probe.py
@@ -1,0 +1,39 @@
+"""Regression tests for model-provider connectivity probes."""
+
+import pytest
+from api.routes.v1 import models
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_probe_matches_streaming_runtime(monkeypatch):
+    captured = {}
+
+    async def fake_http_ping(url, headers, payload, timeout=15):
+        captured.update(
+            {
+                "url": url,
+                "headers": headers,
+                "payload": payload,
+                "timeout": timeout,
+            }
+        )
+        return {"success": True, "latency_ms": 1, "error": None}
+
+    monkeypatch.setattr(models, "_http_ping", fake_http_ping)
+
+    result = await models._ping_openai_compat(
+        "chat",
+        "http://model.test/api/v1/",
+        "test-key",
+        "test-model",
+    )
+
+    assert result["success"] is True
+    assert captured["url"] == "http://model.test/api/v1/chat/completions"
+    assert captured["payload"] == {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 5,
+        "stream": True,
+    }
+    assert captured["headers"]["Authorization"] == "Bearer test-key"


### PR DESCRIPTION
## Summary / 概述

- Send `stream: true` when probing OpenAI-compatible chat providers so Responses-backed gateways that require streaming can pass the connection check.
- Add a regression test covering the composed chat-completions URL and streaming probe payload.
- Align the connection probe with the existing streaming chat runtime.

Validation:

- `PYTHONPATH=src/backend pytest src/backend/tests/api/test_model_connection_probe.py src/backend/tests/services/test_user_model_selection.py -q` — 5 passed.
- Black, isort, compileall, and diff whitespace checks passed for the changed files.
- This repository has no root `npm run preflight` script, so the relevant backend checks above were used.

## Related issue / 关联 Issue

None.

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): Maintainer sync of an upstream backend bug fix.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
- [x] Links and code snippets were verified. 链接与代码片段已验证。
- [x] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。Not applicable; no documentation changed.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。
