### PR TITLE
Fix context usage after compaction and Plan Mode UI

### DIFF
--- a/document/en/modules/chat.md
+++ b/document/en/modules/chat.md
@@ -1,6 +1,6 @@
 # Chat & Agent Orchestration
 
-> Last updated: July 20, 2026
+> Last updated: July 30, 2026
 
 Chat is the core pipeline of HugAgentOS: a user message travels through the FastAPI route, runtime-context assembly, and the streaming orchestrator, then an AgentScope 2.0 ReActAgent drives multi-turn "think → call tool → observe" loops whose events are pushed to the frontend in real time over SSE. This page walks the end-to-end flow as it exists in the code, then covers the citation system, plan mode, sub-agents, conversation summarization, chat sharing, context compression, and oversized-tool-result offloading.
 
@@ -73,6 +73,7 @@ Defensive machinery: a `: heartbeat` SSE comment line every 15 silent seconds (k
 | `tool_pending` | Tool started, args still streaming | `tool_name` |
 | `batch_confirm` | Batch plan generated, awaiting user confirmation (human gate) | `plan_id`, `total`, `preview`, `default_template`, `placeholder_keys` |
 | `file_confirm` | A tool is suspended awaiting confirmation of a MySpace write | confirmation context; the tool resumes in place after an out-of-band `POST /v1/chats/{chat_id}/file-confirm` |
+| `compaction_notice` | A new context-compaction checkpoint was created after the previous turn | `chat_id`, `context_compaction` (coverage boundary and replacement-summary token count) |
 | `meta` | End-of-turn metadata | `route`, `citations[]`, `sources`, `artifacts`, `workspace_files`, `ontology_governance`, `warnings`, `is_markdown`, `message_id`, `usage` |
 | `error` | Failure (mapped to a user-friendly message) | `error`, `chat_id` |
 | `heartbeat` | Heartbeat (event-level; a `: heartbeat` comment line also exists) | — |
@@ -184,6 +185,8 @@ Three complementary layers:
 | Chat title summary | `core/llm/summarizer.py::ConversationSummarizer` (`summarizer` model role, `ENABLE_SUMMARY` flag), `POST /v1/summary` | Auto-titling new chats |
 | History pre-trim + summary | `core/llm/context_manager.py::ContextWindowManager.manage_context()` trims to the model's context window; dropped messages are condensed by `core/llm/history_summarizer.py::summarize_history()` into a `<conversation_summary>` prepended to the history | Loading history that exceeds the token budget |
 | In-session compression | AgentScope 2.0 `ContextConfig` (`trigger_ratio=0.6`); the compression prompt demands a structured, resumable-ReAct-workflow summary (preserving artifact_ids, tool params, TODOs) | Context approaching the window inside the ReAct loop |
+
+Compaction checkpoints are internal `system` messages; they do not hide or delete any user-visible transcript entries. The message-list response and the next turn's `compaction_notice` both expose the latest checkpoint's coverage boundary and replacement-summary token estimate. The frontend context gauge therefore measures `replacement baseline + messages after the checkpoint` instead of continuing to accumulate the full history that the summary has replaced.
 
 ## Oversized tool-result offloading
 

--- a/document/zh-CN/modules/chat.md
+++ b/document/zh-CN/modules/chat.md
@@ -1,6 +1,6 @@
 # 对话与智能体编排
 
-> 最后更新：2026-07-20
+> 最后更新：2026-07-30
 
 对话是 HugAgentOS 的核心链路：一条用户消息经过 FastAPI 路由、运行时上下文装配、流式编排器，最终由 AgentScope 2.0 的 ReActAgent 驱动多轮「思考 → 调工具 → 观察」循环，并以 SSE 事件流实时推送到前端。本篇按真实代码走一遍端到端流程，并展开引用系统、计划模式、子智能体、会话摘要、会话分享、上下文压缩与超长结果 offload 等子能力。
 
@@ -73,6 +73,7 @@ SSE follower：chat_run_executor.follow_run_as_sse()
 | `tool_pending` | 工具已开始、参数仍在流式生成 | `tool_name` |
 | `batch_confirm` | 批量计划生成完毕，等待用户确认（人审门） | `plan_id`, `total`, `preview`, `default_template`, `placeholder_keys` |
 | `file_confirm` | 工具挂起等待用户确认「我的空间」写操作 | 确认上下文；用户带外 `POST /v1/chats/{chat_id}/file-confirm` 后工具原地续跑 |
+| `compaction_notice` | 上一轮结束后已生成新的上下文压缩检查点 | `chat_id`, `context_compaction`（覆盖边界、摘要基线 token 数） |
 | `meta` | 回合收尾元数据 | `route`, `citations[]`, `sources`, `artifacts`, `workspace_files`, `ontology_governance`, `warnings`, `is_markdown`, `message_id`, `usage` |
 | `error` | 出错（已映射为用户友好中文文案） | `error`, `chat_id` |
 | `heartbeat` | 心跳（事件级；另有 `: heartbeat` 注释行） | — |
@@ -150,6 +151,8 @@ data: [DONE]
 | 会话标题摘要 | `core/llm/summarizer.py::ConversationSummarizer`（`summarizer` 模型角色，`ENABLE_SUMMARY` 开关），`POST /v1/summary` | 新会话标题自动生成 |
 | 历史预裁剪 + 摘要 | `core/llm/context_manager.py::ContextWindowManager.manage_context()` 按模型上下文窗口裁剪；被裁掉的旧消息经 `core/llm/history_summarizer.py::summarize_history()` 压成 `<conversation_summary>` 注入队首 | 加载历史超出 token 预算时 |
 | 会话内压缩 | AgentScope 2.0 `ContextConfig`（`trigger_ratio=0.6`），压缩提示词要求产出可恢复 ReAct 工作流的结构化摘要（保留 artifact_id、工具参数、待办） | ReAct 循环内上下文逼近窗口时 |
+
+压缩检查点是内部 `system` 消息，不会从对话记录中隐藏或删除用户可见的历史消息。消息列表接口与下一轮的 `compaction_notice` 会同时返回最新检查点的覆盖边界和替代摘要 token 估算；前端上下文仪表据此按「摘要基线 + 检查点后的新消息」计算，而不是继续累计已经被摘要替换的完整旧历史。
 
 ## 超长工具结果 offload
 

--- a/src/backend/api/routes/v1/chats.py
+++ b/src/backend/api/routes/v1/chats.py
@@ -31,6 +31,7 @@ from core.infra.responses import (
 )
 from core.llm.message_compat import strip_thinking
 from core.services import ChatService, UserService
+from core.services.compaction_service import get_compaction_context_state
 from core.services.model_config import ModelConfigService
 from core.services.project_scope import project_scope_from_context
 from core.services.user_model_selection import (
@@ -415,13 +416,18 @@ async def list_messages(
 
     messages, total = chat_service.message_repo.list_by_chat(chat_id, page, page_size)
     items = [_message_to_dict(m) for m in messages]
-    return paginated_response(
+    response = paginated_response(
         items=items,
         page=page,
         page_size=page_size,
         total_items=total,
         message="Messages retrieved successfully",
     )
+    # Keep the complete transcript visible, while exposing the active
+    # checkpoint baseline separately so context-usage estimates do not keep
+    # counting messages that the model now sees only through the summary.
+    response["data"]["context_compaction"] = get_compaction_context_state(chat_service, chat_id)
+    return response
 
 
 @router.get("/{chat_id}/messages/{message_id}/followups", summary="获取追问问题")

--- a/src/backend/core/db/repository/chat.py
+++ b/src/backend/core/db/repository/chat.py
@@ -265,6 +265,24 @@ class ChatMessageRepository:
 
         return messages, total
 
+    def count_visible_before(self, chat_id: str, before: datetime) -> int:
+        """Count user-facing messages written before an internal checkpoint.
+
+        Compaction checkpoints use ``role='system'`` and are intentionally
+        excluded, matching :meth:`list_by_chat`.  The count gives clients a
+        stable boundary in the visible history without exposing the checkpoint
+        row or its replacement payload.
+        """
+        return int(
+            self.db.query(ChatMessage)
+            .filter(
+                ChatMessage.chat_id == chat_id,
+                ChatMessage.role != "system",
+                ChatMessage.created_at < before,
+            )
+            .count()
+        )
+
     def create(self, message_data: Dict[str, Any]) -> ChatMessage:
         """Create a new chat message."""
         message = ChatMessage(**message_data)

--- a/src/backend/core/services/compaction_service.py
+++ b/src/backend/core/services/compaction_service.py
@@ -483,6 +483,41 @@ def estimate_history_tokens(history: List[Dict[str, Any]]) -> int:
     )
 
 
+def get_compaction_context_state(chat_service: Any, chat_id: str) -> Optional[Dict[str, Any]]:
+    """Return the latest compacted-context baseline for user-facing estimates.
+
+    The visible message history remains complete for reading/export.  This
+    small projection tells clients which visible messages the checkpoint has
+    replaced and how many estimated tokens its replacement history occupies,
+    so a context gauge can count ``replacement + post-checkpoint tail`` instead
+    of accumulating the full pre-compaction transcript forever.
+    """
+    if not settings.compaction.enabled:
+        return None
+
+    ckpt = chat_service.get_latest_compaction_checkpoint(chat_id)
+    if ckpt is None:
+        return None
+
+    extra = getattr(ckpt, "extra_data", None) or {}
+    replacement = extra.get("replacement_history")
+    if not isinstance(replacement, list):
+        replacement = []
+    created_at = getattr(ckpt, "created_at", None)
+    if created_at is None:
+        return None
+
+    return {
+        "checkpoint_id": getattr(ckpt, "message_id", ""),
+        "checkpoint_created_at": created_at.isoformat(),
+        "covered_through_message_id": extra.get("covers_up_to_message_id"),
+        "covered_message_count": chat_service.message_repo.count_visible_before(
+            chat_id, created_at
+        ),
+        "replacement_tokens": estimate_history_tokens(replacement),
+    }
+
+
 async def maybe_run_pre_turn_compaction(
     chat_id: Optional[str],
     history: List[Dict[str, Any]],

--- a/src/backend/orchestration/chat_run_executor.py
+++ b/src/backend/orchestration/chat_run_executor.py
@@ -381,12 +381,27 @@ async def _run_workflow(
         # in the background → notify the user once in this turn's first frame.
         # Failures are silent and must never affect the main conversation.
         try:
-            from core.services.compaction_service import pop_compaction_notice
+            from core.services.compaction_service import (
+                get_compaction_context_state,
+                pop_compaction_notice,
+            )
 
             with SessionLocal() as _cn_db:
-                _notify_compaction = pop_compaction_notice(ChatService(_cn_db), chat_id)
+                _cn_service = ChatService(_cn_db)
+                _notify_compaction = pop_compaction_notice(_cn_service, chat_id)
+                _compaction_state = (
+                    get_compaction_context_state(_cn_service, chat_id)
+                    if _notify_compaction
+                    else None
+                )
             if _notify_compaction:
-                await _emit({"type": "compaction_notice", "chat_id": chat_id})
+                await _emit(
+                    {
+                        "type": "compaction_notice",
+                        "chat_id": chat_id,
+                        "context_compaction": _compaction_state,
+                    }
+                )
         except Exception as _cn_exc:  # noqa: BLE001
             logger.debug("compaction_notice_failed", chat_id=chat_id, error=str(_cn_exc))
 

--- a/src/backend/tests/llm/test_compaction_integration.py
+++ b/src/backend/tests/llm/test_compaction_integration.py
@@ -204,6 +204,34 @@ def test_compaction_notice_popped_exactly_once(db_session):
     assert S.pop_compaction_notice(svc, "chat_no_ckpt") is False
 
 
+def test_context_state_uses_compacted_baseline_and_visible_boundary(db_session):
+    """The UI receives replacement tokens plus an exact visible-message boundary."""
+    _mk_session(db_session)
+    svc = ChatService(db_session)
+    _add_user(svc, "第一轮问题")
+    covered = _add_assistant(svc, "第一轮回答")
+    replacement = [
+        {"role": "user", "content": "第一轮问题"},
+        {"role": "user", "content": C.format_summary_text("第一轮摘要")},
+    ]
+    checkpoint = svc.add_compaction_checkpoint(
+        CHAT_ID,
+        summary_text=C.format_summary_text("第一轮摘要"),
+        replacement_history=replacement,
+    )
+    _add_user(svc, "压缩后的新问题")
+
+    state = S.get_compaction_context_state(svc, CHAT_ID)
+
+    assert state == {
+        "checkpoint_id": checkpoint.message_id,
+        "checkpoint_created_at": checkpoint.created_at.isoformat(),
+        "covered_through_message_id": covered.message_id,
+        "covered_message_count": 2,
+        "replacement_tokens": S.estimate_history_tokens(replacement),
+    }
+
+
 def test_pre_turn_compaction_fast_path_no_llm(monkeypatch):
     """Zero external overhead below threshold / with no determinable threshold: never touches the DB, never calls the LLM (protects time-to-first-token)."""
     import asyncio

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -80,7 +80,7 @@ export default function App() {
   const panelTitles = pageConfig.navigation.panel_titles;
   const brandName = usePageConfig('branding.product_name', 'HugAgentOS');
   const recommendBannerText = usePageConfig('texts.recommend_banner_text', '');
-  const { authUser, authChecking, setAuthUser } = useAuthStore();
+  const { authUser, authChecking, authExpiredUrl, setAuthUser } = useAuthStore();
   const {
     searchKeyword, setSearchResults, setSearchLoading,
     openSearchModal,
@@ -159,7 +159,7 @@ export default function App() {
   const fetchCapabilities = useModelCapabilitiesStore((s) => s.fetchCapabilities);
   const authUserId = authUser?.user_id || '';
   useEffect(() => {
-    if (authChecking) return;
+    if (authChecking || !authUserId) return;
     void fetchCapabilities();
   }, [fetchCapabilities, authChecking, authUserId]);
 
@@ -552,7 +552,9 @@ export default function App() {
     return showAuthSkeleton ? <AppLoadingSkeleton /> : null;
   }
 
-  if (!authUser || window.location.pathname.startsWith('/mock-sso/login')) return null;
+  if (!authUser || window.location.pathname.startsWith('/mock-sso/login')) {
+    return authExpiredUrl ? <AuthExpiredModal /> : null;
+  }
 
   if (authUser.must_change_password) {
     return (

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -538,6 +538,7 @@ export async function getChatMessages(chatId: string): Promise<ChatMessage[]> {
     content: String(item.content ?? ''),
     isMarkdown: Boolean((item.metadata as JsonObject | undefined)?.is_markdown),
     ts: toTimestamp(item.created_at),
+    messageId: typeof item.message_id === 'string' ? item.message_id : undefined,
     citations: Array.isArray((item.metadata as JsonObject | undefined)?.citations)
       ? ((item.metadata as JsonObject).citations as ChatMessage['citations'])
       : undefined,

--- a/src/frontend/src/components/chat/ChatArea.tsx
+++ b/src/frontend/src/components/chat/ChatArea.tsx
@@ -92,7 +92,7 @@ export function ChatArea({
     { value: 'permanent', label: t('长期') },
   ] as const;
   const {
-    store, currentChatId, setInput,
+    store, currentChatId, setInput, planMode,
     shareSelectionMode, selectedShareMessageTs,
     pendingScrollMessageTs, setPendingScrollMessageTs,
     setQuotedFollowUp,
@@ -526,7 +526,7 @@ export function ChatArea({
         )}
       </AnimatePresence>
       <div className="jx-chatFooter">
-        <PlanProgressStrip chatId={currentChatId} />
+        {!planMode && <PlanProgressStrip chatId={currentChatId} />}
         <FileConfirmBar />
         <DesignPickerCard />
         {shareAccessLevel === 'read' ? (

--- a/src/frontend/src/components/chat/ContextGauge.tsx
+++ b/src/frontend/src/components/chat/ContextGauge.tsx
@@ -98,6 +98,9 @@ function GaugeContent({ breakdown, window, ratio, modelName }: GaugeContentProps
 export function ContextGauge() {
   const currentChatId = useChatStore((s) => s.currentChatId);
   const messages = useChatStore((s) => (s.currentChatId ? s.store.chats[s.currentChatId]?.messages : undefined));
+  const compaction = useChatStore((s) => (
+    s.currentChatId ? s.contextCompactions[s.currentChatId] : undefined
+  ));
   const draft = useChatStore((s) => s.input);
   const uploadedFiles = useFileStore((s) => s.uploadedFiles);
   const importedSpaceFiles = useFileStore((s) => s.importedSpaceFiles);
@@ -138,8 +141,9 @@ export function ContextGauge() {
       stagedFiles,
       attachmentPreviewChars,
       systemTokens: systemPromptTokens,
+      compaction,
     }),
-    [messages, draft, stagedFiles, attachmentPreviewChars, systemPromptTokens],
+    [messages, draft, stagedFiles, attachmentPreviewChars, systemPromptTokens, compaction],
   );
 
   const hasContent = (messages?.length || 0) > 0 || !!draft.trim() || uploadedFiles.length > 0 || importedSpaceFiles.length > 0;

--- a/src/frontend/src/hooks/chatStream.ts
+++ b/src/frontend/src/hooks/chatStream.ts
@@ -3,6 +3,7 @@ import { t } from '../i18n';
 import { toFileConfirmInfo, toDesignPickInfo } from '../api';
 import { normalizeArtifactOutput } from '../utils/fileParser';
 import { stripMcpToolPrefix } from '../utils/constants';
+import { parseContextCompactionState } from '../utils/contextUsage';
 import { useChatStore, useCatalogStore, useUIStore, useBatchStore, useCanvasStore } from '../stores';
 import type { ChatItem, ChatMessage, CitationItem, MessageSegment, OntologyGovernanceSummary, SubagentStep, ToolCall } from '../types';
 
@@ -551,7 +552,10 @@ export async function processChatStream(resp: Response, opts: ChatStreamOptions)
           // Earlier context was compacted in the background after the previous turn ended;
           // the backend notifies once in this turn's first frame
           // → ChatArea shows a dismissible notice bar
-          useChatStore.getState().setCompactionNotice(chatId);
+          const chatStore = useChatStore.getState();
+          chatStore.setCompactionNotice(chatId);
+          const contextCompaction = parseContextCompactionState(eventObj.context_compaction);
+          if (contextCompaction) chatStore.setContextCompaction(chatId, contextCompaction);
           return;
         }
         if (eventType === 'end') {

--- a/src/frontend/src/hooks/useChatInit.ts
+++ b/src/frontend/src/hooks/useChatInit.ts
@@ -6,8 +6,9 @@ import { buildHistorySegments } from '../utils/segments';
 import { attachArtifactsToToolCalls } from '../utils/fileParser';
 import { isAutomationHistoryChat } from '../utils/history';
 import { stripMcpToolPrefix } from '../utils/constants';
+import { parseContextCompactionState } from '../utils/contextUsage';
 import { LOGIN_LANDING_KEY, useAuthStore, useSettingsStore, useUIStore, useChatStore, useCatalogStore, useAutomationChatStore, useBatchStore } from '../stores';
-import type { Catalog, ChatItem, ChatMessage, CitationItem, OntologyGovernanceSummary, ToolCall, UpdateEntry, CapItem, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
+import type { Catalog, ChatItem, ChatMessage, CitationItem, ContextCompactionState, OntologyGovernanceSummary, ToolCall, UpdateEntry, CapItem, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
 
 const effectiveApiUrl = (import.meta.env.VITE_API_BASE_URL as string || '').trim() || '/api';
 
@@ -202,6 +203,7 @@ function parseHistoryMessage(m: any): ChatMessage {
     ...(histSkillName && { skillName: histSkillName }),
     ...(histPluginName && { pluginName: histPluginName }),
     ...(histMentionName && { mentionName: histMentionName }),
+    ...(typeof m.message_id === 'string' && m.message_id && { messageId: m.message_id }),
   } as ChatMessage;
 }
 
@@ -456,6 +458,12 @@ export function useChatInit() {
                 const mp = await mr.json();
                 const msgItems: any[] = mp?.data?.items || [];
                 const quickMsgs: ChatMessage[] = msgItems.map(parseHistoryMessage);
+                if (Object.prototype.hasOwnProperty.call(mp?.data || {}, 'context_compaction')) {
+                  useChatStore.getState().setContextCompaction(
+                    targetChatId,
+                    parseContextCompactionState(mp.data.context_compaction),
+                  );
+                }
                 preloadComplete = !mp?.data?.pagination?.has_next;
                 if (!cancelled && quickMsgs.length > 0) {
                   // Detect plan mode from message content (fallback for sessions
@@ -622,6 +630,8 @@ export function useChatInit() {
         // 'preview' by the end, restore currentPlanId so "确认执行" after
         // refresh executes the existing plan instead of generating a new one.
         let pendingPlanId: string | null = null;
+        let contextCompactionSeen = false;
+        let contextCompaction: ContextCompactionState | null = null;
 
         while (true) {
           const r = await authFetch(`${effectiveApiUrl}/v1/chats/${chatId}/messages?page=${page}&page_size=100`, { headers: { ...chatTargetHeaders(chatId) } });
@@ -633,6 +643,10 @@ export function useChatInit() {
           if (!r.ok) throw new Error(`messages page ${page}: HTTP ${r.status}`);
           const payload = await r.json();
           const items: any[] = payload?.data?.items || [];
+          if (!contextCompactionSeen && Object.prototype.hasOwnProperty.call(payload?.data || {}, 'context_compaction')) {
+            contextCompactionSeen = true;
+            contextCompaction = parseContextCompactionState(payload.data.context_compaction);
+          }
 
           for (const m of items) {
             const planSnapshot = m?.metadata?.plan_snapshot;
@@ -651,6 +665,9 @@ export function useChatInit() {
         }
 
         if (!cancelled) {
+          if (contextCompactionSeen) {
+            useChatStore.getState().setContextCompaction(chatId, contextCompaction);
+          }
           loaded = true;
           addLoadedMsgId(chatId);
           updateStore(prev => {

--- a/src/frontend/src/hooks/usePlanMode.ts
+++ b/src/frontend/src/hooks/usePlanMode.ts
@@ -4,7 +4,7 @@ import { generatePlanStream, updatePlanApi, executePlanStream, getPlanApi } from
 import { stripMcpToolPrefix } from '../utils/constants';
 import { useChatStore, useCatalogStore, useFileStore, useModelCapabilitiesStore } from '../stores';
 import { useProjectStore } from '../stores/projectStore';
-import type { ChatItem, ChatMessage, MessageSegment, PlanProgressState, ToolCall } from '../types';
+import type { ChatItem, ChatMessage, MessageSegment, ToolCall } from '../types';
 
 /** Mark the approval decision on the newest preview plan segment carrying planId
  *  (hides the confirm/discard buttons on the card afterwards). */
@@ -45,6 +45,11 @@ export async function processPlanExecuteStream(
     onAfterComplete?: (chatId: string) => void;
   } = {},
 ): Promise<void> {
+  // Manual plan mode renders the complete execution state in its message card.
+  // Clear any compact-strip state left by an older frontend bundle or a
+  // recovered stream so the same plan is never duplicated above the composer.
+  useChatStore.getState().setPlanProgress(chatId, null);
+
   const decoder = new TextDecoder();
   const execReader = response.body?.getReader();
   if (!execReader) return;
@@ -102,21 +107,6 @@ export async function processPlanExecuteStream(
     const content = resultText || '';
     if (resultText) segments.push({ type: 'text', content });
     appendAssistant(content, streaming, [...toolCalls], [...segments]);
-    // Mirror execution progress into the plan bar above the input
-    const barSteps: PlanProgressState['steps'] = (planData?.steps || []).map(s => ({
-      title: s.title,
-      status: s.status === 'running' ? 'in_progress'
-        : s.status === 'success' ? 'completed'
-        : s.status === 'failed' ? 'failed'
-        : 'pending',
-    }));
-    useChatStore.getState().setPlanProgress(chatId, {
-      source: 'plan_mode',
-      title: planTitle || '',
-      steps: barSteps,
-      done: mode === 'complete',
-      updatedAt: Date.now(),
-    });
   };
 
   updatePlanCard(true);

--- a/src/frontend/src/stores/authStore.ts
+++ b/src/frontend/src/stores/authStore.ts
@@ -49,6 +49,12 @@ function isMockLoginUrl(url?: string | null): boolean {
   return !value || value.includes('/mock-sso/login');
 }
 
+function fallbackLoginUrl(): string {
+  if (SSO_LOGIN_URL && !isMockLoginUrl(SSO_LOGIN_URL)) return SSO_LOGIN_URL;
+  const origin = window.location.origin;
+  return `${origin}/mock-sso/login?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+}
+
 /** Resolve the redirect-to-login URL.
  * Priority: 1) non-mock URL from 401 body  2) cached `/v1/auth/sso/authorize-url`
  * 3) `SSO_LOGIN_URL` env / mock-SSO landing.
@@ -65,9 +71,7 @@ async function resolveLoginUrl(serverUrl?: string | null): Promise<string> {
   // call can retry instead of being stuck with the cached failure.
   authorizeUrlPromise = null;
 
-  if (SSO_LOGIN_URL && !isMockLoginUrl(SSO_LOGIN_URL)) return SSO_LOGIN_URL;
-  const origin = window.location.origin;
-  return `${origin}/mock-sso/login?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+  return fallbackLoginUrl();
 }
 
 /** Whether we are in the desktop login bridging flow (system-browser side). */
@@ -236,7 +240,30 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   setAuthExpiredUrl: (url) => set({ authExpiredUrl: url }),
 
   triggerExpired: (loginUrl?: string) => {
-    const wasAuthed = get().wasAuthed;
+    const state = get();
+    const wasAuthed = state.wasAuthed;
+
+    // A protected request may be retried by several mounted effects at once.
+    // On the first 401, synchronously drop the in-memory user so every
+    // authUser-gated timer/effect is cleaned up before resolving the final SSO
+    // URL. Keeping authUser alive until this async lookup completed allowed an
+    // expired client to keep polling the current chat indefinitely.
+    if (wasAuthed) {
+      if (state.authExpiredUrl) {
+        if (state.authUser || state.authChecking) {
+          set({ authUser: null, authChecking: false });
+        }
+        return;
+      }
+      set({
+        authUser: null,
+        authChecking: false,
+        authExpiredUrl: loginUrl && !isMockLoginUrl(loginUrl)
+          ? loginUrl
+          : fallbackLoginUrl(),
+      });
+    }
+
     void resolveLoginUrl(loginUrl).then((url) => {
       if (wasAuthed) {
         set({ authExpiredUrl: url });

--- a/src/frontend/src/stores/chatStore.ts
+++ b/src/frontend/src/stores/chatStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { ChatItem, ChatMessage, ChatStore as ChatStoreData, PlanProgressState } from '../types';
+import type { ChatItem, ChatMessage, ChatStore as ChatStoreData, ContextCompactionState, PlanProgressState } from '../types';
 import { loadChatStore, saveChatStoreDebounced, flushChatStore, nowId, userScopedKey, purgeLegacyUnscopedKeys } from '../storage';
 import { usePageConfigStore } from './pageConfigStore';
 import { usePluginStore } from './pluginStore';
@@ -151,6 +151,8 @@ interface ChatState {
    *  backend compacted earlier context; it notifies once on this turn's first frame. The UI shows
    *  a dismissible banner (not persisted). */
   compactionNotices: Record<string, boolean>;
+  /** chatId → latest server checkpoint baseline used by ContextGauge. */
+  contextCompactions: Record<string, ContextCompactionState>;
   /** chatId → live plan/progress shown by the plan bar above the input (transient, not persisted).
    *  Fed by the agent's update_plan tool (plan_update SSE) and by manual plan-mode execution. */
   planProgress: Record<string, PlanProgressState | null>;
@@ -234,6 +236,8 @@ interface ChatState {
   setCompactionNotice: (chatId: string) => void;
   /** User dismissed the compaction banner */
   dismissCompactionNotice: (chatId: string) => void;
+  /** Replace or clear the active compacted-context baseline for a chat. */
+  setContextCompaction: (chatId: string, state: ContextCompactionState | null) => void;
 
   /** Bind a chat to a project (Claude-style workspace). Creates the chat entry on demand if it
    *  doesn't exist, making chat.projectId the single source of truth — the next message is sent
@@ -299,6 +303,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sessionLoadEpoch: 0,
   activeRuns: {},
   compactionNotices: {},
+  contextCompactions: {},
   planProgress: {},
 
   setStore: (store) => {
@@ -460,6 +465,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const next = { ...s.compactionNotices };
     delete next[chatId];
     return { compactionNotices: next };
+  }),
+  setContextCompaction: (chatId, state) => set((s) => {
+    const next = { ...s.contextCompactions };
+    if (state) next[chatId] = state;
+    else delete next[chatId];
+    return { contextCompactions: next };
   }),
 
   truncateMessagesFrom: (chatId, ts) => {
@@ -679,12 +690,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   deleteChat: (id) => {
     const { store, currentChatId, currentUserId } = get();
-    const { [id]: _, ...rest } = store.chats;
+    const rest = { ...store.chats };
+    delete rest[id];
+    const nextCompactions = { ...get().contextCompactions };
+    const nextNotices = { ...get().compactionNotices };
+    delete nextCompactions[id];
+    delete nextNotices[id];
     const next: ChatStoreData = {
       chats: rest,
       order: store.order.filter((oid) => oid !== id),
     };
-    set({ store: next, storeRef: next });
+    set({
+      store: next,
+      storeRef: next,
+      contextCompactions: nextCompactions,
+      compactionNotices: nextNotices,
+    });
     saveChatStoreDebounced(currentUserId, next);
     if (currentChatId === id) {
       const newId = next.order[0] || nowId('chat');
@@ -741,6 +762,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       currentPlanId: null,
       editingMessageTs: null,
       activeRuns: {},
+      compactionNotices: {},
+      contextCompactions: {},
       chatMode: adminDefaultChatMode(),
     });
   },
@@ -772,6 +795,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       currentPlanId: null,
       editingMessageTs: null,
       activeRuns: {},
+      compactionNotices: {},
+      contextCompactions: {},
     });
   },
 }));

--- a/src/frontend/src/types.ts
+++ b/src/frontend/src/types.ts
@@ -385,6 +385,17 @@ export interface ChatMessage {
   workspaceFiles?: string[] | null;
 }
 
+/** Latest backend context-compaction checkpoint used by the context gauge.
+ * The full transcript stays visible; messages covered by this boundary have
+ * been replaced in the model context by a compacted baseline. */
+export interface ContextCompactionState {
+  checkpointId: string;
+  checkpointTs: number;
+  coveredThroughMessageId?: string;
+  coveredMessageCount: number;
+  replacementTokens: number;
+}
+
 export interface ChatItem {
   id: string;
   title: string;

--- a/src/frontend/src/utils/contextUsage.ts
+++ b/src/frontend/src/utils/contextUsage.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ToolCall } from '../types';
+import type { ChatMessage, ContextCompactionState, ToolCall } from '../types';
 
 /**
  * Client-side context-usage estimation.
@@ -202,6 +202,61 @@ export interface BreakdownOptions {
    * SYSTEM_BASE_TOKENS when not provided.
    */
   systemTokens?: number;
+  /** Latest server-side compaction checkpoint, when this chat was compacted. */
+  compaction?: ContextCompactionState | null;
+}
+
+/** Parse the snake_case checkpoint projection returned by the API/SSE. */
+export function parseContextCompactionState(value: unknown): ContextCompactionState | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const checkpointId = typeof raw.checkpoint_id === 'string' ? raw.checkpoint_id : '';
+  const checkpointCreatedAt = typeof raw.checkpoint_created_at === 'string'
+    ? Date.parse(raw.checkpoint_created_at)
+    : Number.NaN;
+  const coveredMessageCount = Number(raw.covered_message_count);
+  const replacementTokens = Number(raw.replacement_tokens);
+  if (
+    !checkpointId
+    || !Number.isFinite(coveredMessageCount)
+    || coveredMessageCount < 0
+    || !Number.isFinite(replacementTokens)
+    || replacementTokens < 0
+  ) {
+    return null;
+  }
+  return {
+    checkpointId,
+    checkpointTs: Number.isNaN(checkpointCreatedAt) ? 0 : checkpointCreatedAt,
+    coveredThroughMessageId: typeof raw.covered_through_message_id === 'string'
+      ? raw.covered_through_message_id
+      : undefined,
+    coveredMessageCount: Math.floor(coveredMessageCount),
+    replacementTokens: Math.floor(replacementTokens),
+  };
+}
+
+function messagesAfterCompaction(
+  messages: ChatMessage[],
+  compaction: ContextCompactionState,
+): ChatMessage[] {
+  // The persisted boundary ID is the strongest signal and also works when
+  // client/server clocks or timezone serialization differ.
+  if (compaction.coveredThroughMessageId) {
+    const boundary = messages.findIndex(
+      (m) => m.messageId === compaction.coveredThroughMessageId,
+    );
+    if (boundary >= 0) return messages.slice(boundary + 1);
+  }
+  // The API supplies the count in the same visible ordering as /messages.
+  if (messages.length >= compaction.coveredMessageCount) {
+    return messages.slice(compaction.coveredMessageCount);
+  }
+  // Partial-history fallback while a multi-page load is still in progress.
+  if (compaction.checkpointTs > 0) {
+    return messages.filter((m) => m.ts > compaction.checkpointTs);
+  }
+  return [];
 }
 
 /** Compute the estimated context breakdown for a conversation. */
@@ -209,12 +264,16 @@ export function computeContextBreakdown(
   messages: ChatMessage[] | undefined | null,
   opts: BreakdownOptions = {},
 ): ContextBreakdown {
-  let messagesTok = 0;
+  let messagesTok = opts.compaction?.replacementTokens || 0;
   let toolsTok = 0;
   let thinkingTok = 0;
   let filesTok = 0;
 
-  for (const m of messages || []) {
+  const visibleMessages = messages || [];
+  const activeMessages = opts.compaction
+    ? messagesAfterCompaction(visibleMessages, opts.compaction)
+    : visibleMessages;
+  for (const m of activeMessages) {
     const t = tokensForMessage(m);
     messagesTok += t.messages;
     toolsTok += t.tools;


### PR DESCRIPTION
## What changed

- Expose the latest context-compaction checkpoint boundary and replacement token baseline through message-list responses and `compaction_notice` events.
- Make the context gauge count the compacted baseline plus only post-checkpoint messages.
- Stop protected polling immediately on session expiry and keep the re-login modal visible.
- Remove the duplicate compact Plan Mode strip while preserving model-driven `update_plan` progress.
- Document compaction state behavior in Chinese and English.

## Why

After server-side compaction, the visible transcript remains complete, so the client continued counting history that the model had already replaced with a summary. Expired sessions could also keep mounted polling effects alive while the login URL resolved. Manual Plan Mode still mirrored its full in-message card above the composer.

## Impact

Context usage now reflects the model's effective history, expired sessions settle promptly into re-authentication, and manual Plan Mode has one progress surface. Regular `update_plan` progress remains unchanged.

## Checks

- 13 compaction integration tests
- CE brand, required/forbidden-file, import/OpenAPI/ORM, and release regression gates
- Public frontend i18n, TypeScript, and Vite build under Node 20
- Private and derived CE frontend builds under Node 20
- `git diff --check`
