### PR TITLE
fix(ce): register MCP marketplace routes

### DIFF
--- a/src/backend/api/routes/v1/__init__.py
+++ b/src/backend/api/routes/v1/__init__.py
@@ -37,6 +37,7 @@ CE_ROUTERS: tuple[tuple[str, str], ...] = (
     ("api_keys", "router"),
     ("me_capabilities", "router"),
     ("marketplace", "router"),
+    ("mcp_marketplace", "router"),
     ("agent_marketplace", "router"),
     ("plugins", "router"),
     ("integrations", "router"),

--- a/src/backend/tests/ce_release/test_ce_release_regressions.py
+++ b/src/backend/tests/ce_release/test_ce_release_regressions.py
@@ -94,6 +94,26 @@ def test_ce_api_key_crud_is_reachable_from_personal_settings(initialized_ce_data
         assert revoked.status_code == 200, revoked.text
 
 
+def test_ce_mcp_marketplace_is_registered_and_returns_items(initialized_ce_database):
+    from api.app import app
+
+    with TestClient(app) as client:
+        login = client.post(
+            "/login",
+            data={"username": "admin", "password": "admin", "redirect": "/"},
+            follow_redirects=False,
+        )
+        assert login.status_code == 303, login.text
+        ticket = parse_qs(urlparse(login.headers["location"]).query)["ticket"][0]
+        exchange = client.post("/v1/auth/ticket/exchange", json={"code": ticket})
+        assert exchange.status_code == 200, exchange.text
+
+        response = client.get("/v1/mcp-market/items")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["data"]
+
+
 def test_ce_registers_all_local_auth_routes():
     from api.app import app
 


### PR DESCRIPTION
## Summary / 概述

- Register the existing `mcp_marketplace` router in the generated CE route registry so `/v1/mcp-market/*` no longer returns `404 Not Found`.
- Add a CE release regression that authenticates through the local session flow, requests `/v1/mcp-market/items`, and verifies that the marketplace returns items.
- Root cause: the MCP marketplace implementation shipped in #48, but the CE overlay route registry omitted its router entry. The source files were present while FastAPI never mounted their endpoints.

## Related issue / 关联 Issue

Follow-up fix for #48.

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): maintainer sync from the upstream FULL source of truth into the generated CE mirror.

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。（维护者上游回流修复，不适用）
- [x] Links and code snippets were verified. 链接与代码片段已验证。（未新增外部链接或文档代码片段）
- [x] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。（未改文档，不适用）
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。

## Validation / 验证

- `PYTHONPATH=src/backend ... pytest -q src/backend/tests/ce_release` — 7 passed.
- Upstream `python scripts/build_ce.py --import-check --pytest-check --allow-placeholder-license` — CE derivation, brand gate, Import/OpenAPI/ORM contract, and release regressions passed.
- Upstream `PYTHONPATH=src/backend pytest -q src/backend/tests/test_mcp_marketplace.py` — 35 passed.
- The generic `npm run preflight` command is unavailable because this generated mirror has no root `package.json` or `preflight` script; no frontend files are changed.
