### PR TITLE
Fix duplicate manual Plan Mode progress and conversation titles

### DIFF
--- a/document/en/modules/chat.md
+++ b/document/en/modules/chat.md
@@ -117,6 +117,7 @@ Plan Mode splits complex tasks into "generate plan → user reviews/edits → ex
 
 - **Generate** (`astream_generate_plan` / `POST /v1/plans/generate`): a "bare LLM" agent (`disable_tools=True`) produces a structured JSON plan. System-prompt resolution: active `plan_mode` version in the prompt pool → legacy `system/90_plan_mode` part → fallback file `prompts/prompt_text/plan_mode/plan_mode.system.md` → hardcoded minimal prompt.
 - **Execute** (`astream_execute_plan` / `POST /v1/plans/{plan_id}/execute`): each step gets its own agent, executed sequentially, with step-level MCP/skill/sub-agent bindings and cancellation (`is_run_cancelled` polling); execution also goes through ChatRun + Redis Stream, so it survives disconnects.
+- **Frontend presentation and title**: manual Plan Mode keeps plan previews and execution progress in the in-conversation plan card instead of duplicating them in the compact strip above the composer (that strip is reserved for model-driven `update_plan` progress in regular chats). A model-generated conversation title is requested as soon as the preview is ready, with a first-task title used as the temporary fallback.
 - **Model role**: plan mode prefers the `plan_agent` role and falls back to `main_agent` (the `_mode_role` branch in `agent_factory.py`).
 - Unattended modes (plan execution / automation) remove `batch_runner` from the toolkit, since `batch_plan`'s confirmation dialog has no UI in those contexts (`workflow.py::_resolve_batch_runner_visibility`).
 

--- a/document/zh-CN/modules/chat.md
+++ b/document/zh-CN/modules/chat.md
@@ -107,6 +107,7 @@ data: [DONE]
 
 - **生成**（`astream_generate_plan` / `POST /v1/plans/generate`）：以 `disable_tools=True` 的"裸模型"产出结构化 JSON 计划。系统提示词解析顺序：版本池 `plan_mode` 激活版本 → 旧版 `system/90_plan_mode` 分段 → 文件兜底 `prompts/prompt_text/plan_mode/plan_mode.system.md` → 硬编码最小提示。
 - **执行**（`astream_execute_plan` / `POST /v1/plans/{plan_id}/execute`）：每个步骤独立建 agent 顺序执行，支持步骤级 MCP/技能/子智能体绑定、取消（`is_run_cancelled` 轮询）；执行同样走 ChatRun + Redis Stream，可断线续播。
+- **前端呈现与标题**：手动计划模式的预览和执行进度统一显示在对话内的计划卡片，不再重复显示输入框上方的紧凑计划条（该计划条只服务普通对话中的模型 `update_plan`）；计划预览生成后即触发会话标题自动摘要，摘要完成前由首条任务生成临时标题。
 - **模型角色**：计划模式优先解析 `plan_agent` 角色，未配置降级 `main_agent`（`agent_factory.py` `_mode_role` 分支）。
 - 无人值守模式（计划执行 / 自动化）会从工具集中摘除 `batch_runner`，因为 `batch_plan` 的确认弹窗在该场景无 UI 可确认（`workflow.py::_resolve_batch_runner_visibility`）。
 

--- a/src/backend/api/routes/v1/plans.py
+++ b/src/backend/api/routes/v1/plans.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from core.auth.backend import get_current_user, UserContext
+from core.chat.context import generate_smart_title
 from core.db.engine import get_db
 from core.infra.responses import success_response, sse_response
 from core.services.plan_service import PlanService
@@ -81,6 +82,7 @@ def _ensure_plan_session(
     db: Session,
     chat_id: Optional[str],
     user_id: str,
+    title_seed: str,
     project_id: Optional[str] = None,
 ) -> Optional[str]:
     """Ensure a chat session exists for plan mode messages.
@@ -100,7 +102,7 @@ def _ensure_plan_session(
         svc.ensure_session(
             chat_id=chat_id,
             user_id=user_id,
-            title="计划模式",
+            title=generate_smart_title(title_seed),
             extra_data={"plan_chat": True},
             project_id=project_id,
         )
@@ -182,7 +184,13 @@ async def generate_plan(
     后台 task 跑生成工作流，HTTP 连接断开（刷新页面）任务继续；前端可通过
     ``GET /v1/chats/{chat_id}/active-run`` 探测，结束后从消息列表拿到完整 plan。
     """
-    db_chat_id = _ensure_plan_session(db, req.chat_id, user.user_id, project_id=req.project_id)
+    db_chat_id = _ensure_plan_session(
+        db,
+        req.chat_id,
+        user.user_id,
+        req.task_description,
+        project_id=req.project_id,
+    )
     if not db_chat_id:
         raise HTTPException(status_code=400, detail="chat_id 必填，无法创建后台生成任务")
     try:
