### PR TITLE
feat(models): add OpenAI Codex reasoning provider

### DIFF
--- a/src/backend/core/chat/tool_log.py
+++ b/src/backend/core/chat/tool_log.py
@@ -17,6 +17,8 @@ def build_thinking_event(chunk: dict, chat_id: str) -> Dict[str, Any]:
     yields it as SSE or pushes it via ``_emit``.
     """
     evt: Dict[str, Any] = {"type": "thinking", "chat_id": chat_id}
+    if chunk.get("structured_reasoning") is True:
+        evt["structured_reasoning"] = True
     if "delta" in chunk:
         evt["delta"] = chunk.get("delta", "")
     else:

--- a/src/backend/core/llm/chat_models.py
+++ b/src/backend/core/llm/chat_models.py
@@ -86,6 +86,7 @@ class OpenAICompatChatModel(StructuredFallbackMixin, OpenAIChatModel):
         context_size: int,
         extra_body: dict | None = None,
         azure: dict | None = None,
+        structured_reasoning: bool = False,
     ) -> None:
         super().__init__(
             credential=credential,
@@ -101,6 +102,9 @@ class OpenAICompatChatModel(StructuredFallbackMixin, OpenAIChatModel):
         self._http_client = http_client
         self._extra_body = extra_body or {}
         self._azure = azure  # when {"api_version": ...} is non-empty, use AsyncAzureOpenAI
+        # The SSE layer uses this to distinguish structured reasoning_content from
+        # legacy models that embed reasoning in content as <think>...</think>.
+        self.structured_reasoning = structured_reasoning
 
     def _build_client(self):
         import openai
@@ -235,6 +239,7 @@ def _make_openai_compatible(
         context_size=context_size,
         extra_body=extra_body,
         azure=azure,
+        structured_reasoning=spec.structured_reasoning,
     )
 
 

--- a/src/backend/core/llm/chat_models.py
+++ b/src/backend/core/llm/chat_models.py
@@ -208,12 +208,17 @@ def _make_openai_compatible(
         azure = {"api_version": provider_extra.get("api_version", "")}
         actual_model = provider_extra.get("deployment") or model
 
-    extra_body = {
+    extra_body: dict[str, Any] = {
         "chat_template_kwargs": _build_chat_template_kwargs(
             disable_thinking=disable_thinking,
             reasoning_effort=reasoning_effort,
         )
     }
+    if spec.reasoning_effort_top_level and reasoning_effort is not None:
+        # OpenAI Responses-backed Chat Completions gateways expose reasoning
+        # only when the effort is sent at the request root. Keep the nested
+        # switch as well so OpenAI-compatible template controls still work.
+        extra_body["reasoning_effort"] = reasoning_effort
     parameters = OpenAIChatModel.Parameters(
         temperature=temperature,
         max_tokens=max_tokens,

--- a/src/backend/core/llm/providers/registry.py
+++ b/src/backend/core/llm/providers/registry.py
@@ -47,6 +47,9 @@ class ProviderSpec:
     # placeholders, or vendors without a fixed URL stay False.
     autofill_base_url: bool = False
     api_key_required: bool = True
+    # OpenAI/Codex-style gateways expect reasoning_effort at the request root.
+    # Generic compatible vendors keep using chat_template_kwargs only.
+    reasoning_effort_top_level: bool = False
     fields: tuple[ProviderField, ...] = ()  # vendor-specific extra fields (stored in extra_config)
 
     @property
@@ -73,6 +76,12 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         id="openai_compatible", label="OpenAI 兼容", engine="openai",
         supports_types=("chat", "embedding", "reranker"),
         base_url_template="https://api.openai.com/v1",
+    ),
+    "openai": ProviderSpec(
+        id="openai", label="OpenAI / Codex", engine="openai",
+        supports_types=("chat", "embedding"),
+        base_url_template="https://api.openai.com/v1",
+        reasoning_effort_top_level=True,
     ),
     "deepseek": ProviderSpec(
         id="deepseek", label="DeepSeek", engine="openai",

--- a/src/backend/core/llm/providers/registry.py
+++ b/src/backend/core/llm/providers/registry.py
@@ -50,6 +50,8 @@ class ProviderSpec:
     # OpenAI/Codex-style gateways expect reasoning_effort at the request root.
     # Generic compatible vendors keep using chat_template_kwargs only.
     reasoning_effort_top_level: bool = False
+    # Reasoning arrives separately as reasoning_content instead of being embedded in content.
+    structured_reasoning: bool = False
     fields: tuple[ProviderField, ...] = ()  # vendor-specific extra fields (stored in extra_config)
 
     @property
@@ -82,6 +84,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         supports_types=("chat", "embedding"),
         base_url_template="https://api.openai.com/v1",
         reasoning_effort_top_level=True,
+        structured_reasoning=True,
     ),
     "deepseek": ProviderSpec(
         id="deepseek", label="DeepSeek", engine="openai",

--- a/src/backend/orchestration/autonomous_loop.py
+++ b/src/backend/orchestration/autonomous_loop.py
@@ -306,6 +306,9 @@ async def _run_worker_iteration(
                 text += payload
                 if emit and not hold_output:
                     await emit({"type": "content", "event": "ai_message", "delta": payload})
+            elif et == "reasoning_protocol":
+                if emit:
+                    await emit({"type": "thinking", **payload})
             elif et == "thinking_delta":
                 if emit:
                     await emit({"type": "thinking", "delta": payload})

--- a/src/backend/orchestration/streaming.py
+++ b/src/backend/orchestration/streaming.py
@@ -113,6 +113,22 @@ class StreamingAgent:
         self._raw_text = ""
         self._emitted_answer = ""
         self._in_thinking = False
+        self._reasoning_protocol_emitted = False
+
+    def _take_reasoning_protocol(self) -> Optional[Dict[str, bool]]:
+        """Return the structured-reasoning marker once the active model is known.
+
+        DynamicModelMiddleware may replace ``agent.model`` at reply start, so this is
+        evaluated immediately before mapping the first AgentScope event rather than in
+        ``__init__``.
+        """
+        if self._reasoning_protocol_emitted:
+            return None
+        model = getattr(self.agent, "model", None)
+        if not bool(getattr(model, "structured_reasoning", False)):
+            return None
+        self._reasoning_protocol_emitted = True
+        return {"structured_reasoning": True}
 
     def get_usage(self) -> Dict[str, int]:
         total_prompt = sum(r.get("prompt_tokens", 0) for r in self._usage_records)
@@ -243,6 +259,9 @@ class StreamingAgent:
                     yield ("subagent_event", payload)
                     continue
                 # kind == "ev"
+                reasoning_protocol = self._take_reasoning_protocol()
+                if reasoning_protocol is not None:
+                    yield ("reasoning_protocol", reasoning_protocol)
                 async for out in self._map_event(payload):
                     if not _first_event_logged:
                         _ttfe = (time.monotonic() - _stream_start) * 1000

--- a/src/backend/orchestration/workflow.py
+++ b/src/backend/orchestration/workflow.py
@@ -1416,6 +1416,9 @@ async def _astream_subagent_direct(
                     full_response += payload
                     yield {"type": "content", "event": "ai_message", "delta": payload}
 
+                elif event_type == "reasoning_protocol":
+                    yield {"type": "thinking", **payload}
+
                 elif event_type == "thinking_delta":
                     yield {"type": "thinking", "delta": payload}
 
@@ -2099,6 +2102,9 @@ async def astream_chat_workflow(
                 if event_type == "text_delta":
                     full_response += payload
                     yield {"type": "content", "event": "ai_message", "delta": payload}
+
+                elif event_type == "reasoning_protocol":
+                    yield {"type": "thinking", **payload}
 
                 elif event_type == "thinking_delta":
                     yield {"type": "thinking", "delta": payload}

--- a/src/backend/tests/llm/test_openai_provider.py
+++ b/src/backend/tests/llm/test_openai_provider.py
@@ -1,0 +1,47 @@
+"""Tests for the dedicated OpenAI/Codex provider preset."""
+
+from core.llm.chat_models import make_chat_model
+from core.llm.providers.registry import get_spec, to_frontend_schema
+
+
+def _make_model(provider: str, reasoning_effort: str | None):
+    return make_chat_model(
+        model="test-model",
+        temperature=0.0,
+        max_tokens=32,
+        timeout=10,
+        base_url="http://model.test/api/v1",
+        api_key="test-key",
+        provider=provider,
+        reasoning_effort=reasoning_effort,
+        stream=True,
+        context_size=4096,
+    )
+
+
+def test_openai_provider_is_exposed_to_dynamic_forms():
+    spec = get_spec("openai")
+
+    assert spec.label == "OpenAI / Codex"
+    assert spec.reasoning_effort_top_level is True
+    assert any(row["id"] == "openai" for row in to_frontend_schema())
+
+
+def test_openai_provider_sends_top_level_reasoning_effort():
+    model = _make_model("openai", "high")
+
+    assert model._extra_body["reasoning_effort"] == "high"
+    assert model._extra_body["chat_template_kwargs"] == {
+        "thinking": True,
+        "reasoning_effort": "high",
+    }
+
+
+def test_generic_compatible_provider_keeps_existing_reasoning_transport():
+    model = _make_model("openai_compatible", "high")
+
+    assert "reasoning_effort" not in model._extra_body
+    assert model._extra_body["chat_template_kwargs"] == {
+        "thinking": True,
+        "reasoning_effort": "high",
+    }

--- a/src/backend/tests/llm/test_openai_provider.py
+++ b/src/backend/tests/llm/test_openai_provider.py
@@ -24,6 +24,7 @@ def test_openai_provider_is_exposed_to_dynamic_forms():
 
     assert spec.label == "OpenAI / Codex"
     assert spec.reasoning_effort_top_level is True
+    assert spec.structured_reasoning is True
     assert any(row["id"] == "openai" for row in to_frontend_schema())
 
 
@@ -35,6 +36,7 @@ def test_openai_provider_sends_top_level_reasoning_effort():
         "thinking": True,
         "reasoning_effort": "high",
     }
+    assert model.structured_reasoning is True
 
 
 def test_generic_compatible_provider_keeps_existing_reasoning_transport():
@@ -45,3 +47,4 @@ def test_generic_compatible_provider_keeps_existing_reasoning_transport():
         "thinking": True,
         "reasoning_effort": "high",
     }
+    assert model.structured_reasoning is False

--- a/src/backend/tests/orchestration/test_structured_reasoning_protocol.py
+++ b/src/backend/tests/orchestration/test_structured_reasoning_protocol.py
@@ -1,0 +1,35 @@
+"""Regression tests for structured reasoning SSE protocol markers."""
+
+from types import SimpleNamespace
+
+from core.chat.tool_log import build_thinking_event
+from orchestration.streaming import StreamingAgent
+
+
+def test_streaming_agent_emits_structured_reasoning_protocol_once():
+    agent = SimpleNamespace(model=SimpleNamespace(structured_reasoning=True))
+    streaming_agent = StreamingAgent(agent, mcp_clients=[])
+
+    assert streaming_agent._take_reasoning_protocol() == {"structured_reasoning": True}
+    assert streaming_agent._take_reasoning_protocol() is None
+
+
+def test_streaming_agent_skips_protocol_for_inline_reasoning_models():
+    agent = SimpleNamespace(model=SimpleNamespace(structured_reasoning=False))
+    streaming_agent = StreamingAgent(agent, mcp_clients=[])
+
+    assert streaming_agent._take_reasoning_protocol() is None
+
+
+def test_thinking_event_preserves_structured_reasoning_marker():
+    event = build_thinking_event(
+        {"type": "thinking", "structured_reasoning": True},
+        "chat_test",
+    )
+
+    assert event == {
+        "type": "thinking",
+        "chat_id": "chat_test",
+        "structured_reasoning": True,
+        "message": "正在思考...",
+    }

--- a/src/frontend/src/hooks/chatStream.ts
+++ b/src/frontend/src/hooks/chatStream.ts
@@ -927,6 +927,17 @@ export async function processChatStream(resp: Response, opts: ChatStreamOptions)
           // event, not embedded in `content` as <think>...</think>.
           // Disable the embed-tag parser so subsequent content chunks
           // are not treated as buffered thinking.
+          if (eventObj.structured_reasoning === true) {
+            structuredReasoning = true;
+            if (parseBuffer) {
+              // An explicit protocol marker means content is always the answer body.
+              // This also repairs replay streams where the marker arrives after a
+              // buffered content frame.
+              appendTextSeg(parseBuffer);
+              parseBuffer = '';
+            }
+            thinkingPhaseActive = false;
+          }
           if (obj.delta) {
             structuredReasoning = true;
             if (thinkingPhaseActive && parseBuffer) {


### PR DESCRIPTION
## Summary / 概述

- Add a dedicated `OpenAI / Codex` provider preset for OpenAI Responses-backed Chat Completions gateways.
- Send `reasoning_effort` at the request root for that provider while retaining the nested `chat_template_kwargs` compatibility controls.
- Mark dedicated OpenAI streams as structured-reasoning streams so ordinary response text stays in the answer when the model emits no `reasoning_content`.
- Preserve the existing generic `OpenAI 兼容` inline `<think>` behavior and add regression coverage for both protocols.

Validation:

- `PYTHONPATH=src/backend pytest -q src/backend/tests/llm/test_openai_provider.py src/backend/tests/orchestration/test_structured_reasoning_protocol.py src/backend/tests/api/test_model_connection_probe.py src/backend/tests/services/test_user_model_selection.py` — 11 passed.
- Frontend i18n check, TypeScript production build, and targeted ESLint for `src/hooks/chatStream.ts` passed.
- A live streaming gateway check with `reasoning_effort=max` produced both `ThinkingBlock` and `TextBlock`; no reasoning text or credentials are included here.
- `git diff --check` passed. The repository has no root `npm run preflight` script, so the relevant backend and frontend checks above were used.

## Related issue / 关联 Issue

Follow-up to #39.

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): Maintainer sync of an upstream provider adaptation and streaming display fix.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
- [x] Links and code snippets were verified. 链接与代码片段已验证。
- [x] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。 Not applicable; no documentation changed.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。
