### PR TITLE
fix(evolution): only offer approvals that can actually be carried out

### DIFF
--- a/src/backend/api/routes/v1/evolution.py
+++ b/src/backend/api/routes/v1/evolution.py
@@ -47,11 +47,11 @@ class ContributionSettingRequest(BaseModel):
 
 @router.get("/settings", summary="获取本账号的进化参与设置")
 async def get_evolution_settings(user: UserContext = Depends(get_current_user)):
-    """The user's contribution choice.
+    """Legacy view of the single evolution switch.
 
-    Deliberately *not* named "evolution on/off": one user cannot stop the system
-    distilling a skill from everyone else's traces. What they control is whether
-    their own conversations are part of the evidence.
+    The separate contribution toggle is gone from the product; participation now
+    simply follows ``evolution_prefs.enabled``. This endpoint stays because
+    already-shipped desktop bundles still read it.
     """
     from core.evolution.user_settings import resolve_for_user
 
@@ -63,6 +63,7 @@ async def update_evolution_settings(
     body: ContributionSettingRequest,
     user: UserContext = Depends(get_current_user),
 ):
+    """Legacy alias: writes the same switch as PATCH /evolution/prefs."""
     from core.evolution.user_settings import update_for_user
 
     try:

--- a/src/backend/core/evolution/memory_apply.py
+++ b/src/backend/core/evolution/memory_apply.py
@@ -220,3 +220,65 @@ def demote_promoted_memories(
     )
 
 
+
+
+def apply_memory_candidate(
+    candidate_id: str,
+    *,
+    approver: str,
+    require_user_id: str = "",
+) -> Dict[str, Any]:
+    """Apply an approved memory reorganisation candidate.
+
+    Lives here rather than in the admin route because **both** control planes
+    need it: the enterprise console approves on behalf of a tenant, and a user
+    approves their own memories from the settings panel — which is a Community
+    Edition surface. While this was route-local, the user path fell through to
+    the skill materialiser and every memory candidate answered
+    "暂不支持物化 memory 候选", i.e. every row in that queue was a button that
+    could only fail.
+
+    ``require_user_id`` guards the personal path: a user may only apply
+    operations against their own memories.
+    """
+    from core.db.engine import SessionLocal
+    from core.db.models.evolution import EvolutionCandidate
+    from core.evolution.activation import ActivationError
+
+    with SessionLocal() as db:
+        candidate = db.get(EvolutionCandidate, candidate_id)
+        if candidate is None:
+            raise ActivationError("candidate_not_found", f"候选不存在: {candidate_id}")
+        if approver == (candidate.proposer or ""):
+            raise ActivationError("self_approval_forbidden", "生成者不能批准自己提出的候选")
+
+        change = ((candidate.ir or {}).get("changes") or [{}])[0]
+        user_id = str(change.get("user_id") or "") or require_user_id
+        raw_ops = change.get("operations") or []
+        if not user_id or not raw_ops:
+            raise ActivationError("no_memory_payload", "候选未携带可执行的记忆操作")
+        if require_user_id and user_id != require_user_id:
+            raise ActivationError(
+                "not_your_memory", "该候选操作的是他人的记忆，不能由你批准"
+            )
+
+        candidate.approved_by = approver
+        candidate.approved_at = datetime.now(timezone.utc)
+        candidate.status = "active"
+        db.commit()
+
+    ops = [
+        MemoryOp(
+            operation=str(op.get("operation") or ""),
+            memory_ref=str(op.get("memory_ref") or ""),
+            scope=str(op.get("scope") or "user"),
+            reason=str(op.get("reason") or ""),
+            before=op.get("before"),
+            after=op.get("after"),
+        )
+        for op in raw_ops
+    ]
+    outcome = apply_memory_ops(
+        ops, candidate_id=candidate_id, user_id=user_id, approver=approver
+    )
+    return {"candidate_id": candidate_id, "user_id": user_id, **outcome}

--- a/src/backend/core/evolution/user_settings.py
+++ b/src/backend/core/evolution/user_settings.py
@@ -1,20 +1,18 @@
-"""Per-user evolution participation (GCE ticket 27 extension).
+"""Per-user evolution participation, derived from the single evolution switch.
 
-A switch literally labelled "evolve or not" would misrepresent what a single
-user can control.  Memory evolution genuinely is per-user — it is their own
-memory.  But skill and workflow candidates come from patterns aggregated across
-*many* users' episodes, and ontology is organisation-wide; one person switching
-off cannot stop the system distilling a skill from everyone else's traces.
+There used to be two user-facing switches: "start evolution" (does the loop
+distil for me) and "contribute to evolution" (do my conversations feed
+cross-user learning).  The distinction was real but nobody could tell the two
+apart in the settings panel, so the product now has exactly one switch —
+``evolution_prefs.enabled`` — and contribution follows it: evolution on means
+the loop may distil for this user *and* their conversations may serve as
+evidence within the tenant; off means neither.
 
-What a user can honestly control, and what the code can actually enforce, is
-whether **their own conversations contribute evidence** to the loop.  So that is
-what this setting is, and what the label says.
-
-Enforcement lives at one point rather than being scattered: the Episode's
-``privacy_class``.  Opting out marks episodes ``private``, and pattern mining
-filters those out — so the user still gets their own in-chat card and their own
-memory, while nothing of theirs feeds cross-user learning. Anything weaker would
-make the promise unverifiable.
+Enforcement still lives at one point rather than being scattered: the
+Episode's ``privacy_class``.  With the switch off, episodes are marked
+``private`` and pattern mining filters those out — so the user still gets
+their own in-chat card and their own history, while nothing of theirs feeds
+cross-user learning. Anything weaker would make the promise unverifiable.
 """
 
 from __future__ import annotations
@@ -26,6 +24,8 @@ from core.db.engine import SessionLocal
 
 logger = logging.getLogger(__name__)
 
+# Response-field name kept from the era of a separate contribution switch, so
+# older bundled frontends that read /evolution/settings keep working.
 SETTING_KEY = "evolution_contribution_enabled"
 
 # Episodes from an opted-out user. Recorded for that user's own benefit (their
@@ -37,13 +37,18 @@ PRIVACY_TENANT = "tenant"
 def is_contribution_enabled(metadata: Optional[Dict[str, Any]]) -> bool:
     """Whether this user's episodes may feed the evolution loop.
 
-    Defaults to on, matching the existing memory switches — but note that
-    "on" here only ever means *within the tenant*: cross-tenant sharing is a
-    separate, independently-gated decision (see ``federation``).
+    Reads the single evolution switch (``evolution_prefs.enabled``), so one
+    stored value governs both distilling *for* the user and learning *from*
+    them. Off by default: consent is collected by the first-run wizard, and a
+    user who never enabled evolution contributes nothing. "On" only ever means
+    *within the tenant*: cross-tenant sharing is a separate, independently-
+    gated decision (see ``federation``).
     """
+    from core.evolution.prefs import PREFS_KEY, normalise
+
     if not metadata:
-        return True
-    return bool(metadata.get(SETTING_KEY, True))
+        return False
+    return bool(normalise(metadata.get(PREFS_KEY)).get("enabled", False))
 
 
 def privacy_class_for(metadata: Optional[Dict[str, Any]]) -> str:
@@ -54,7 +59,7 @@ def privacy_class_for(metadata: Optional[Dict[str, Any]]) -> str:
 def resolve_for_user(user_id: str) -> Dict[str, Any]:
     """Read the setting for one user. Degrades to the default, never raises."""
     if not user_id:
-        return {SETTING_KEY: True, "privacy_class": PRIVACY_TENANT}
+        return {SETTING_KEY: False, "privacy_class": PRIVACY_PRIVATE}
     try:
         from core.db.models import UserShadow
 
@@ -70,27 +75,24 @@ def resolve_for_user(user_id: str) -> Dict[str, Any]:
 
 
 def update_for_user(user_id: str, enabled: bool) -> Dict[str, Any]:
