### PR TITLE
chore(desktop): bump version to 0.2.11

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugagent-desktop",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS/Linux 离线本机服务）",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1687,7 +1687,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hugagent-desktop"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "axum",
  "bytes",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugagent-desktop"
-version = "0.2.10"
+version = "0.2.11"
 description = "HugAgentOS桌面客户端"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HugAgentOS",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "identifier": "com.hugagent.desktop",
   "build": {
     "frontendDist": "../../src/frontend/dist",


### PR DESCRIPTION
Bump the desktop client to 0.2.11 ahead of the next release, which picks up the memory write-governance changes from #53 (pre-write dedup, tiered TTL, expiry sweep, LLM write gate) in the bundled local server.

Synchronizes the five version files via `npm --prefix desktop run version:desktop -- 0.2.11`.