@@ -359,7 +367,13 @@ async def execute_plan(
         raise HTTPException(status_code=400, detail=f"计划状态为 '{plan.status}'，需要先审批")
 
     # Ensure chat session and save "确认执行" user message
-    db_chat_id = _ensure_plan_session(db, req.chat_id, user.user_id, project_id=req.project_id)
+    db_chat_id = _ensure_plan_session(
+        db,
+        req.chat_id,
+        user.user_id,
+        plan.title,
+        project_id=req.project_id,
+    )
     if not db_chat_id:
         raise HTTPException(status_code=400, detail="chat_id 必填，无法创建后台执行任务")
     actual_model_name = resolve_effective_chat_model_name() or "qwen"

--- a/src/backend/tests/chat/test_plan_session.py
+++ b/src/backend/tests/chat/test_plan_session.py
@@ -1,0 +1,28 @@
+from api.routes.v1 import plans as plans_route
+from core.chat.context import generate_smart_title
+
+
+def test_plan_session_uses_task_based_initial_title(monkeypatch):
+    captured = {}
+
+    class StubChatService:
+        def __init__(self, db):
+            self.db = db
+
+        def ensure_session(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(plans_route, "ChatService", StubChatService)
+
+    task = "梳理本季度重点项目并输出风险清单"
+    chat_id = plans_route._ensure_plan_session(
+        object(),
+        "chat_plan_title",
+        "user_1",
+        task,
+    )
+
+    assert chat_id == "chat_plan_title"
+    assert captured["title"] == generate_smart_title(task)
+    assert captured["title"] != "计划模式"
+    assert captured["extra_data"] == {"plan_chat": True}

--- a/src/frontend/src/components/chat/PlanProgressStrip.tsx
+++ b/src/frontend/src/components/chat/PlanProgressStrip.tsx
@@ -11,8 +11,9 @@ import { t } from '../../i18n';
 /* ───────────────────────────────────────────
    Plan bar — slim plan/progress strip pinned
    above the chat input. Fed by chatStore
-   planProgress (agent update_plan tool + manual
-   plan-mode execution). Collapsed: one 40px row
+   planProgress from the agent update_plan tool.
+   Manual plan mode already renders its full progress
+   inside the conversation. Collapsed: one 40px row
    with a determinate progress ring; click to
    expand the step checklist.
    ─────────────────────────────────────────── */
@@ -54,16 +55,21 @@ export function PlanProgressStrip({ chatId }: { chatId: string }) {
   const progress = useChatStore((s) => s.planProgress[chatId]);
   const [expanded, setExpanded] = useState(false);
 
-  const steps = progress?.steps ?? [];
+  // Manual plan mode already owns a full plan card in the message stream.
+  // Showing the same steps here would duplicate that UI above the composer;
+  // keep this compact strip for model-initiated update_plan progress only.
+  const visibleProgress = progress?.source === 'agent' ? progress : null;
+
+  const steps = visibleProgress?.steps ?? [];
   const completed = steps.filter((s) => s.status === 'completed').length;
   const failed = steps.filter((s) => s.status === 'failed').length;
   const total = steps.length;
   const current = steps.find((s) => s.status === 'in_progress');
-  const allDone = !!progress?.done || (total > 0 && completed + failed === total);
+  const allDone = !!visibleProgress?.done || (total > 0 && completed + failed === total);
 
   return (
     <AnimatePresence initial={false}>
-      {progress && total > 0 && (
+      {visibleProgress && total > 0 && (
         <motion.div
           key="planStrip"
           className="jx-planStrip"
@@ -86,7 +92,7 @@ export function PlanProgressStrip({ chatId }: { chatId: string }) {
                 ? <CloseCircleFilled className="jx-planStrip-doneIcon jx-planStrip-doneIcon--fail" />
                 : <CheckCircleFilled className="jx-planStrip-doneIcon" />)
               : <ProgressRing completed={completed} total={total} />}
-            <span className="jx-planStrip-title">{progress.title || t('任务计划')}</span>
+            <span className="jx-planStrip-title">{visibleProgress.title || t('任务计划')}</span>
             {!allDone && current && (
               <>
                 <span className="jx-planStrip-sep" aria-hidden>·</span>

--- a/src/frontend/src/hooks/usePlanMode.ts
+++ b/src/frontend/src/hooks/usePlanMode.ts
@@ -509,10 +509,18 @@ export async function sendPlanMode(
         opts.suppressUserEcho,
       );
       if (!genResp.ok) throw new Error(t('计划生成请求失败: {status}', { status: genResp.status }));
-      await processPlanGenerateStream(genResp, currentChatId, {
+      const { planEvt } = await processPlanGenerateStream(genResp, currentChatId, {
         placeholderTs,
         onSetCurrentPlanId: setCurrentPlanId,
       });
+      if (planEvt) {
+        // The plan session now exists on the backend. Generate its model-written
+        // conversation title as soon as the preview is ready instead of waiting
+        // until the user eventually confirms and finishes the whole plan.
+        useChatStore.getState().addBackendSessionId(streamChatId);
+        useChatStore.getState().addLoadedMsgId(streamChatId);
+        setTimeout(() => generateSummary(streamChatId), 500);
+      }
     }
 
   } catch (e: any) {


### PR DESCRIPTION
## What changed

- hide the compact progress strip for manual Plan Mode while preserving it for model-driven `update_plan` progress
- generate a model-written conversation title as soon as a plan preview is ready
- seed new plan sessions with a task-derived fallback title instead of the fixed “计划模式” label
- add a regression test and update the Chinese and English chat documentation

## Why

Manual Plan Mode already renders the full plan and execution state inside the conversation. Mirroring the same steps above the composer duplicated the UI. Plan sessions were also created with a fixed title and title summarization only ran after full execution, so preview-only sessions could remain named “计划模式”.

## Impact

Manual planning now has one authoritative progress surface, and plan conversations receive useful titles immediately after preview generation. Regular chat planning through `update_plan` is unchanged.

## Checks

- CE brand, required-file, import/OpenAPI/ORM, and release regression gates
- targeted backend regression test
- frontend TypeScript build and ESLint for the changed progress component
- `git diff --check`