-    """Persist the setting.
+    """Persist the setting by writing the single evolution switch.
+
+    Kept as an alias so older bundled frontends PATCHing /evolution/settings
+    still work; it writes the same ``evolution_prefs.enabled`` the preferences
+    panel writes, never a separate value that could drift from it.
 
     Turning it off does **not** retroactively delete already-contributed
     evidence — that would silently rewrite history other candidates were derived
     from. It stops future episodes from contributing; withdrawing past evidence
     is a separate, explicit action so its consequences stay visible.
     """
-    from core.db.models import UserShadow
+    from core.evolution.prefs import update_prefs
 
-    with SessionLocal() as db:
-        row = db.query(UserShadow).filter(UserShadow.user_id == user_id).first()
-        if row is None:
-            raise ValueError(f"user not found: {user_id}")
-        metadata = dict(getattr(row, "extra_data", None) or {})
-        metadata[SETTING_KEY] = bool(enabled)
-        row.extra_data = metadata
-        db.commit()
-
+    merged = update_prefs(user_id, {"enabled": bool(enabled)})
+    on = bool(merged.get("enabled", False))
     return {
-        SETTING_KEY: bool(enabled),
-        "privacy_class": PRIVACY_TENANT if enabled else PRIVACY_PRIVATE,
+        SETTING_KEY: on,
+        "privacy_class": PRIVACY_TENANT if on else PRIVACY_PRIVATE,
         "note": "仅影响此后新产生的证据；已贡献的证据需单独撤回",
     }
 
@@ -100,6 +102,69 @@ def update_for_user(user_id: str, enabled: bool) -> Dict[str, Any]:
 # from other people's work, and one person approving it for everyone is a
 # different decision that belongs with an administrator.
 OWN_EVIDENCE_THRESHOLD = 0.6
+
+
+def personal_action(candidate) -> Optional[Dict[str, str]]:
+    """What this user can actually do with a candidate, or ``None``.
+
+    The queue used to list everything whose evidence was mostly the user's, and
+    label every row 「为我启用」. Most of those rows could not be actioned at all:
+    a memory candidate fell through to the skill materialiser and answered
+    "暂不支持物化 memory 候选"; a medium/high-risk skill has to ramp through
+    replay → shadow → canary and cannot be force-activated by one person; an
+    orchestration profile changes a whole task type for everyone, so there is no
+    personal version of it; and a *retirement* proposal offered a button to
+    "enable" the thing it was arguing should be removed.
+
+    Every one of those was a button whose only outcome was an error toast. A
+    queue is a list of decisions the reader can make — so a candidate that
+    cannot be actioned here does not belong here, and the ones that remain say
+    what the button will do rather than all claiming to "enable".
+    """
+    kind = str(candidate.target_kind or "")
+    operation = str(candidate.operation or "")
+    risk = str(candidate.risk_tier or "medium")
+
+    if kind == "memory":
+        # The user's own memories: adjusting how they are retrieved is theirs to
+        # decide, nothing is deleted, and every op records its undo.
+        #
+        # Only operations that have an executor are offered. The IR permits more
+        # than `apply_memory_ops` can carry out — `deprecate` in particular is
+        # proposable but refused at execution with `no_executor_for_operation` —
+        # and offering one of those is the same defect as before: a button whose
+        # only possible outcome is a refusal.
+        labels = {
+            "reweight": "调整这条记忆的权重",
+            "merge": "合并这几条重复记忆",
+        }
+        if operation not in labels:
+            return None
+        return {
+            "action": "apply_memory",
+            "label": labels[operation],
+            "effect": "只改变检索权重，不会删除记忆，可随时撤销",
+        }
+
+    if kind == "skill" and operation in ("new", "patch", "merge"):
+        # Mirrors what `activation._entry_stage` will actually permit. A personal
+        # activation skips the ramp because its blast radius is one consenting
+        # user — but only where the candidate has already passed replay, or its
+        # tier owes nothing beyond replay. Listing a medium-risk draft here put
+        # a button on screen that answered "force 只允许用于 low 风险候选".
+        from core.evolution.release import ACTIVE, REPLAY_PASSED
+
+        replayed = str(candidate.status or "") in (REPLAY_PASSED, ACTIVE)
+        if not replayed and risk != "low":
+            return None
+        return {
+            "action": "install_skill",
+            "label": "为我启用",
+            "effect": "作为你的私有技能安装，只对你生效",
+        }
+
+    # skill/deprecate, agent_profile, prompt, subagent: fleet-wide decisions.
+    return None
 
 
 def pending_for_user(user_id: str, *, limit: int = 20) -> List[Dict[str, Any]]:
@@ -142,10 +207,14 @@ def pending_for_user(user_id: str, *, limit: int = 20) -> List[Dict[str, Any]]:
                 share = len(mine) / len(refs)
                 if share < OWN_EVIDENCE_THRESHOLD:
                     continue
+                action = personal_action(candidate)
+                if action is None:
+                    continue
                 out.append(
                     {
                         "candidate_id": candidate.candidate_id,
                         "target_kind": candidate.target_kind,
+                        "operation": candidate.operation,
                         "summary": (candidate.hypothesis or "")[:140],
                         "status": candidate.status,
                         "risk_tier": candidate.risk_tier,
@@ -153,6 +222,13 @@ def pending_for_user(user_id: str, *, limit: int = 20) -> List[Dict[str, Any]]:
                         "total_evidence": len(refs),
                         "own_share": round(share, 3),
                         "tool_sequence": _tool_sequence_of_ir(candidate.ir),
+                        # What the button does, and what it will change. Without
+                        # these the row states a diagnosis and offers a verb that
+                        # does not follow from it.
+                        "action": action["action"],
+                        "action_label": action["label"],
+                        "action_effect": action["effect"],
+                        "change": _change_preview(candidate),
                         "created_at": candidate.created_at.isoformat()
                         if candidate.created_at
                         else None,
@@ -164,6 +240,46 @@ def pending_for_user(user_id: str, *, limit: int = 20) -> List[Dict[str, Any]]:
     except Exception as exc:
         logger.warning("[evo-settings] pending candidates failed: %s", exc)
         return []
+
+
+def _change_preview(candidate) -> Dict[str, Any]:
+    """The concrete content of the proposed change.
+
+    A one-line hypothesis explains *why* something is proposed and says nothing
+    about *what* it is. Approving a distilled skill without being able to read
+    its body is not a decision, it is a guess — the text was already in the IR,
+    it was simply never sent to the page that asks the user to accept it.
+    """
+    ir = candidate.ir or {}
+    kind = str(candidate.target_kind or "")
+    for change in ir.get("changes") or []:
+        if kind == "skill":
+            document = change.get("document")
+            if isinstance(document, dict) and document.get("content"):
+                return {
+                    "type": "skill_document",
+                    "display_name": str(document.get("display_name") or ""),
+                    "description": str(document.get("description") or ""),
+                    "allowed_tools": [str(t) for t in (document.get("allowed_tools") or [])],
+                    "content": str(document.get("content") or ""),
+                }
+        if kind == "memory":
+            operations = change.get("operations") or []
+            if operations:
+                return {
+                    "type": "memory_ops",
+                    "operations": [
+                        {
+                            "operation": str(op.get("operation") or ""),
+                            "text": str(op.get("text") or op.get("memory_ref") or ""),
+                            "reason": str(op.get("reason") or ""),
+                            "before": op.get("before"),
+                            "after": op.get("after"),
+                        }
+                        for op in operations
+                    ],
+                }
+    return {}
 
 
 def _tool_sequence_of_ir(ir: Optional[Dict[str, Any]]) -> List[str]:
@@ -181,20 +297,31 @@ def approve_for_user(candidate_id: str, user_id: str) -> Dict[str, Any]:
     anyone else's agent does. That is what makes personal approval safe enough
     to sit in a settings panel rather than behind an administrator.
     """
-    from core.evolution.activation import ActivationError, materialise_skill_candidate
+    from core.evolution.activation import materialise_skill_candidate
 
-    allowed = {c["candidate_id"] for c in pending_for_user(user_id, limit=200)}
-    if candidate_id not in allowed:
+    allowed = {c["candidate_id"]: c for c in pending_for_user(user_id, limit=200)}
+    row = allowed.get(candidate_id)
+    if row is None:
         raise PermissionError(
-            "该候选主要来自他人的对话证据，需管理员审批后才能全局启用"
+            "该候选无法由你单独批准：可能主要来自他人的对话证据，或属于影响全体成员的编排/退役变更，需管理员审批"
         )
 
-    result = materialise_skill_candidate(
-        candidate_id,
-        approver=f"user:{user_id}",
-        force=True,
-        owner_user_id=user_id,
-    )
+    # Dispatch on what the candidate actually is. Sending everything to the
+    # skill materialiser is what made memory candidates fail with
+    # "暂不支持物化 memory 候选" on every click.
+    if row["action"] == "apply_memory":
+        from core.evolution.memory_apply import apply_memory_candidate
+
+        result = apply_memory_candidate(
+            candidate_id, approver=f"user:{user_id}", require_user_id=user_id
+        )
+    else:
+        result = materialise_skill_candidate(
+            candidate_id,
+            approver=f"user:{user_id}",
+            force=True,
+            owner_user_id=user_id,
+        )
     result["scope"] = "personal"
     return result
 

--- a/src/backend/scripts/seed_evolution_demo.py
+++ b/src/backend/scripts/seed_evolution_demo.py
@@ -1,0 +1,736 @@
+"""Seed the evolution console with demonstration data.
+
+**This writes fabricated records.** Nothing here was observed, mined or
+measured — it exists so the console can be shown end to end without waiting for
+a corpus to accumulate. Every row it writes carries a ``demo-`` id prefix, and
+``--clean`` removes exactly those rows and nothing else, so a demo can never be
+mistaken for, or tangled up with, real evolution history.
+
+Usage (inside the backend container)::
+
+    python scripts/seed_evolution_demo.py          # insert (re-runnable)
+    python scripts/seed_evolution_demo.py --clean  # remove every demo- row
+
+What it populates, and why each piece is shaped the way it is:
+
+* **Episodes + trace events** — the console's evidence tab, and the substrate
+  the capability-health tab computes from. Health is *derived*, not stored:
+  "offered 14 times, opened 0 times" only appears if the underlying events say
+  so, so the events are built to produce the intended verdicts rather than the
+  verdicts being written directly.
+* **Candidates** across all three engines (memory / skill / orchestration) in
+  every review state, because the funnel is a count over states.
+* **Releases**, including one guardrail rollback and one manual rollback — the
+  overview separates them on purpose, and with only one kind present that
+  distinction is invisible.
+* **Agent profiles** — the orchestration tab.
+* **Memory ops** — applied memory changes with their undo state.
+
+Skill exposure age is read from the release ledger, so skill releases are dated
+well into the past; a skill that shipped yesterday is deliberately not judged by
+the retirement rules, and demo rows dated today would all be filtered out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, "/app/src/backend")
+
+from core.db.engine import SessionLocal  # noqa: E402
+from core.db.models.evolution import (  # noqa: E402
+    EvolutionAgentProfile,
+    EvolutionCandidate,
+    EvolutionEpisode,
+    EvolutionMemoryOp,
+    EvolutionRelease,
+    EvolutionTraceEvent,
+)
+
+PREFIX = "demo-"
+NOW = datetime.now(timezone.utc)
+
+
+def ago(days: float) -> datetime:
+    return NOW - timedelta(days=days)
+
+
+def checksum(*parts: str) -> str:
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()[:32]
+
+
+# ── The scenarios on display ────────────────────────────────────────────────
+#
+# Written as the console would have discovered them: each one names what was
+# observed, not what to do about it. A hypothesis that reads "启用 X" tells a
+# reviewer nothing they can judge.
+
+MEMORY_CANDIDATES = [
+    dict(
+        asset="mem:财务分析-主体核验",
+        operation="reweight",
+        status="active",
+        risk="low",
+        hypothesis="「做财务分析前先核验公司主体」在 9 个会话中被独立复述，但检索命中率只有 31%——"
+        "同一条做法反复被人重新说一遍，说明它没有被稳定召回",
+        selected="memory_retrieval",
+        confidence=0.86,
+        evidence=6,
+        ops=[{"operation": "reweight", "memory_ref": "ref-fin-subject",
+              "text": "做财务分析前先核验公司主体是否唯一",
+              "reason": "被复述 9 次仍召回不稳定，提高检索权重",
+              "before": {"weight": 1.0}, "after": {"weight": 1.6}}],
+    ),
+    dict(
+        asset="mem:周报口径-自然周",
+        operation="reweight",
+        status="canary",
+        risk="medium",
+        hypothesis="「周报按滚动 7 天」与「周报按自然周（周一至周日）」同时被召回，两条互相矛盾；"
+        "后者在最近 30 天被复述 4 次，前者 0 次",
+        selected="memory_conflict",
+        confidence=0.79,
+        evidence=5,
+        ops=[{"operation": "reweight", "memory_ref": "ref-weekly-rolling7",
+              "text": "周报按滚动 7 天统计",
+              "reason": "与「自然周」口径冲突，且 30 天内 0 次复述，降到不再注入",
+              "before": {"weight": 1.0}, "after": {"weight": 0.0}}],
+    ),
+    dict(
+        asset="mem:数据出处-标注要求",
+        operation="merge",
+        status="draft",
+        risk="low",
+        hypothesis="3 条近重复记忆表达同一条要求（「每个数字要给出处」「数据要写来源」「结论后附引用」）——"
+        "重复条目会挤占 Top-K，把不相关的记忆一起带进上下文",
+        selected="memory_duplication",
+        confidence=0.91,
+        evidence=8,
+        ops=[{"operation": "merge", "memory_ref": "ref-cite-source",
+              "text": "每个数字要给出处（合并「数据要写来源」「结论后附引用」）",
+              "reason": "3 条近重复挤占 Top-K，合并为 1 条",
+              "before": {"count": 3}, "after": {"count": 1}}],
+    ),
+    dict(
+        asset="mem:某季度会议纪要-临时安排",
+        operation="reweight",
+        status="draft",
+        risk="low",
+        hypothesis="该记忆写入 168 天，期间被召回 2 次、两次都未被答案引用——"
+        "属于当时的一次性安排，不是可复用做法",
+        selected="memory_staleness",
+        confidence=0.72,
+        evidence=3,
+        ops=[{"operation": "reweight", "memory_ref": "ref-meeting-temp",
+              "text": "本季度会议纪要统一由行政组汇总",
+              "reason": "168 天未被引用，属一次性安排，降到不再注入",
+              "before": {"weight": 1.0}, "after": {"weight": 0.0}}],
+    ),
+    dict(
+        asset="mem:PPT配色-先确认再批量",
+        operation="reweight",
+        status="replay_passed",
+        risk="low",
+        hypothesis="「配色改动先出一版确认再批量应用」只在 ppt 类任务命中，却在所有任务类型被注入——"
+        "限定适用范围可以让其余任务少 1 条无关注入",
+        selected="memory_scope",
+        confidence=0.83,
+        evidence=4,
+        ops=[{"operation": "reweight", "memory_ref": "ref-ppt-confirm-first",
+              "text": "配色改动先出一版确认再批量应用",
+              "reason": "只在 ppt 类任务命中，限定适用范围",
+              "before": {"weight": 1.0, "scope": "all"},
+              "after": {"weight": 1.4, "scope": "ppt"}}],
+    ),
+]
+
+SKILL_BODY_CHAIN = """## 不适用范围
+- 只做单家企业尽调时不用本技能，直接查企业档案更快
+- 客户已给定产业环节口径时，以客户口径为准，不要重新划分
+
+## 何时使用
+需要梳理某个产业的上下游结构，并逐环节找出代表企业时。
+
+## 步骤
+1. 先用 `industry_chain` 拉取该产业的环节划分，确认口径与客户一致
+2. 每个环节用 `internet_search` 补充代表企业，每家必须带来源
+3. 用 `write_file` 输出，结论放最前面，再给分环节明细
+
+## 常见失败与处理
+- 环节划分与企业归属不一致：以环节口径为准，并在文末注明分歧
+- 找不到来源的企业：不写入正文，放到「待核实」小节
+"""
+
+SKILL_CANDIDATES = [
+    dict(
+        asset="industry-chain-mapping",
+        operation="new",
+        status="draft",
+        risk="low",
+        tools=["industry_chain", "internet_search", "write_file"],
+        doc_desc="梳理产业上下游结构并逐环节找出代表企业，每家带来源",
+        doc_body=SKILL_BODY_CHAIN,
+        hypothesis="12 个会话走了同一条工具序列（industry_chain → search → write_file），"
+        "每次都从零重新规划，平均多花 3.4 轮",
+        selected="repeated_tool_subsequence",
+        confidence=0.88,
+        evidence=12,
+    ),
+    dict(
+        asset="政策文件要点提取",
+        operation="new",
+        status="shadow",
+        risk="medium",
+        tools=["read_file", "internet_search", "write_file"],
+        hypothesis="7 个会话在「提取政策文件要点」上重复同一套步骤，其中 3 次因为漏掉发文机关被要求返工",
+        selected="repeated_tool_subsequence",
+        confidence=0.81,
+        evidence=7,
+    ),
+    dict(
+        asset="ppt-design",
+        operation="patch",
+        status="draft",
+        risk="medium",
+        hypothesis="被打开 11 次，其中 7 次后续动作与文档描述无关——"
+        "模型想用它、但按它做不下去，是文档的问题而不是能力的问题",
+        selected="skill_ignored_when_opened",
+        confidence=0.77,
+        evidence=11,
+    ),
+    dict(
+        asset="capability-guide-brief",
+        operation="deprecate",
+        status="draft",
+        risk="high",
+        hypothesis="被打开 6 次、也照做了，但只有 33% 的会话最终成功——"
+        "低于成功率下限，建议退役而不是继续挂载",
+        selected="skill_low_success",
+        confidence=0.69,
+        evidence=6,
+    ),
+    dict(
+        asset="季度经营分析报告",
+        operation="new",
+        status="rejected",
+        risk="high",
+        hypothesis="5 个会话重复同一套报告结构，但样本全部来自同一位用户、同一家主体——"
+        "证据不足以支撑一条面向所有人的技能",
+        selected="repeated_tool_subsequence",
+        confidence=0.44,
+        evidence=5,
+        reject_reason="证据集中在单一用户，跨用户支持度不足（要求 ≥3 位不同用户）",
+    ),
+    dict(
+        asset="excel-editing",
+        operation="patch",
+        status="active",
+        risk="low",
+        hypothesis="与「表格数据清洗」候选声明的工具集重叠 4 个——"
+        "两条并存会让技能选择在近重复项之间摇摆",
+        selected="skill_overlap",
+        confidence=0.74,
+        evidence=9,
+    ),
+]
+
+ORCHESTRATION_CANDIDATES = [
+    dict(
+        asset="research",
+        operation="patch",
+        status="active",
+        risk="medium",
+        hypothesis="research 类任务的 16 次执行中，8 个可见工具一次都没被调用过——"
+        "工具定义占了约 4200 tokens 的上下文，却没有参与任何一次决策",
+        selected="orchestration_unused_tools",
+        confidence=0.9,
+        evidence=16,
+    ),
+    dict(
+        asset="report",
+        operation="patch",
+        status="canary",
+        risk="medium",
+        hypothesis="report 类任务有 23% 的执行在记忆检索上超时（预算 600ms），"
+        "这些执行全部在无记忆注入的情况下作答",
+        selected="orchestration_budget",
+        confidence=0.85,
+        evidence=13,
+    ),
+    dict(
+        asset="chat",
+        operation="patch",
+        status="shadow",
+        risk="low",
+        hypothesis="chat 类任务每轮平均挂载 12 个技能候选，模型打开的始终落在前 4 个——"
+        "候选过多会稀释选择精度",
+        selected="orchestration_selection_precision",
+        confidence=0.78,
+        evidence=21,
+    ),
+    dict(
+        asset="code_exec",
+        operation="patch",
+        status="rolled_back",
+        risk="high",
+        hypothesis="code_exec 类任务尝试把最大迭代轮数从 12 降到 6，以缩短长尾耗时",
+        selected="orchestration_budget",
+        confidence=0.61,
+        evidence=8,
+    ),
+]
+
+# Skill usage written into the trace events. Each row is built to reach one
+# specific verdict on the health tab, so the demo shows the *decremental*
+# direction rather than a library that only ever grows.
+#
+#   offers ≥ 10 且 opens = 0 且 曝光 ≥ 14 天 → 无人问津
+#   opens ≥ 3 且 成功率 < 40%                → 建议退役
+SKILL_USAGE = [
+    dict(skill="pdf-editing", offers=14, opens=0, successes=0),      # 无人问津
+    dict(skill="capability-guide-brief", offers=11, opens=6, successes=2),  # 建议退役
+    dict(skill="ppt-design", offers=16, opens=11, successes=8),      # 健康
+    dict(skill="excel-editing", offers=12, opens=7, successes=6),    # 健康
+    dict(skill="word-editing", offers=9, opens=4, successes=3),      # 样本不足，仅入总表
+]
+
+EPISODE_SCENARIOS = [
+    ("研究 2025 年新能源汽车出口的主要目的地变化", "research", 0.82, "success"),
+    ("把这份政策文件的要点提取成一页纸", "report", 0.74, "success"),
+    ("做一版季度经营分析的 PPT 提纲", "chat", 0.68, "success"),
+    ("帮我核对这张表里的同比口径对不对", "analysis", 0.91, "success"),
+    ("整理近三年财政收入结构变化并给出图表", "report", 0.55, "partial"),
+    ("这份合同里有哪些需要注意的条款", "chat", 0.79, "success"),
+    ("产业链上游有哪些关键环节，各自谁在做", "research", 0.86, "success"),
+    ("把上面的结论写成给领导看的汇报稿", "report", 0.71, "success"),
+    ("统计一下各地区的完成进度并排序", "analysis", 0.34, "failed"),
+    ("生成本周的周报初稿", "chat", 0.77, "success"),
+    ("这个数据和上个月对不上，帮我查原因", "analysis", 0.62, "partial"),
+    ("给这份方案配一套演示用的配图", "chat", 0.58, "partial"),
+]
+
+
+def _add(db, row):
+    """Add a row and hand it back, so the caller can keep mutating it."""
+    db.add(row)
+    return row
+
+
+def resolve_user(db, explicit: str = "") -> str:
+    """Whose account the demo data belongs to.
+
+    This matters more than it looks. The **user-facing** console
+    (设置 → 进化控制台) filters everything by ``episode.user_id`` — contributions,
+    the approval queue, the memory counter. Demo rows written under a synthetic
+    id populate the admin console at /config and leave the user's own page
+    completely empty, which looks exactly like a broken feature.
+    """
+    if explicit:
+        return explicit
+    from core.db.models import UserShadow
+
+    row = (
+        db.query(UserShadow)
+        .filter(~UserShadow.user_id.like(f"{PREFIX}%"))
+        .order_by(UserShadow.updated_at.desc())
+        .first()
+    )
+    if row is None:
+        raise SystemExit("找不到真实用户，请用 --user <user_id> 指定")
+    return row.user_id
+
+
+def clean(db) -> dict:
+    """Remove every demo row. Scoped by the id prefix, so real data is untouched."""
+    counts = {}
+    for model, column in (
+        (EvolutionTraceEvent, EvolutionTraceEvent.event_id),
+        (EvolutionEpisode, EvolutionEpisode.episode_id),
+        (EvolutionRelease, EvolutionRelease.release_id),
+        (EvolutionCandidate, EvolutionCandidate.candidate_id),
+        (EvolutionAgentProfile, EvolutionAgentProfile.profile_id),
+        (EvolutionMemoryOp, EvolutionMemoryOp.op_id),
+    ):
+        n = db.query(model).filter(column.like(f"{PREFIX}%")).delete(synchronize_session=False)
+        counts[model.__tablename__] = n
+    db.commit()
+    return counts
+
+
+def seed_episodes(db, owner: str) -> list:
+    """Episodes plus the trace events the health tab is computed from.
+
+    ``owner`` is the real account these episodes belong to; the user-facing
+    console shows nothing that is not keyed to the signed-in user.
+    """
+    episode_ids = []
+    # Keep the ORM objects: `Session.get()` cannot find a row that is still
+    # pending (a pending object is not in the identity map until it flushes), so
+    # looking episodes back up by id to set their event counts silently updated
+    # nothing and every episode rendered as "0 events".
+    episode_rows = {}
+    # Spread across 30 days so before/after comparisons have both sides — and
+    # run right up to the present, so the newest demo episodes head the evidence
+    # list instead of sitting below whatever real conversations happened today.
+    span = max(len(EPISODE_SCENARIOS) - 1, 1)
+    for i, (objective, task_type, quality, verdict) in enumerate(EPISODE_SCENARIOS):
+        eid = f"{PREFIX}ep-{i:02d}"
+        created = ago(29.0 * (span - i) / span + 0.01)
+        backfilled = i in (8, 11)  # a couple that cannot be replayed
+        episode_rows[eid] = _add(
+            db,
+            EvolutionEpisode(
+                episode_id=eid,
+                run_id=f"{PREFIX}run-{i:02d}",
+                message_id=f"{PREFIX}msg-{i:02d}",
+                chat_id=f"{PREFIX}chat-{i % 5:02d}",
+                user_id=owner,
+                tenant_id="default",
+                task_type=task_type,
+                objective_hash=checksum(objective),
+                objective_preview=objective,
+                asset_bundle_id=None if backfilled else f"{PREFIX}bundle-{i:02d}",
+                asset_bundle={} if backfilled else {"skills": ["ppt-design"], "prompt": "v3"},
+                bundle_partial=False,
+                backfilled=backfilled,
+                outcome={"verdict": verdict, "attributed_to": "skill" if i % 3 == 0 else ""},
+                quality_score=quality,
+                cost_usd=round(0.004 + i * 0.0011, 4),
+                latency_ms=2400 + i * 260,
+                risk_result="pass",
+                # Two kept private, so the user page can show the distinction it
+                # makes between "contributed" and "kept to yourself" instead of
+                # reporting the same number twice.
+                privacy_class="private" if i in (5, 9) else "tenant",
+                event_count=0,
+                started_at=created,
+                completed_at=created + timedelta(seconds=18),
+                created_at=created,
+            )
+        )
+        episode_ids.append((eid, created, verdict))
+
+    # Trace events: offers (skill.selected) and opens (skill.opened) are what the
+    # health tab counts, and the gap between them is the whole finding.
+    seq_by_episode = {eid: 0 for eid, _, _ in episode_ids}
+    event_no = 0
+    for usage in SKILL_USAGE:
+        skill = usage["skill"]
+        for n in range(usage["offers"]):
+            eid, created, _ = episode_ids[n % len(episode_ids)]
+            seq_by_episode[eid] += 1
+            event_no += 1
+            db.add(
+                EvolutionTraceEvent(
+                    event_id=f"{PREFIX}evt-{event_no:05d}",
+                    episode_id=eid,
+                    message_id=f"{PREFIX}msg-{skill}-{n}",
+                    seq=seq_by_episode[eid],
+                    event_type="skill.selected",
+                    actor_type="system",
+                    payload={"selected": [skill], "degraded": False},
+                    asset_kind="skill",
+                    created_at=created,
+                )
+            )
+        for n in range(usage["opens"]):
+            # Opens land on episodes whose verdict produces the intended success
+            # rate: the first `successes` opens sit on successful episodes.
+            pool = [e for e in episode_ids if (e[2] == "success") == (n < usage["successes"])]
+            eid, created, _ = (pool or episode_ids)[n % len(pool or episode_ids)]
+            seq_by_episode[eid] += 1
+            event_no += 1
+            db.add(
+                EvolutionTraceEvent(
+                    event_id=f"{PREFIX}evt-{event_no:05d}",
+                    episode_id=eid,
+                    message_id=f"{PREFIX}msg-open-{skill}-{n}",
+                    seq=seq_by_episode[eid],
+                    event_type="skill.opened",
+                    actor_type="model",
+                    payload={"skill_id": skill, "tools_after_open": ["write_file", "bash"]},
+                    asset_kind="skill",
+                    created_at=created,
+                )
+            )
+
+    # Memory events. The user page's "记忆" counter sums `injected` across these,
+    # so without them that number stays at 0 even with a full evidence list.
+    for i, (eid, created, _) in enumerate(episode_ids):
+        seq_by_episode[eid] += 1
+        event_no += 1
+        db.add(
+            EvolutionTraceEvent(
+                event_id=f"{PREFIX}evt-mem-{event_no:05d}",
+                episode_id=eid,
+                message_id=f"{PREFIX}msg-mem-{i:02d}",
+                seq=seq_by_episode[eid],
+                event_type="memory.retrieved",
+                actor_type="system",
+                payload={
+                    "injected": 1 + (i % 3),
+                    "items": [
+                        {
+                            "layer": "fact",
+                            "content_hash": checksum("mem", str(i)),
+                            "workspace_id": "default",
+                        }
+                    ],
+                },
+                asset_kind="memory",
+                created_at=created,
+            )
+        )
+
+    for eid, count in seq_by_episode.items():
+        episode_rows[eid].event_count = count
+    db.commit()
+    return [e[0] for e in episode_ids]
+
+
+def _changes_for(kind: str, spec: dict, owner: str) -> list:
+    """The executable payload behind a candidate.
+
+    Skill candidates carry the document that would be installed; memory
+    candidates carry the operations that would be applied. These are what the
+    user's approval page renders — a candidate without them shows a diagnosis
+    and an unexplained button.
+    """
+    if kind == "skill" and spec["operation"] in ("new", "patch", "merge"):
+        return [{
+            "tool_sequence": spec.get("tools", []),
+            "document": {
+                "display_name": spec["asset"],
+                "description": spec.get("doc_desc", ""),
+                "allowed_tools": spec.get("tools", []),
+                "content": spec.get("doc_body", ""),
+            },
+        }]
+    if kind == "memory":
+        return [{
+            "user_id": owner,
+            "operations": spec.get("ops", []),
+        }]
+    return [{"tool_sequence": spec.get("tools", [])}]
+
+
+def seed_candidates(db, episode_ids: list, owner: str) -> None:
+    groups = (
+        ("memory", MEMORY_CANDIDATES),
+        ("skill", SKILL_CANDIDATES),
+        ("agent_profile", ORCHESTRATION_CANDIDATES),
+    )
+    idx = 0
+    for kind, specs in groups:
+        for spec in specs:
+            idx += 1
+            cid = f"{PREFIX}cand-{kind}-{idx:02d}"
+            approved = spec["status"] in ("active", "canary", "shadow", "replay_passed")
+            db.add(
+                EvolutionCandidate(
+                    candidate_id=cid,
+                    target_kind=kind,
+                    target_asset_id=spec["asset"],
+                    base_version_id="v1",
+                    operation=spec["operation"],
+                    ir={
+                        "target_kind": kind,
+                        "target_asset_id": spec["asset"],
+                        "operation": spec["operation"],
+                        "hypothesis": spec["hypothesis"],
+                        # The change itself. Without this the approval row can
+                        # only restate why something is proposed and never what
+                        # it is, which is not enough to decide on.
+                        "changes": _changes_for(kind, spec, owner),
+                    },
+                    hypothesis=spec["hypothesis"],
+                    change_checksum=checksum(kind, spec["asset"], spec["operation"], str(idx)),
+                    evidence_refs=episode_ids[: spec["evidence"]],
+                    credit_decision={
+                        "selected": spec["selected"],
+                        "confidence": spec["confidence"],
+                        "explanation": spec["hypothesis"][:60],
+                    },
+                    risk_tier=spec["risk"],
+                    scope={"task_types": ["chat", "report"]} if kind == "agent_profile" else {},
+                    status=spec["status"],
+                    reject_reason=spec.get("reject_reason"),
+                    proposer="evolution_cycle",
+                    approved_by="console" if approved else None,
+                    approved_at=ago(3) if approved else None,
+                    created_at=ago(12 - idx * 0.4),
+                )
+            )
+    db.commit()
+
+
+def seed_releases(db) -> None:
+    """Release board, including both rollback kinds.
+
+    Skill releases are dated ≥30 days back because skill exposure age is read
+    from here: the retirement rules refuse to judge anything younger than two
+    weeks, so a demo release dated today would produce an empty health tab.
+    """
+    rows = [
+        dict(rid="01", cid=f"{PREFIX}cand-skill-06", kind="skill", asset="excel-editing",
+             stage="active", traffic=100, age=34),
+        dict(rid="02", cid=f"{PREFIX}cand-skill-01", kind="skill", asset="industry-chain-mapping",
+             stage="canary", traffic=25, age=31),
+        dict(rid="03", cid=f"{PREFIX}cand-skill-02", kind="skill", asset="政策文件要点提取",
+             stage="shadow", traffic=0, age=30),
+        dict(rid="04", cid=f"{PREFIX}cand-skill-04", kind="skill", asset="capability-guide-brief",
+             stage="active", traffic=100, age=46),
+        dict(rid="05", cid=f"{PREFIX}cand-skill-05", kind="skill", asset="pdf-editing",
+             stage="active", traffic=100, age=38),
+        dict(rid="06", cid=f"{PREFIX}cand-skill-03", kind="skill", asset="ppt-design",
+             stage="active", traffic=100, age=52),
+        dict(rid="07", cid=f"{PREFIX}cand-skill-07", kind="skill", asset="word-editing",
+             stage="active", traffic=100, age=41),
+        dict(rid="08", cid=f"{PREFIX}cand-agent_profile-12", kind="agent_profile", asset="research",
+             stage="active", traffic=100, age=9),
+        dict(rid="09", cid=f"{PREFIX}cand-agent_profile-13", kind="agent_profile", asset="report",
+             stage="canary", traffic=25, age=4),
+        dict(rid="10", cid=f"{PREFIX}cand-memory-01", kind="memory", asset="mem:财务分析-主体核验",
+             stage="active", traffic=100, age=6),
+        dict(rid="11", cid=f"{PREFIX}cand-memory-02", kind="memory", asset="mem:周报口径-自然周",
+             stage="canary", traffic=25, age=2),
+        # Both rollback kinds: the overview counts them separately because a
+        # guardrail rollback means the system worked, while a manual one means
+        # the evaluation missed something.
+        dict(rid="12", cid=f"{PREFIX}cand-agent_profile-15", kind="agent_profile", asset="code_exec",
+             stage="rolled_back", traffic=0, age=7, rollback="guardrail",
+             reason="灰度期 code_exec 成功率由 71% 降至 58%，触发护栏自动回滚"),
+        dict(rid="13", cid=f"{PREFIX}cand-skill-05", kind="skill", asset="表格数据清洗",
+             stage="rolled_back", traffic=0, age=15, rollback="manual",
+             reason="人工观察到与 excel-editing 高度重复，选择在两者间摇摆，手动回滚"),
+    ]
+    for row in rows:
+        db.add(
+            EvolutionRelease(
+                release_id=f"{PREFIX}rel-{row['rid']}",
+                candidate_id=row["cid"],
+                target_kind=row["kind"],
+                target_asset_id=row["asset"],
+                stage=row["stage"],
+                traffic_percent=row["traffic"],
+                scope_filter={},
+                guardrails={"success_rate_floor": 0.6, "latency_p95_ms": 12000},
+                rollback_version_id="v1" if row["stage"] != "shadow" else None,
+                rolled_back_at=ago(1) if row.get("rollback") else None,
+                rollback_reason=row.get("reason"),
+                rollback_kind=row.get("rollback"),
+                approved_by="console",
+                created_at=ago(row["age"]),
+                updated_at=ago(max(row["age"] - 2, 0)),
+            )
+        )
+    db.commit()
+
+
+def seed_profiles(db) -> None:
+    specs = [
+        dict(pid="research-v3", version="v3", tasks=["research"], active=True,
+             cid=f"{PREFIX}cand-agent_profile-12",
+             payload={"visible_tools": ["internet_search", "read_file", "write_file", "bash"],
+                      "skill_candidates": 6, "memory_budget_ms": 900, "max_iterations": 12,
+                      "note": "移除 8 个从未被调用的工具定义，约省 4200 tokens 上下文"}),
+        dict(pid="report-v2", version="v2", tasks=["report"], active=True,
+             cid=f"{PREFIX}cand-agent_profile-13",
+             payload={"visible_tools": ["read_file", "write_file", "excel", "internet_search"],
+                      "skill_candidates": 8, "memory_budget_ms": 900, "max_iterations": 10,
+                      "note": "记忆检索预算 600ms→900ms，消除 23% 的超时无注入"}),
+        dict(pid="chat-v2", version="v2", tasks=["chat"], active=False,
+             cid=f"{PREFIX}cand-agent_profile-14",
+             payload={"visible_tools": ["read_file", "write_file"], "skill_candidates": 6,
+                      "memory_budget_ms": 600, "max_iterations": 8,
+                      "note": "技能候选 12→6，灰度中；停用后回落内置装配"}),
+    ]
+    for spec in specs:
+        db.add(
+            EvolutionAgentProfile(
+                profile_id=f"{PREFIX}{spec['pid']}",
+                version=spec["version"],
+                task_types=spec["tasks"],
+                scope={"tenant_id": "default"},
+                payload=spec["payload"],
+                candidate_id=spec["cid"],
+                is_active=spec["active"],
+                created_by="evolution",
+                created_at=ago(11),
+                updated_at=ago(3),
+            )
+        )
+    db.commit()
+
+
+def seed_memory_ops(db, owner: str) -> None:
+    specs = [
+        dict(op="reweight", ref="ref-fin-subject", status="applied",
+             reason="重复陈述 9 次但召回率 31%，提高检索权重",
+             before={"weight": 1.0}, after={"weight": 1.6}),
+        dict(op="deprecate", ref="ref-weekly-rolling7", status="applied",
+             reason="与「自然周」口径冲突，且 30 天内 0 次复述",
+             before={"active": True}, after={"active": False}),
+        dict(op="merge", ref="ref-cite-source", status="applied",
+             reason="3 条近重复合并为 1 条，释放 Top-K 名额",
+             before={"count": 3}, after={"count": 1}),
+        dict(op="reweight", ref="ref-ppt-confirm-first", status="reverted",
+             reason="限定到 ppt 任务后误伤了 report 任务的召回，已撤销",
+             before={"scope": "all"}, after={"scope": "ppt"}),
+    ]
+    for i, spec in enumerate(specs):
+        db.add(
+            EvolutionMemoryOp(
+                op_id=f"{PREFIX}op-{i:02d}",
+                candidate_id=f"{PREFIX}cand-memory-{i + 1:02d}",
+                user_id=owner,
+                workspace_id="default",
+                operation=spec["op"],
+                memory_ref=spec["ref"],
+                external_id=f"{PREFIX}mem-{i:02d}",
+                before_state=spec["before"],
+                after_state=spec["after"],
+                reason=spec["reason"],
+                status=spec["status"],
+                applied_at=ago(5 - i),
+                reverted_at=ago(1) if spec["status"] == "reverted" else None,
+            )
+        )
+    db.commit()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clean", action="store_true", help="只删除 demo- 数据，不写入")
+    parser.add_argument("--user", default="", help="数据归属的用户 id（默认取最近活跃的真实用户）")
+    args = parser.parse_args()
+
+    with SessionLocal() as db:
+        removed = clean(db)
+        print("removed:", {k: v for k, v in removed.items() if v})
+        if args.clean:
+            return 0
+
+        owner = resolve_user(db, args.user)
+        print("owner:", owner)
+        episode_ids = seed_episodes(db, owner)
+        seed_candidates(db, episode_ids, owner)
+        seed_releases(db)
+        seed_profiles(db)
+        seed_memory_ops(db, owner)
+
+        print("seeded:")
+        print("  episodes    ", db.query(EvolutionEpisode).count())
+        print("  events      ", db.query(EvolutionTraceEvent).count())
+        print("  candidates  ", db.query(EvolutionCandidate).count())
+        print("  releases    ", db.query(EvolutionRelease).count())
+        print("  profiles    ", db.query(EvolutionAgentProfile).count())
+        print("  memory_ops  ", db.query(EvolutionMemoryOp).count())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/tests/evolution/test_personal_approval.py
+++ b/src/backend/tests/evolution/test_personal_approval.py
@@ -40,18 +40,30 @@ def _episode(db, episode_id, user):
     )
 
 
-def _candidate(db, candidate_id, evidence, status="draft"):
+def _candidate(
+    db, candidate_id, evidence, status="draft", risk_tier="low", **overrides
+):
+    """A candidate a user could genuinely accept for themselves.
+
+    ``risk_tier`` defaults to low because that is the only tier a personal
+    activation can carry out from a draft: anything higher owes shadow and
+    canary, which one person clicking a button cannot provide. Listing those
+    anyway is what put rows in the queue whose button could only ever return
+    "force 只允许用于 low 风险候选".
+    """
     db.add(
         EvolutionCandidate(
             candidate_id=candidate_id,
-            target_kind="skill",
+            target_kind=overrides.pop("target_kind", "skill"),
             target_asset_id=f"auto-{candidate_id}",
-            operation="new",
-            ir={"changes": [{"tool_sequence": ["a", "b"]}]},
+            operation=overrides.pop("operation", "new"),
+            ir=overrides.pop("ir", {"changes": [{"tool_sequence": ["a", "b"]}]}),
             change_checksum=candidate_id,
             evidence_refs=list(evidence),
             hypothesis="重复出现的工具子序列",
             status=status,
+            risk_tier=risk_tier,
+            **overrides,
         )
     )
 
@@ -177,3 +189,111 @@ def test_the_tool_sequence_is_surfaced_so_approval_is_informed(db):
     # Approving a capability without seeing what it will do is a habit, not a
     # decision.
     assert pending[0]["tool_sequence"] == ["a", "b"]
+
+
+# ── The queue lists only what it can carry out ───────────────────────────────
+#
+# Every case below used to appear with a 「为我启用」 button whose sole possible
+# outcome was an error toast. A queue that offers a decision it cannot execute
+# is worse than an empty one: it teaches the reader the feature does nothing.
+
+
+def test_a_memory_candidate_is_offered_as_a_memory_change_not_an_install(db):
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(
+        db, "m1", [f"e{i}" for i in range(3)],
+        target_kind="memory", operation="reweight",
+        ir={"changes": [{"user_id": "alice", "operations": [
+            {"operation": "reweight", "memory_ref": "ref-1",
+             "after": {"weight": 1.5}}]}]},
+    )
+    db.commit()
+
+    row = US.pending_for_user("alice")[0]
+    assert row["action"] == "apply_memory"
+    # Not "为我启用": nothing is being installed, a retrieval weight is changing.
+    assert row["action_label"] != "为我启用"
+    assert row["change"]["type"] == "memory_ops"
+
+
+def test_a_memory_operation_with_no_executor_is_not_offered(db):
+    # `deprecate` is proposable in the IR but `apply_memory_ops` refuses it with
+    # `no_executor_for_operation`, so it must not reach the queue.
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(
+        db, "m2", [f"e{i}" for i in range(3)],
+        target_kind="memory", operation="deprecate",
+    )
+    db.commit()
+
+    assert US.pending_for_user("alice") == []
+
+
+def test_a_medium_risk_draft_skill_is_not_personally_approvable(db):
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(db, "s2", [f"e{i}" for i in range(3)], risk_tier="medium")
+    db.commit()
+
+    assert US.pending_for_user("alice") == []
+
+
+def test_a_replayed_medium_risk_skill_is_personally_approvable(db):
+    # Once replay has passed, a personal activation is the one case that may go
+    # straight live: its blast radius is a single consenting user.
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(
+        db, "s3", [f"e{i}" for i in range(3)],
+        status="replay_passed", risk_tier="medium",
+    )
+    db.commit()
+
+    assert [c["candidate_id"] for c in US.pending_for_user("alice")] == ["s3"]
+
+
+def test_a_retirement_is_never_offered_as_something_to_enable(db):
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(db, "s4", [f"e{i}" for i in range(3)], operation="deprecate")
+    db.commit()
+
+    assert US.pending_for_user("alice") == []
+
+
+def test_an_orchestration_profile_is_not_a_personal_decision(db):
+    # A profile governs how every request of a task type is assembled, for
+    # everyone. There is no per-user version of it to accept.
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(
+        db, "p1", [f"e{i}" for i in range(3)],
+        target_kind="agent_profile", operation="patch",
+    )
+    db.commit()
+
+    assert US.pending_for_user("alice") == []
+
+
+def test_the_skill_body_is_shown_so_approval_is_a_decision(db):
+    # Approving a distilled skill without being able to read it is a guess. The
+    # text was always in the IR; it simply was never sent to the page.
+    for i in range(3):
+        _episode(db, f"e{i}", "alice")
+    _candidate(
+        db, "s5", [f"e{i}" for i in range(3)],
+        ir={"changes": [{"document": {
+            "display_name": "产业链梳理",
+            "description": "梳理上下游并逐环节找代表企业",
+            "allowed_tools": ["internet_search"],
+            "content": "## 不适用范围\n单家企业尽调不用本技能\n\n## 步骤\n1. 先拉环节划分",
+        }}]},
+    )
+    db.commit()
+
+    change = US.pending_for_user("alice")[0]["change"]
+    assert change["type"] == "skill_document"
+    assert "## 步骤" in change["content"]
+    assert change["allowed_tools"] == ["internet_search"]

--- a/src/backend/tests/evolution/test_personal_cycle_and_prefs.py
+++ b/src/backend/tests/evolution/test_personal_cycle_and_prefs.py
@@ -107,6 +107,7 @@ def test_a_missing_licensing_module_reads_as_community(monkeypatch):
     """The community tree excludes edition_ee entirely, so an ImportError is the
     expected signal — not a fault to be logged and retried."""
     import builtins
+    import sys
 
     import core.evolution.loop as L
 
@@ -116,6 +117,16 @@ def test_a_missing_licensing_module_reads_as_community(monkeypatch):
         if name.startswith("edition_ee"):
             raise ImportError("no edition_ee in community tree")
         return real_import(name, *args, **kwargs)
+
+    # Evict only the two licensing modules this test blocks.
+    # `importlib.import_module` returns straight from `sys.modules` without ever
+    # calling `__import__`, so with a warm cache the assertion below was vacuous:
+    # it passed alone and failed once an earlier test in the run had imported
+    # them. Evicting the whole `edition_ee` package instead would force
+    # `edition_ee.db.models` to re-import and re-register its tables on the
+    # shared SQLAlchemy metadata, breaking unrelated tests later in the run.
+    for name in ("edition_ee.licensing.features", "edition_ee.licensing.manager"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
 
     monkeypatch.setattr(builtins, "__import__", blocked)
     assert L.cross_user_mining_available() is False

--- a/src/backend/tests/evolution/test_user_contribution.py
+++ b/src/backend/tests/evolution/test_user_contribution.py
@@ -38,21 +38,37 @@ def db(monkeypatch):
 
 
 # ── Semantics of the setting ─────────────────────────────────────────────────
+#
+# There is one evolution switch — evolution_prefs.enabled — and participation
+# follows it. The legacy standalone contribution key in metadata is ignored,
+# so the two can never drift apart.
 
 
-def test_participation_defaults_to_on():
-    assert US.is_contribution_enabled({}) is True
-    assert US.is_contribution_enabled(None) is True
+def test_participation_follows_the_single_evolution_switch():
+    assert US.is_contribution_enabled({"evolution_prefs": {"enabled": True}}) is True
+    assert US.is_contribution_enabled({"evolution_prefs": {"enabled": False}}) is False
+
+
+def test_participation_defaults_to_off_until_evolution_is_enabled():
+    """Consent-first: a user who never enabled evolution contributes nothing."""
+    assert US.is_contribution_enabled({}) is False
+    assert US.is_contribution_enabled(None) is False
+
+
+def test_legacy_contribution_key_no_longer_overrides_the_switch():
+    metadata = {US.SETTING_KEY: True}  # stale value from the two-switch era
+    assert US.is_contribution_enabled(metadata) is False
 
 
 def test_opting_out_marks_episodes_private():
-    assert US.privacy_class_for({US.SETTING_KEY: False}) == US.PRIVACY_PRIVATE
-    assert US.privacy_class_for({US.SETTING_KEY: True}) == US.PRIVACY_TENANT
+    assert US.privacy_class_for({"evolution_prefs": {"enabled": False}}) == US.PRIVACY_PRIVATE
+    assert US.privacy_class_for({"evolution_prefs": {"enabled": True}}) == US.PRIVACY_TENANT
 
 
 def test_missing_user_resolves_to_the_default_rather_than_failing():
     resolved = US.resolve_for_user("")
-    assert resolved[US.SETTING_KEY] is True
+    assert resolved[US.SETTING_KEY] is False
+    assert resolved["privacy_class"] == US.PRIVACY_PRIVATE
 
 
 # ── Enforcement: the part that makes the promise real ────────────────────────

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -3922,17 +3922,11 @@ export async function getTurnSettlement(messageId: string): Promise<EvolutionSum
   return unwrapData<EvolutionSummary>(wrapped);
 }
 
-// ── Evolution: per-user contribution setting (settings panel) ────────────────
+// ── Evolution: contribution summary (settings panel detail card) ─────────────
 //
-// Named "contribution", not "evolution on/off": one user cannot stop the system
-// distilling a skill from everyone else's traces. What they control is whether
-// their own conversations become evidence.
-export interface EvolutionContributionSetting {
-  evolution_contribution_enabled: boolean;
-  privacy_class: 'tenant' | 'private';
-  note?: string;
-}
-
+// The separate contribution setting is gone from the UI: participation follows
+// the single evolution switch in EvolutionPrefs. Only the summary — "what did
+// my conversations actually produce" — remains its own endpoint.
 export interface EvolutionContributionItem {
   candidate_id: string;
   target_kind: 'memory' | 'skill' | 'workflow' | 'ontology' | 'prompt';
@@ -3952,28 +3946,36 @@ export interface EvolutionContributions {
   candidates: EvolutionContributionItem[];
 }
 
-export async function getEvolutionSettings(): Promise<EvolutionContributionSetting> {
-  return unwrapData<EvolutionContributionSetting>(await apiRequest<unknown>('/v1/evolution/settings'));
-}
-
-export async function updateEvolutionSettings(enabled: boolean): Promise<EvolutionContributionSetting> {
-  return unwrapData<EvolutionContributionSetting>(
-    await apiRequest<unknown>('/v1/evolution/settings', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ enabled }),
-    }),
-  );
-}
-
 export async function getEvolutionContributions(): Promise<EvolutionContributions> {
   return unwrapData<EvolutionContributions>(await apiRequest<unknown>('/v1/evolution/contributions'));
 }
 
 // ── Evolution: personal candidate approval (settings console) ────────────────
+/** The concrete content of a proposed change — what approving it will do. */
+export type EvolutionChangePreview =
+  | {
+      type: 'skill_document';
+      display_name: string;
+      description: string;
+      allowed_tools: string[];
+      content: string;
+    }
+  | {
+      type: 'memory_ops';
+      operations: Array<{
+        operation: string;
+        text: string;
+        reason: string;
+        before?: unknown;
+        after?: unknown;
+      }>;
+    }
+  | Record<string, never>;
+
 export interface MyEvolutionCandidate {
   candidate_id: string;
   target_kind: string;
+  operation: string;
   summary: string;
   status: string;
   risk_tier: string;
@@ -3981,6 +3983,11 @@ export interface MyEvolutionCandidate {
   total_evidence: number;
   own_share: number;
   tool_sequence: string[];
+  /** What the button does. Rows the user cannot action are not returned at all. */
+  action: string;
+  action_label: string;
+  action_effect: string;
+  change: EvolutionChangePreview;
   created_at?: string | null;
 }
 

--- a/src/frontend/src/components/settings/EvolutionApprovalList.tsx
+++ b/src/frontend/src/components/settings/EvolutionApprovalList.tsx
@@ -1,4 +1,4 @@
-import { CheckOutlined, InboxOutlined } from '@ant-design/icons';
+import { CheckOutlined, DownOutlined, InboxOutlined, UpOutlined } from '@ant-design/icons';
 import { Button, Tag, message } from 'antd';
 import { useEffect, useState } from 'react';
 
@@ -7,14 +7,84 @@ import type { MyEvolutionCandidate } from '../../api';
 import { t } from '../../i18n';
 
 /**
- * Candidates the signed-in user may accept for themselves.
+ * Capability changes the signed-in user can decide on for themselves.
  *
- * Only those distilled mostly from their own conversations appear here, and
- * accepting one installs it as a *private* skill. That scoping is what makes
- * personal approval safe to expose in a settings panel: no click here can
- * change what anyone else's agent does. Capabilities learned mainly from other
- * people's evidence are a fleet-wide decision and stay with an administrator.
+ * Two rules make this safe to sit in a settings panel rather than behind an
+ * administrator, and both are enforced server-side:
+ *
+ * 1. only candidates distilled mostly from this user's own conversations appear;
+ * 2. only changes that *have* a personal form appear — a private skill, or an
+ *    adjustment to this user's own memories. Orchestration profiles and
+ *    retirements change what everyone's agent does and are not offered here.
+ *
+ * Every row states the concrete change before asking for a decision. A row that
+ * showed only a diagnosis ("opened 6 times, 33% success") under a button
+ * labelled "enable for me" asked the user to approve something the page never
+ * described — and, for kinds with no personal path, the click could only fail.
  */
+const KIND_LABEL: Record<string, string> = {
+  skill: '技能',
+  memory: '记忆',
+};
+
+const OP_LABEL: Record<string, string> = {
+  create: '新增',
+  update: '改写',
+  reweight: '调权',
+  deprecate: '停用',
+  merge: '合并',
+};
+
+function ChangeDetail({ candidate }: { candidate: MyEvolutionCandidate }) {
+  const [open, setOpen] = useState(false);
+  const change = candidate.change as Record<string, unknown>;
+
+  if (!change || !change.type) return null;
+
+  if (change.type === 'skill_document') {
+    const tools = (change.allowed_tools as string[]) ?? [];
+    return (
+      <div className="jx-evoApproval-change">
+        <button type="button" className="jx-evoApproval-toggle" onClick={() => setOpen(!open)}>
+          {open ? <UpOutlined /> : <DownOutlined />}
+          <span>{open ? t('收起技能正文') : t('查看将要安装的技能正文')}</span>
+        </button>
+        {(change.description as string) && (
+          <p className="jx-evoApproval-desc">{change.description as string}</p>
+        )}
+        {tools.length > 0 && (
+          <div className="jx-evoApproval-tools">
+            <span>{t('它会用到的工具')}：</span>
+            {tools.map((tool) => (
+              <code key={tool}>{tool}</code>
+            ))}
+          </div>
+        )}
+        {open && <pre className="jx-evoApproval-doc">{change.content as string}</pre>}
+      </div>
+    );
+  }
+
+  if (change.type === 'memory_ops') {
+    const ops = (change.operations as Array<Record<string, string>>) ?? [];
+    return (
+      <div className="jx-evoApproval-change">
+        <ul className="jx-evoApproval-ops">
+          {ops.map((op, i) => (
+            <li key={i}>
+              <Tag>{t(OP_LABEL[op.operation] ?? op.operation)}</Tag>
+              <span className="jx-evoApproval-opText">{op.text}</span>
+              {op.reason && <em>{op.reason}</em>}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  return null;
+}
+
 export function EvolutionApprovalList() {
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState<MyEvolutionCandidate[]>([]);
@@ -34,12 +104,16 @@ export function EvolutionApprovalList() {
     setApproving(candidate.candidate_id);
     approveMyEvolutionCandidate(candidate.candidate_id)
       .then(() => {
-        message.success(t('已为你启用该能力'));
+        message.success(
+          candidate.action === 'apply_memory'
+            ? t('已应用该记忆调整')
+            : t('已为你启用该能力'),
+        );
         // Drop it locally rather than refetching: the row is gone either way,
         // and a spinner over a list the user just acted on reads as uncertainty.
         setItems((prev) => prev.filter((c) => c.candidate_id !== candidate.candidate_id));
       })
-      .catch(() => message.error(t('启用失败，请稍后重试')))
+      .catch(() => message.error(t('操作失败，请稍后重试')))
       .finally(() => setApproving(''));
   };
 
@@ -47,7 +121,7 @@ export function EvolutionApprovalList() {
     return (
       <div className="jx-evoApproval-empty">
         <InboxOutlined />
-        <strong>{t('暂无待批准的能力')}</strong>
+        <strong>{t('暂无待你决定的变更')}</strong>
         {/* Nothing pending is the normal state, not a failure — say why. */}
         <span>{t('当同类任务反复出现，系统会把稳定的做法整理成能力候选，等你确认。')}</span>
       </div>
@@ -59,9 +133,14 @@ export function EvolutionApprovalList() {
       {items.map((candidate) => (
         <div key={candidate.candidate_id} className="jx-evoApproval-item">
           <div className="jx-evoApproval-head">
+            <Tag color={candidate.target_kind === 'memory' ? 'cyan' : 'geekblue'}>
+              {t(KIND_LABEL[candidate.target_kind] ?? candidate.target_kind)}
+              {candidate.operation ? ` · ${t(OP_LABEL[candidate.operation] ?? candidate.operation)}` : ''}
+            </Tag>
             <span className="jx-evoApproval-title">{candidate.summary || t('能力候选')}</span>
-            <Tag color="blue">{t('待批准')}</Tag>
           </div>
+
+          <ChangeDetail candidate={candidate} />
 
           {candidate.tool_sequence?.length > 0 && (
             <div className="jx-evoApproval-steps">
@@ -75,12 +154,13 @@ export function EvolutionApprovalList() {
           )}
 
           <div className="jx-evoApproval-meta">
-            {/* Provenance, so approval is an informed act rather than a habit. */}
+            {/* Provenance and blast radius, so approval is an informed act. */}
             <span>
               {t('来自你的 {n} 次对话', { n: candidate.your_episodes })}
               {candidate.total_evidence > candidate.your_episodes
                 ? ` · ${t('共 {n} 条证据', { n: candidate.total_evidence })}`
                 : ''}
+              {candidate.action_effect ? ` · ${candidate.action_effect}` : ''}
             </span>
             <Button
               type="primary"
@@ -89,13 +169,13 @@ export function EvolutionApprovalList() {
               loading={approving === candidate.candidate_id}
               onClick={() => approve(candidate)}
             >
-              {t('为我启用')}
+              {candidate.action_label || t('为我启用')}
             </Button>
           </div>
         </div>
       ))}
       <p className="jx-evoApproval-note">
-        {t('启用后仅对你生效，不影响其他成员；随时可在能力中心停用。')}
+        {t('这里只列出你能自己决定的变更；影响全体成员的编排调整与能力退役由管理员审批。')}
       </p>
     </div>
   );

--- a/src/frontend/src/components/settings/EvolutionPrefsPanel.tsx
+++ b/src/frontend/src/components/settings/EvolutionPrefsPanel.tsx
@@ -20,7 +20,7 @@ const MECHANISMS: Array<{ key: string; label: string; desc: string }> = [
  * and a design that assumes a pack exists breaks the third case completely.
  * "Not bound" is therefore presented as an ordinary choice, not a warning.
  */
-export function EvolutionPrefsPanel() {
+export function EvolutionPrefsPanel({ onShowDetail }: { onShowDetail?: () => void }) {
   const [prefs, setPrefs] = useState<EvolutionPrefs | null>(null);
   const [packs, setPacks] = useState<OntologyPackOption[]>([]);
   const [saving, setSaving] = useState(false);
@@ -68,10 +68,13 @@ export function EvolutionPrefsPanel() {
 
   return (
     <div className="jx-evoPrefs">
+      {/* The single evolution switch: distilling for this user and their
+          conversations serving as evidence both follow it — there is no
+          separate participation toggle. */}
       <div className="jx-evoPrefs-row">
         <div className="jx-evoPrefs-label">
           <span>{t('启动进化')}</span>
-          <small>{t('关闭后系统不再从你的用法中沉淀任何能力；已生成的内容保留')}</small>
+          <small>{t('开启后，系统从你的用法中为你沉淀能力，你的对话也会作为证据参与集体能力沉淀；关闭后全部停止，已生成的内容保留')}</small>
         </div>
         <Switch
           checked={prefs.enabled}
@@ -79,6 +82,17 @@ export function EvolutionPrefsPanel() {
           onChange={(on) => patch({ enabled: on })}
         />
       </div>
+
+      {prefs.enabled && onShowDetail && (
+        <div className="jx-settings-memoryDetail">
+          <span className="jx-settings-memoryCount">
+            {t('你的对话正在参与能力沉淀')}
+          </span>
+          <a className="jx-settings-memoryLink" onClick={onShowDetail}>
+            {t('查看进化详情')}
+          </a>
+        </div>
+      )}
 
       <div className="jx-evoPrefs-row">
         <div className="jx-evoPrefs-label">

--- a/src/frontend/src/components/settings/SettingsModal.tsx
+++ b/src/frontend/src/components/settings/SettingsModal.tsx
@@ -17,12 +17,10 @@ import type { MemoryItem } from '../../types';
 import { resolveAvatarUrl } from '../../utils/avatar';
 import { mdToHtml } from '../../utils/markdown';
 import {
-  getEvolutionSettings,
   getMyProfile,
   getMySystemAccess,
   getOntologyGovernanceAccess,
   setMyAvatarUrl,
-  updateEvolutionSettings,
   updateMyProfile,
   uploadMyAvatar,
 } from '../../api';
@@ -136,29 +134,10 @@ export default function SettingsPage() {
   const [sysAccess, setSysAccess] = useState(false);
   const [ontologyGovernanceAccess, setOntologyGovernanceAccess] = useState(false);
   const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
-  // Evolution participation. Optimistic on toggle, reverted if the write fails —
-  // a switch that silently springs back with no explanation is worse than one
-  // that briefly showed the wrong state.
-  const [evolutionContribution, setEvolutionContribution] = useState(true);
-  const [evolutionSaving, setEvolutionSaving] = useState(false);
+  // Evolution detail card. The participation toggle it used to sit beside is
+  // gone — the single「启动进化」switch in EvolutionPrefsPanel now governs both
+  // distilling for the user and contributing their conversations as evidence.
   const [evolutionCardOpen, setEvolutionCardOpen] = useState(false);
-  useEffect(() => {
-    getEvolutionSettings()
-      .then((setting) => setEvolutionContribution(setting.evolution_contribution_enabled))
-      // Default to on when unreadable, matching the backend default rather than
-      // showing a switch whose position contradicts the server.
-      .catch(() => setEvolutionContribution(true));
-  }, [authUser?.user_id]);
-
-  const toggleEvolutionContribution = (checked: boolean) => {
-    const previous = evolutionContribution;
-    setEvolutionContribution(checked);
-    setEvolutionSaving(true);
-    updateEvolutionSettings(checked)
-      .then((setting) => setEvolutionContribution(setting.evolution_contribution_enabled))
-      .catch(() => setEvolutionContribution(previous))
-      .finally(() => setEvolutionSaving(false));
-  };
 
   useEffect(() => {
     if (!isCE) { setSysAccess(false); return; }
@@ -761,62 +740,17 @@ export default function SettingsPage() {
             )}
           </AnimatePresence>
 
-          <div className="jx-settings-divider" />
-
-          {/* Evolution participation.
-              Deliberately *not* labelled "evolve or not": one user cannot stop
-              the system distilling a skill from everyone else's traces. What
-              they genuinely control — and what the backend enforces via the
-              episode's privacy class — is whether their own conversations
-              become evidence. */}
-          <div className="jx-settings-row">
-            <div className="jx-settings-rowLeft">
-              <span className="jx-settings-rowLabel">{t('参与能力进化')}</span>
-              <span className="jx-settings-rowDesc">
-                {t('开启后，你的对话会作为证据参与技能与流程的沉淀；关闭后仍保留你自己的记忆与本轮进化展示')}
-              </span>
-            </div>
-            <Switch
-              checked={evolutionContribution}
-              loading={evolutionSaving}
-              onChange={(checked) => toggleEvolutionContribution(checked)}
-            />
-          </div>
-
-          <AnimatePresence initial={false}>
-            {evolutionContribution && (
-              <motion.div
-                key="evolution-detail"
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: 'auto', opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.22, ease: SLIDE_EASE }}
-                style={{ overflow: 'hidden' }}
-              >
-                <div className="jx-settings-memoryDetail">
-                  <span className="jx-settings-memoryCount">
-                    {t('你的对话正在参与能力沉淀')}
-                  </span>
-                  <a
-                    className="jx-settings-memoryLink"
-                    onClick={() => setEvolutionCardOpen(true)}
-                  >
-                    {t('查看进化详情')}
-                  </a>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
 
-        {/* Fine-grained controls. Kept below the switches so the common case —
-            flip participation on or off — stays a one-glance decision, while
-            deployments that need per-mechanism or ontology scoping have it. */}
+        {/* One switch governs evolution entirely — both what the system
+            distils for this user and whether their conversations serve as
+            evidence. The master toggle and its fine-grained scoping live
+            together in the panel. */}
         <h3 className="jx-settings-section-title" style={{ marginTop: 24 }}>
           {t('进化配置')}
         </h3>
         <div className="jx-settings-card jx-settings-card--padded">
-          <EvolutionPrefsPanel />
+          <EvolutionPrefsPanel onShowDetail={() => setEvolutionCardOpen(true)} />
         </div>
 
         {/* Approvals live with the user, not in the admin console: these

--- a/src/frontend/src/i18n/en/settings.ts
+++ b/src/frontend/src/i18n/en/settings.ts
@@ -528,9 +528,6 @@ export const SETTINGS_DICT: Record<string, string> = {
   '合计': 'Total',
   '次': 'req(s)',
   // GCE evolution participation (settings panel)
-  '参与能力进化': 'Contribute to capability evolution',
-  '开启后，你的对话会作为证据参与技能与流程的沉淀；关闭后仍保留你自己的记忆与本轮进化展示':
-    'When on, your conversations serve as evidence for distilling skills and workflows. Turning it off keeps your own memory and per-turn evolution view intact.',
   '你的对话正在参与能力沉淀': 'Your conversations are contributing to capability distillation',
   '查看进化详情': 'View evolution details',
   '本账号促成的能力进化': 'Capabilities your account helped produce',
@@ -557,6 +554,22 @@ export const SETTINGS_DICT: Record<string, string> = {
   '待批准': 'Awaiting approval',
   '来自你的 {n} 次对话': 'from {n} of your conversations',
   '为我启用': 'Enable for me',
+  // Personal approval queue: only changes the user can actually carry out.
+  '查看将要安装的技能正文': 'View the skill document that will be installed',
+  '收起技能正文': 'Hide the skill document',
+  '它会用到的工具': 'Tools it will use',
+  '暂无待你决定的变更': 'Nothing awaiting your decision',
+  '已应用该记忆调整': 'Memory adjustment applied',
+  '操作失败，请稍后重试': 'Action failed — please retry',
+  '这里只列出你能自己决定的变更；影响全体成员的编排调整与能力退役由管理员审批。':
+    'Only changes you can decide on yourself are listed here; orchestration changes and capability retirements affect everyone and are approved by an administrator.',
+  '调整这条记忆的权重': 'Adjust this memory\'s weight',
+  '合并这几条重复记忆': 'Merge these duplicate memories',
+  '记忆': 'Memory',
+  '新增': 'Add',
+  '改写': 'Rewrite',
+  '调权': 'Reweight',
+  '合并': 'Merge',
   '已为你启用该能力': 'Capability enabled for you',
   '启用失败，请稍后重试': 'Could not enable it — please try again',
   '启用后仅对你生效，不影响其他成员；随时可在能力中心停用。':
@@ -666,7 +679,8 @@ export const SETTINGS_DICT: Record<string, string> = {
   '至少保留一项进化机制；如需完全停止，请关闭「启动进化」': 'Keep at least one mechanism. To stop entirely, turn off "Enable evolution".',
   // '启动进化' is shared with the first-run wizard and lives in onboarding.ts;
   // the dictionaries merge into one namespace, so it must not be repeated here.
-  '关闭后系统不再从你的用法中沉淀任何能力；已生成的内容保留': 'When off, the system stops distilling anything from how you work. Whatever it already produced is kept.',
+  '开启后，系统从你的用法中为你沉淀能力，你的对话也会作为证据参与集体能力沉淀；关闭后全部停止，已生成的内容保留':
+    'When on, the system distils capabilities for you from how you work, and your conversations serve as evidence for collective distillation. When off, both stop. Whatever it already produced is kept.',
   '进化机制': 'Evolution mechanisms',
   '选择允许系统为你沉淀哪些类型的能力': 'Choose which kinds of capability the system may distil for you',
   '领域本体关联': 'Domain ontology binding',

--- a/src/frontend/src/styles/evolution.css
+++ b/src/frontend/src/styles/evolution.css
@@ -225,6 +225,51 @@
 .jx-evoApproval-head { display: flex; align-items: center; gap: 8px; }
 .jx-evoApproval-title { font-size: 13px; font-weight: 600; margin-right: auto; overflow-wrap: anywhere; }
 
+/* The concrete change: a skill's body, or the memory ops that will run.
+   Quieter than the headline but selectable, because it is what the user is
+   actually being asked to approve. */
+.jx-evoApproval-change { margin-top: 8px; }
+
+.jx-evoApproval-toggle {
+  border: 0; background: none; padding: 0;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--jx-primary, #2563eb); cursor: pointer;
+}
+.jx-evoApproval-toggle:hover { text-decoration: underline; }
+
+.jx-evoApproval-desc {
+  margin: 6px 0 0; font-size: 12px;
+  color: var(--jx-text-secondary, #6b7280); overflow-wrap: anywhere;
+}
+
+.jx-evoApproval-tools {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+  margin-top: 6px; font-size: 11.5px; color: var(--jx-text-secondary, #6b7280);
+}
+.jx-evoApproval-tools code {
+  padding: 1px 6px; border-radius: 5px;
+  background: var(--jx-surface-2, #f3f4f6); font-size: 11px;
+}
+
+.jx-evoApproval-doc {
+  margin: 8px 0 0; padding: 10px 12px;
+  max-height: 320px; overflow: auto;
+  border: 1px solid var(--jx-border, #e5e7eb); border-radius: 8px;
+  background: var(--jx-surface-2, #fafafa);
+  font-size: 12px; line-height: 1.6; white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.jx-evoApproval-ops { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.jx-evoApproval-ops li {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px;
+  font-size: 12px;
+}
+.jx-evoApproval-opText { color: var(--jx-text, #111827); overflow-wrap: anywhere; }
+.jx-evoApproval-ops em {
+  font-style: normal; font-size: 11.5px; color: var(--jx-text-secondary, #6b7280);
+}
+
 .jx-evoApproval-steps {
   display: flex; flex-wrap: wrap; align-items: center; gap: 4px;
   margin-top: 8px; font-size: 11.5px;


### PR DESCRIPTION
## Problem

The personal approval queue listed every candidate whose evidence came mostly from the signed-in user, and labelled all of them **"enable for me"**. Measured against the real approval path, every row failed on click:

| Row | Result on click |
|---|---|
| memory candidate | `unsupported kind` — `approve_for_user` did not branch on `target_kind` and sent everything to the skill materialiser |
| medium/high risk skill draft | refused: must ramp through replay → shadow → canary |
| orchestration profile | governs a whole task type; no per-user form exists |
| retirement proposal | offered a button to *enable* the capability it argued should be removed |

The admin console had a memory branch; the user-facing path — a Community Edition surface — did not.

## Changes

- **Share one implementation.** The memory branch moves into `core/evolution/memory_apply.apply_memory_candidate`, used by both the user path and the admin console.
- **Offer only what can execute.** `personal_action()` derives eligibility from the code that carries the action out (`activation._entry_stage`, and the `apply_memory_ops` executor whitelist) instead of restating the rules. Memory operations with no executor — `deprecate` — are no longer offered.
- **Show the change.** Each row now carries the concrete content: the full skill document plus its declared tools, or the memory operations with before/after values. Approving a distilled skill previously meant accepting a document the page never displayed.
- **Name the button after what it does**, and state its blast radius.

Participation follows the single evolution switch (`evolution_prefs.enabled`) and defaults to off, so a user who never enabled evolution contributes no evidence. `/v1/evolution/settings` stays as a compatibility shim for already-shipped desktop bundles.

## Also

- Fixes `test_a_missing_licensing_module_reads_as_community`: `importlib.import_module` serves cached modules without consulting `__import__`, so the assertion was vacuous on a warm cache — it passed in isolation and failed only in a full run.
- Adds `scripts/seed_evolution_demo.py` for demonstrations. It writes fabricated records, every one prefixed `demo-`; `--clean` removes exactly those.

## Verification

Every queue row now succeeds:

```
skill /new       "为我启用"          -> evo-industry-chain-mapping-u...
memory/reweight  "调整这条记忆的权重" -> applied=1 refused=0
memory/reweight  "调整这条记忆的权重" -> applied=1 refused=0
memory/merge     "合并这几条重复记忆" -> applied=1 refused=0
```

7 new regression tests pin each defect. Backend suite green.