### PR TITLE
feat(evolution): compile skills from layered evidence with L3 graph memory

### DIFF
--- a/document/en/architecture/backend.md
+++ b/document/en/architecture/backend.md
@@ -98,7 +98,7 @@ Enterprise Edition (EE): `team_service` / `team_folder_service` / `sso_sync` (te
 | File | Responsibility |
 |---|---|
 | `profile.py` | L1 profile memory: bounded markdown dossier, frozen and injected at session start |
-| `service.py` | L2/L3 wrapper: mem0 + Milvus vector facts, Neo4j graph (config assembly + async wrapping) |
+| `service.py` / `graph.py` | L2: mem0 + Milvus procedure vectors; L3: local Neo4j graph relations (config assembly + async wrapping) |
 | `pipeline.py` | Post-hoc write pipeline — all memory writes are taken off the SSE hot path |
 | `extractors/` | 4 LLM extractors (identity/preference/fact/task) + `router.py` classification dispatch + `writers.py` persistence fan-out |
 | `sanitizer.py` | Sensitive-data scrubbing gate (rules stored in `memory_sanitizer_rules`) |

--- a/document/en/modules/memory.md
+++ b/document/en/modules/memory.md
@@ -1,8 +1,8 @@
 # Memory System (mem0)
 
-> Last updated: 2026-06-11
+> Last updated: 2026-08-03
 
-HugAgentOS ships with a **layered persistent memory system** built on [mem0](https://github.com/mem0ai/mem0). When enabled, the agent remembers a user's identity, preferences, and **how work is done here** (definitions, orderings, red lines) across sessions, and automatically brings that context into new conversations. Memory is organized into three layers by information stability (L1 profile / L2 procedures / L3 knowledge graph) — all three layers are Community Edition capabilities; only **memory auditing** (compliance trail) belongs to the commercial edition (Enterprise Edition, EE).
+HugAgentOS ships with a **layered persistent memory system**. L2 uses [mem0](https://github.com/mem0ai/mem0) with Milvus, while L3 uses a local adapter that connects directly to Neo4j. When enabled, the agent remembers a user's identity, preferences, **how work is done here** (definitions, orderings, red lines), and stable entity relationships across sessions. Memory is organized into three layers by information stability (L1 profile / L2 procedures / L3 knowledge graph) — all three layers are Community Edition capabilities; only **memory auditing** (compliance trail) belongs to the commercial edition (Enterprise Edition, EE).
 
 The whole system honors one core promise: **no memory I/O ever blocks the SSE hot path** — retrieval runs as a background task with a time budget, and writes go through a bounded post-response pipeline after the SSE stream closes (see the module docstring in `src/backend/core/memory/__init__.py`).
 
@@ -12,7 +12,7 @@ The whole system honors one core promise: **no memory I/O ever blocks the SSE ho
 |---|---|---|---|---|
 | L1 | Profile | DB (bounded markdown, 1500-char default cap) | Frozen into context at session start | `core/memory/profile.py` |
 | L2 | Procedures | Milvus vector store (collection `hugagent_memories`) | Top-K similarity retrieval at session start | `core/memory/service.py` (mem0 wrapper) |
-| L3 | Graph | Neo4j (optional, `MEM0_GRAPH_ENABLED=true`) | On-demand retrieval | `core/memory/service.py` (mem0 `enable_graph`) |
+| L3 | Graph | Neo4j (optional, `MEM0_GRAPH_ENABLED=true`) | Entity-aware on-demand retrieval | `core/memory/graph.py` (local Neo4j adapter) |
 | — | Session working set | `chats.metadata.session_memory` | Within a single session | per-session task working set |
 | — | Audit side channel (Enterprise Edition, EE) | DB table `memory_audit` | Side-recorded on every read/write | `core/memory/audit.py` |
 
@@ -30,7 +30,8 @@ api/routes/v1/chats.py
 orchestration/workflow.py
   ├─► launch_memory_retrieval()            ← background task, returns immediately
   │     └─ core/memory/service.retrieve_memories()
-  │          └─ mem0.Memory.search() → Milvus vector search (+ optional Neo4j graph search)
+  │          ├─ mem0.Memory.search() → Milvus vector search
+  │          └─ core/memory/graph.py → optional Neo4j relation search
   │
   ├─► build_frozen_memory_block()          ← assembles the "session-frozen" block
   │     · L1 profile: DB read, <20ms, always awaited
@@ -48,12 +49,12 @@ orchestration/workflow.py
 save_memories_background()
   └─ core/memory/pipeline.schedule_post_response_tasks()
        · global semaphore caps concurrency (default 8)
-       · classification → runs 0–4 extractors (identity/preference/task by keyword; procedural on every substantive turn)
+       · classification → runs 0–5 extractors (identity/preference/task by keyword; procedural on every substantive turn; graph only when L3 is enabled)
        · each extractor has its own 30s timeout
-       · sanitizer gate → write L1/L2/session → audit side channel
+       · sanitizer gate → write L1/L2/L3/session → audit side channel
 ```
 
-The integration layer for retrieval and injection lives in `src/backend/orchestration/memory_integration.py`; mem0 configuration assembly (LLM / embedder / Milvus / Neo4j / reranker) is in `src/backend/core/memory/service.py` — model configs are resolved from the DB roles `memory` / `embedding` first, falling back to environment variables.
+The integration layer for retrieval and injection lives in `src/backend/orchestration/memory_integration.py`. mem0's LLM / embedder / Milvus / reranker configuration is assembled in `src/backend/core/memory/service.py`, while Neo4j graph reads and writes live in `src/backend/core/memory/graph.py`. Model configs are resolved from the DB roles `memory` / `embedding` first, falling back to environment variables.
 
 ## Write pipeline and extractors
 
@@ -64,7 +65,10 @@ Writes happen only when the user has explicitly enabled `memory_write_enabled` (
 - **Milvus circuit breaker**: after N consecutive failures (default 3) the breaker opens for 60 seconds; retrieval and write paths share the same `milvus_breaker`;
 - **Extractor routing** (`core/memory/extractors/router.py`): `identity`, `preference`, and `task` run only on keyword cues; **`procedural` has no keyword gate** and runs on every substantive turn (user ≥ 8 chars, assistant ≥ 30 chars) — a convention is stated in whatever words the user happened to use, so a regex deciding "no procedure here" before the model reads the turn drops them silently and invisibly. An empty classification skips all LLM calls entirely.
 - **L2 stores procedures, not facts**: a fact starts decaying the moment it is written, so remembering it makes the system confidently recall a stale number instead of looking the current one up. What survives repetition — and what a skill can be compiled from — is how work gets done. There is no fact extractor and no fallback path.
+- **L3 stores stable relationships, not procedures**: its extractor accepts user-asserted or user-confirmed affiliation, responsibility, dependency, use, composition, alias, and classification relationships. Volatile measurements, status, news, and one-off instructions never enter the graph. Repeated observations reinforce the same edge by increasing `seen_count` and refreshing `last_seen_at` instead of creating duplicates.
 - **Writes bypass mem0's own inference**: every write passes `infer=False`. By default mem0 re-judges the text with its generic fact-extraction prompt and can silently discard an already-distilled rule, which surfaces as "the write succeeded and stored nothing" — no error in the log, no entry on the card.
+
+> mem0ai 2.x removed graph-store support from the open-source `Memory` class. The project no longer passes an ignored `graph_store` configuration to mem0; `core/memory/graph.py` uses the existing `neo4j` driver for L3 persistence, retrieval, exact-edge reinforcement, and deletion.
 
 ## Sanitizer gate
 
@@ -99,7 +103,8 @@ Route file: `src/backend/api/routes/v1/memories.py` (registered in the CE router
 | PATCH | `/v1/memories/profile/field` | Edit one L1 profile field |
 | DELETE | `/v1/memories/profile/field` | Delete one L1 profile field |
 | GET | `/v1/memories/profile` | L1 profile (full markdown + char cap) |
-| GET | `/v1/memories/graph` | L3 graph (currently returns enabled status; structured relation queries planned) |
+| GET | `/v1/memories/graph` | L3 relation list; supports `?project_id=` scope |
+| DELETE | `/v1/memories/graph/{relation_id}` | Delete one L3 relation |
 | GET | `/v1/memories/audit` | Audit records (Enterprise Edition, EE) |
 | GET | `/v1/memories/settings` | Read user memory / reranker toggles |
 | PATCH | `/v1/memories/settings` | Update toggles (persisted to `users_shadow.metadata`) |
@@ -191,10 +196,11 @@ See the [environment variable reference](../deployment/environment-variables.md)
 | Path | Responsibility |
 |---|---|
 | `src/backend/core/memory/__init__.py` | Layered memory package entry and public API |
-| `src/backend/core/memory/service.py` | mem0 config assembly and async wrappers (Milvus / Neo4j / reranker) |
+| `src/backend/core/memory/service.py` | mem0 config and async wrappers (Milvus / reranker), plus L3 retrieval merge |
+| `src/backend/core/memory/graph.py` | L3 Neo4j relation persistence, reinforcement, retrieval, and deletion |
 | `src/backend/core/memory/profile.py` | L1 profile: get / patch / compact / delete |
 | `src/backend/core/memory/pipeline.py` | Post-response write pipeline, semaphore, Milvus circuit breaker |
-| `src/backend/core/memory/extractors/` | identity / preference / task / procedural extractors + router |
+| `src/backend/core/memory/extractors/` | identity / preference / task / procedural / graph extractors + router |
 | `src/backend/core/memory/sanitizer.py` | Sanitizer gate (hardcoded + DB-managed rules) |
 | `src/backend/core/memory/audit.py` | Audit side channel (Enterprise Edition, EE) |
 | `src/backend/core/memory/context.py` | `MemoryContext` and workspace / layer resolution |

--- a/document/zh-CN/architecture/backend.md
+++ b/document/zh-CN/architecture/backend.md
@@ -98,7 +98,7 @@ src/backend/
 | 文件 | 职责 |
 |---|---|
 | `profile.py` | L1 画像记忆：有界 markdown 档案，会话启动冻结注入 |
-| `service.py` | L2/L3 封装：mem0 + Milvus 向量事实、Neo4j 图谱（配置组装 + 异步包装） |
+| `service.py` / `graph.py` | L2：mem0 + Milvus 做法向量；L3：本地 Neo4j 图谱关系（配置组装 + 异步包装） |
 | `pipeline.py` | 写入后置流水线——全部记忆写操作剥离出 SSE 主链路 |
 | `extractors/` | 4 个 LLM 抽取器（identity/preference/fact/task）+ `router.py` 分类调度 + `writers.py` 落盘分发 |
 | `sanitizer.py` | 敏感数据脱敏闸门（规则存 `memory_sanitizer_rules` 表） |

--- a/document/zh-CN/modules/memory.md
+++ b/document/zh-CN/modules/memory.md
@@ -1,8 +1,8 @@
 # 记忆系统（mem0）
 
-> 最后更新：2026-06-11
+> 最后更新：2026-08-03
 
-HugAgentOS 内置一套**分层持久记忆系统**，基于 [mem0](https://github.com/mem0ai/mem0) 构建：开启后，智能体能跨会话记住用户的身份背景、偏好习惯，以及**这里做事的方式**（口径、顺序、红线），并在新会话中自动带入这些上下文。记忆按信息稳定性分为三层（L1 档案 / L2 做法沉淀 / L3 知识图谱），三层均属社区版能力；只有**记忆审计**（合规留痕）属于商业版（商业版 EE）。
+HugAgentOS 内置一套**分层持久记忆系统**：L2 向量层使用 [mem0](https://github.com/mem0ai/mem0) + Milvus，L3 图谱层由本地适配器直连 Neo4j。开启后，智能体能跨会话记住用户的身份背景、偏好习惯、**这里做事的方式**（口径、顺序、红线），以及稳定的实体关系。记忆按信息稳定性分为三层（L1 档案 / L2 做法沉淀 / L3 知识图谱），三层均属社区版能力；只有**记忆审计**（合规留痕）属于商业版（商业版 EE）。
 
 整套系统遵循一条核心承诺：**所有记忆 I/O 绝不在 SSE 主链路上同步等待**——检索走带预算超时的后台任务，写入走 SSE 关闭后的有界后置流水线（见 `src/backend/core/memory/__init__.py` 模块文档）。
 
@@ -12,7 +12,7 @@ HugAgentOS 内置一套**分层持久记忆系统**，基于 [mem0](https://gith
 |---|---|---|---|---|
 | L1 | Profile 用户档案 | DB（bounded markdown，默认上限 1500 字符） | 会话启动时冻结注入 | `core/memory/profile.py` |
 | L2 | Procedural 做法沉淀 | Milvus 向量库（collection `hugagent_memories`） | 会话启动时按相似度检索 Top-K 注入 | `core/memory/service.py`（mem0 封装） |
-| L3 | Graph 图谱记忆 | Neo4j（可选，`MEM0_GRAPH_ENABLED=true`） | 按需检索 | `core/memory/service.py`（mem0 `enable_graph`） |
+| L3 | Graph 图谱记忆 | Neo4j（可选，`MEM0_GRAPH_ENABLED=true`） | 按实体按需检索 | `core/memory/graph.py`（本地 Neo4j 适配器） |
 | — | Session 辅助层 | `chats.metadata.session_memory` | 单会话内 | 会话任务工作集 |
 | — | Audit 审计旁路（商业版 EE） | DB 表 `memory_audit` | 所有读写旁路记录 | `core/memory/audit.py` |
 
@@ -30,7 +30,8 @@ api/routes/v1/chats.py
 orchestration/workflow.py
   ├─► launch_memory_retrieval()            ← 后台 task，立即返回（不阻塞）
   │     └─ core/memory/service.retrieve_memories()
-  │          └─ mem0.Memory.search() → Milvus 向量检索（+ Neo4j 图检索，可选）
+  │          ├─ mem0.Memory.search() → Milvus 向量检索
+  │          └─ core/memory/graph.py → Neo4j 实体关系检索（可选）
   │
   ├─► build_frozen_memory_block()          ← 组装"会话冻结块"
   │     · L1 Profile：读 DB，<20ms，必等
@@ -47,12 +48,12 @@ orchestration/workflow.py
 save_memories_background()
   └─ core/memory/pipeline.schedule_post_response_tasks()
        · 全局 Semaphore 限并发（默认 8）
-       · 分类 → 跑 0~4 个 extractor（identity/preference/task 关键词命中；procedural 每个实质轮次都跑）
+       · 分类 → 跑 0~5 个 extractor（identity/preference/task 关键词命中；procedural 每个实质轮次都跑；graph 仅在 L3 开启时跑）
        · 每个 extractor 单独 30s 超时
-       · sanitize 脱敏闸门 → 写 L1/L2/Session → audit 旁路
+       · sanitize 脱敏闸门 → 写 L1/L2/L3/Session → audit 旁路
 ```
 
-检索与注入的整合层在 `src/backend/orchestration/memory_integration.py`；mem0 配置组装（LLM / Embedder / Milvus / Neo4j / Reranker）在 `src/backend/core/memory/service.py`，模型配置优先取 DB 中 `memory` / `embedding` 角色，缺省回落到环境变量。
+检索与注入的整合层在 `src/backend/orchestration/memory_integration.py`；mem0 的 LLM / Embedder / Milvus / Reranker 配置在 `src/backend/core/memory/service.py`，Neo4j 图谱读写在 `src/backend/core/memory/graph.py`。模型配置优先取 DB 中 `memory` / `embedding` 角色，缺省回落到环境变量。
 
 ## 写入流水线与抽取器
 
@@ -63,7 +64,10 @@ save_memories_background()
 - **Milvus 熔断器**：连续失败 N 次（默认 3）后短路 60 秒，检索 / 写入路径共用（`milvus_breaker`）；
 - **抽取器路由**（`core/memory/extractors/router.py`）：`identity`（身份）、`preference`（偏好）、`task`（任务）按关键词线索命中才跑；**`procedural`（做法）不设关键词闸门**，只要本轮实质（用户 ≥8 字且助手 ≥30 字）就跑——一条约定用什么措辞说出来是不可预测的，正则在模型读到之前就替它决定"这轮没有做法"，漏掉的部分既无声也不可见。空集则直接跳过所有 LLM 调用。
 - **L2 只存做法，不存事实**：事实写下来的那一刻就开始过期，记住它等于让系统自信地复述一个陈旧数字，而不是去查当前值；能被重复使用、且能进一步编译成技能的，只有"这里怎么做事"。因此没有 fact 抽取器，也没有回退路径。
+- **L3 只存稳定关系，不存步骤**：图谱抽取器只接受用户明确陈述或确认的隶属、负责、依赖、使用、组成、别名、分类等实体关系；快速变化的数值、状态、新闻以及一次性指令均拒绝入图。相同关系再次出现时增加 `seen_count` 并刷新 `last_seen_at`，不会复制边。
 - **写入不经 mem0 二次推断**：写入统一带 `infer=False`。mem0 默认会用它自己的通用事实抽取 prompt 再判一次，把我们已经蒸馏好的规则悄悄丢掉——表现为"写入成功但什么都没写"，日志无错、卡片无内容。
+
+> mem0ai 2.x 已从开源 `Memory` 类移除 graph store。项目不再向 mem0 传入会被忽略的 `graph_store` 配置，而由 `core/memory/graph.py` 使用既有 `neo4j` 驱动完成 L3 的抽取后写入、查询、去重强化和删除。
 
 ## 脱敏闸门（sanitizer）
 
@@ -98,7 +102,8 @@ save_memories_background()
 | PATCH | `/v1/memories/profile/field` | 改写 L1 档案的单个字段 |
 | DELETE | `/v1/memories/profile/field` | 删除 L1 档案的单个字段 |
 | GET | `/v1/memories/profile` | L1 用户档案（markdown 全文 + 字符上限） |
-| GET | `/v1/memories/graph` | L3 图谱（当前返回 enabled 状态，结构化关系查询待后续版本） |
+| GET | `/v1/memories/graph` | L3 图谱关系列表；支持 `?project_id=` 项目作用域 |
+| DELETE | `/v1/memories/graph/{relation_id}` | 删除单条 L3 图谱关系 |
 | GET | `/v1/memories/audit` | 审计记录（商业版 EE） |
 | GET | `/v1/memories/settings` | 读用户记忆 / 重排开关 |
 | PATCH | `/v1/memories/settings` | 更新开关（持久化到 `users_shadow.metadata`） |
@@ -190,10 +195,11 @@ RERANKER_API_KEY=...
 | 路径 | 职责 |
 |---|---|
 | `src/backend/core/memory/__init__.py` | 分层记忆包入口与公共 API |
-| `src/backend/core/memory/service.py` | mem0 配置组装与异步封装（Milvus / Neo4j / Reranker） |
+| `src/backend/core/memory/service.py` | mem0 配置组装与异步封装（Milvus / Reranker）+ L3 检索合流 |
+| `src/backend/core/memory/graph.py` | L3 Neo4j 图谱关系的写入、强化、查询与删除 |
 | `src/backend/core/memory/profile.py` | L1 档案：get / patch / compact / delete |
 | `src/backend/core/memory/pipeline.py` | 后置写入流水线、信号量、Milvus 熔断器 |
-| `src/backend/core/memory/extractors/` | identity / preference / task / procedural 抽取器 + 路由 |
+| `src/backend/core/memory/extractors/` | identity / preference / task / procedural / graph 抽取器 + 路由 |
 | `src/backend/core/memory/sanitizer.py` | 脱敏闸门（硬编码规则 + DB 动态规则） |
 | `src/backend/core/memory/audit.py` | 审计旁路（商业版 EE） |
 | `src/backend/core/memory/context.py` | `MemoryContext` 与 workspace / 层级解析 |

--- a/src/backend/api/routes/v1/memories.py
+++ b/src/backend/api/routes/v1/memories.py
@@ -8,6 +8,7 @@ GET    /v1/memories/settings        get the user's memory settings
 PATCH  /v1/memories/settings        update the user's memory settings (switches)
 PATCH  /v1/memories/profile/field   edit one L1 profile field
 DELETE /v1/memories/profile/field   delete one L1 profile field
+DELETE /v1/memories/graph/{id}      delete one L3 graph relation
 DELETE /v1/memories                 clear all L2 memories
 PATCH  /v1/memories/{id}            edit a single L2 memory
 DELETE /v1/memories/{id}            delete a single L2 memory
@@ -25,15 +26,11 @@ from core.config.settings import settings as _jx_settings
 from core.db.engine import get_db
 from core.infra.responses import error_response, success_response
 from core.memory.context import MemoryContext
+from core.memory.graph import delete_graph_relation, list_graph_relations
 from core.memory.profile import delete_field as profile_delete_field
 from core.memory.profile import get as profile_get
 from core.memory.profile import upsert_field as profile_upsert_field
-from core.memory.service import (
-    delete_all_memories,
-    delete_memory,
-    get_all_memories,
-    update_memory,
-)
+from core.memory.service import delete_all_memories, delete_memory, get_all_memories, update_memory
 from core.services import UserService
 from core.services.memory_settings_service import MemorySettingsService
 from fastapi import APIRouter, Depends, Query
@@ -286,6 +283,26 @@ async def remove_profile_field(
     return success_response(data={"deleted": key})
 
 
+# ── L3 graph: one relation at a time ──────────────────────────────────────
+
+
+@router.delete("/graph/{relation_id}", summary="删除单条图谱关系")
+async def remove_graph_relation(
+    relation_id: str,
+    message_id: Optional[str] = Query(None, description="上报该关系的消息 id"),
+    user: UserContext = Depends(get_current_user),
+):
+    """删除当前用户默认作用域中的一条 L3 关系。"""
+    ok = await delete_graph_relation(relation_id, scope_user_id=str(user.user_id))
+    if not ok:
+        return error_response(code=50001, message="删除失败", status_code=500)
+    if message_id:
+        from core.evolution.settlement_store import drop_entry
+
+        drop_entry(message_id, relation_id)
+    return success_response(data={"deleted": relation_id})
+
+
 # ── L2 procedures: one entry at a time ────────────────────────────────────
 
 
@@ -404,15 +421,35 @@ async def list_memory_audit(
 
 @router.get("/graph", summary="查询图谱记忆")
 async def get_memory_graph(
-    user: UserContext = Depends(get_current_user),
     limit: int = Query(30, ge=1, le=200, description="返回关系条数"),
+    project_id: Optional[str] = Query(None, description="若指定，返回该项目作用域的关系"),
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    """L3 图谱记忆：当前用户的实体关系（Neo4j）。
-
-    当前返回 `enabled` 状态 + 空 relations 列表。结构化 graph 查询需要 service 层
-    暴露 `mem0.Memory.search(filters={"graph_only": True})`，下轮实现；前端 Tab 以
-    `enabled` 字段决定显示占位或关系。
-    """
+    """L3 图谱记忆：当前用户或项目作用域的实体关系（Neo4j）。"""
     if not (_jx_settings.memory.enabled and _jx_settings.memory.graph_enabled):
         return success_response(data={"enabled": False, "relations": [], "count": 0})
-    return success_response(data={"enabled": True, "relations": [], "count": 0})
+
+    scope_user_id = str(user.user_id)
+    workspace_id = "default"
+    if project_id:
+        from core.services.project_scope import project_memory_policy
+
+        policy = project_memory_policy(db, project_id, scope_user_id)
+        if policy is None:
+            return success_response(data={"enabled": False, "relations": [], "count": 0})
+        ws_enabled, scope_user_id = policy
+        if not ws_enabled:
+            return success_response(data={"enabled": False, "relations": [], "count": 0})
+        workspace_id = f"project:{project_id}"
+    else:
+        user_settings = UserService(db).get_user_settings(str(user.user_id))
+        if not bool(user_settings.get("memory_enabled", False)):
+            return success_response(data={"enabled": False, "relations": [], "count": 0})
+
+    relations = await list_graph_relations(
+        scope_user_id,
+        workspace_id=workspace_id,
+        limit=limit,
+    )
+    return success_response(data={"enabled": True, "relations": relations, "count": len(relations)})

--- a/src/backend/core/db/models/evolution.py
+++ b/src/backend/core/db/models/evolution.py
@@ -154,6 +154,10 @@ class EvolutionCandidate(Base):
     change_checksum = Column(String(64), nullable=False)
 
     evidence_refs = Column(JSONType, default=list)
+    # The immutable, content-addressed evidence pack this candidate was compiled
+    # from (``evolution_evidence_packs``). ``evidence_refs`` stays as the quick
+    # display list; the pack is the authoritative, resolvable evidence.
+    evidence_pack_id = Column(String(64), index=True)
     credit_decision = Column(JSONType)
     risk_tier = Column(String(16), default="medium", nullable=False)
     scope = Column(JSONType, default=dict)
@@ -309,6 +313,97 @@ class EvolutionAgentProfile(Base):
 
     __table_args__ = (
         Index("idx_evolution_profiles_active", "is_active", "updated_at"),
+    )
+
+
+class EvolutionEvidencePack(Base):
+    """One immutable, content-addressed evidence pack (compiler V2, P1).
+
+    ``pack_id`` is derived from the pack's canonical content, so resolving the
+    same evidence twice yields the same row — which is what stops repeated
+    cycles from minting duplicate candidates, and what makes "which exact
+    evidence was this skill compiled from?" answerable years later. Rows are
+    never updated; a different pack is a different row.
+    """
+
+    __tablename__ = "evolution_evidence_packs"
+
+    pack_id = Column(String(64), primary_key=True)
+    schema_version = Column(String(8), nullable=False, default="2")
+    pack_hash = Column(String(80), nullable=False)
+    scope = Column(JSONType, default=dict)
+    pack = Column(JSONType, nullable=False)
+    support = Column(JSONType, default=dict)
+    created_at = Column(TIMESTAMP(timezone=True), default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("pack_hash", name="uq_evolution_evidence_packs_hash"),
+        Index("idx_evolution_evidence_packs_created", "created_at"),
+    )
+
+
+class EvolutionCreditDecision(Base):
+    """One persisted attribution verdict.
+
+    ``CreditDecision`` used to be a runtime object only: the candidate stored a
+    JSON copy, but "why did this cycle blame L2 rather than L3?" could not be
+    answered for decisions that produced nothing. Persisting every decision that
+    reaches the candidate builder is what makes attribution auditable, and
+    candidates reference the decision id rather than owning the only copy.
+    """
+
+    __tablename__ = "evolution_credit_decisions"
+
+    decision_id = Column(String(64), primary_key=True)
+    episode_id = Column(String(64), index=True)
+    selected = Column(String(32), nullable=False, default="no_update")
+    verdict = Column(String(32), default="")
+    confidence = Column(Float, default=0.0)
+    scores = Column(JSONType, default=dict)
+    features = Column(JSONType, default=dict)
+    explanation = Column(Text, default="")
+    assigner_version = Column(String(32), default="")
+    created_at = Column(TIMESTAMP(timezone=True), default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("idx_evolution_credit_selected", "selected", "created_at"),
+    )
+
+
+class EvolutionPromotionLink(Base):
+    """One edge of the promotion lineage graph.
+
+    First-class rather than derived, because the questions it answers span
+    tables that each know only their own side: which L2 memories a skill was
+    compiled from (``compiled_from``), which L3 relations bound it
+    (``constrained_by``), which episodes validated it (``validated_by``),
+    which profile assembled it (``assembled_into``), and where a rollback went
+    (``rolled_back_to``).
+    """
+
+    __tablename__ = "evolution_promotion_links"
+
+    link_id = Column(String(64), primary_key=True)
+    source_kind = Column(String(24), nullable=False)
+    source_id = Column(String(160), nullable=False)
+    relation = Column(String(32), nullable=False)
+    target_kind = Column(String(24), nullable=False)
+    target_id = Column(String(160), nullable=False)
+    candidate_id = Column(String(64), index=True)
+    created_at = Column(TIMESTAMP(timezone=True), default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        # One fact, one row — re-materialising must not duplicate the lineage.
+        UniqueConstraint(
+            "source_kind",
+            "source_id",
+            "relation",
+            "target_kind",
+            "target_id",
+            name="uq_evolution_promotion_links_edge",
+        ),
+        Index("idx_evolution_promotion_links_target", "target_kind", "target_id"),
+        Index("idx_evolution_promotion_links_source", "source_kind", "source_id"),
     )
 
 

--- a/src/backend/core/evolution/activation.py
+++ b/src/backend/core/evolution/activation.py
@@ -519,6 +519,7 @@ def materialise_skill_candidate(
         tools: List[str] = []
         constraints: List[Dict[str, Any]] = []
         document: Optional[Dict[str, Any]] = None
+        manifest: Optional[Dict[str, Any]] = None
         # ref → owning user. Demotion happens inside one person's store, so a
         # skill compiled from several people's memories needs the owner of each.
         source_memories: Dict[str, str] = {}
@@ -532,9 +533,20 @@ def materialise_skill_candidate(
             written = change.get("document")
             if isinstance(written, dict) and written.get("content"):
                 document = written
+            declared = change.get("manifest")
+            if isinstance(declared, dict) and declared:
+                manifest = declared
             for item in change.get("source_memories") or []:
                 if isinstance(item, dict) and item.get("ref"):
                     source_memories[str(item["ref"])] = str(item.get("user_id") or "")
+
+        # 图谱证据自相矛盾的候选可以存在、可以进 shadow 观测，但不允许自动
+        # 走到 ACTIVE：冲突意味着「适用条件」本身不可信，必须先由人裁决。
+        if manifest and manifest.get("graph_conflict") and stage == ACTIVE:
+            raise ActivationError(
+                "graph_conflict_requires_review",
+                f"L3 图谱证据存在冲突，禁止直接激活：{manifest.get('graph_conflicts')}",
+            )
 
         skill_id = candidate.target_asset_id
         if not skill_id.startswith(EVOLUTION_PREFIX):
@@ -634,13 +646,25 @@ def materialise_skill_candidate(
         row.version = _next_version(previous)
         row.tags = sorted(set((previous or {}).get("tags", [])) | {EVOLUTION_TAG})
         # The distilled ordering, in the shape the runtime reads.
-        row.extra_files = {
+        extra_files = {
             **(previous or {}).get("extra_files", {}),
             "tool_sequence.json": _json(tools),
             # The transferable part. A consumer that only understands sequences
             # still works; one that understands rules gets the wider benefit.
             "ordering_constraints.json": _json(constraints),
         }
+        if manifest:
+            # 机器读 manifest（边界/依赖/证据引用），Agent 读 SKILL.md —— 两者
+            # 职责分离。作用域以本次激活实际发生的为准，而不是候选申报的。
+            extra_files["evolution_manifest.json"] = _json(
+                {
+                    **manifest,
+                    "scope": "personal" if owner_user_id else str(
+                        manifest.get("scope") or "workspace"
+                    ),
+                }
+            )
+        row.extra_files = extra_files
         row.allowed_tools = tools
         row.is_enabled = True
 
@@ -731,6 +755,29 @@ def materialise_skill_candidate(
             )
             demoted.extend(op["memory_ref"] for op in outcome.get("applied", []))
 
+    # 血缘落账：这一版技能由哪些 L2 记忆编译（compiled_from）、被哪些 L3 关系
+    # 约束（constrained_by）、由哪些 Episode 验证（validated_by）。尽力而为——
+    # 账本失败绝不回滚一次已经成立的激活。
+    lineage_written = 0
+    try:
+        from core.evolution import lineage
+
+        with SessionLocal() as db:
+            refreshed = db.get(EvolutionCandidate, candidate_id)
+            pack_id = str(getattr(refreshed, "evidence_pack_id", "") or "")
+        pack = lineage.load_evidence_pack(pack_id) if pack_id else None
+        if pack is not None:
+            lineage_written = len(
+                lineage.record_links(
+                    lineage.links_for_skill(
+                        pack, skill_id=skill_id, skill_version=new_version
+                    ),
+                    candidate_id=candidate_id,
+                )
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[activation] lineage recording skipped: %s", exc)
+
     return {
         "skill_id": skill_id,
         "release_id": release_id,
@@ -738,6 +785,7 @@ def materialise_skill_candidate(
         "traffic_percent": traffic,
         "scope": scope_filter,
         "demoted_memories": demoted,
+        "lineage_links": lineage_written,
         # Spelled out because "activated" previously implied "live for
         # everyone", and for anything above low risk it no longer does.
         "exposed_to": (
@@ -851,6 +899,13 @@ def advance_skill_release(
             raise ActivationError("promotion_refused", reason)
 
         if target_stage == ACTIVE:
+            # 冲突的 L3 证据在 shadow/canary 里观测没问题，但升到全量必须先由
+            # 人裁决冲突本身——适用条件不可信的技能不配自动放大到所有人。
+            if _has_graph_conflict(candidate):
+                raise ActivationError(
+                    "graph_conflict_requires_review",
+                    "候选的 L3 图谱证据存在未裁决的冲突，禁止放量到 active",
+                )
             _check_pace(db, tenant_id=str((release.scope_filter or {}).get("tenant_id") or "default"))
 
         release.stage = target_stage
@@ -884,6 +939,17 @@ def advance_skill_release(
         }
 
 
+def _has_graph_conflict(candidate) -> bool:
+    """Whether the candidate's manifest flags contradictory L3 evidence."""
+    if candidate is None:
+        return False
+    for change in (getattr(candidate, "ir", None) or {}).get("changes") or []:
+        manifest = change.get("manifest") if isinstance(change, dict) else None
+        if isinstance(manifest, dict) and manifest.get("graph_conflict"):
+            return True
+    return False
+
+
 def rollback_skill_activation(
     release_id: str, *, actor: str, reason: str, kind: str = "manual"
 ) -> Dict[str, Any]:
@@ -898,7 +964,11 @@ def rollback_skill_activation(
     which is the number that tells you whether the ramp is worth its cost.
     """
     from core.db.models import AdminSkill
-    from core.db.models.evolution import EvolutionCandidate, EvolutionRelease
+    from core.db.models.evolution import (
+        EvolutionAgentProfile,
+        EvolutionCandidate,
+        EvolutionRelease,
+    )
     from core.evolution.release import ROLLBACK_GUARDRAIL, ROLLBACK_MANUAL, ROLLED_BACK
 
     if not actor or not reason:
@@ -910,11 +980,13 @@ def rollback_skill_activation(
             raise ActivationError("release_not_found", f"发布记录不存在: {release_id}")
 
         previous = (release.guardrails or {}).get("previous")
+        skill_id = release.target_asset_id
         row = (
             db.query(AdminSkill)
-            .filter(AdminSkill.skill_id == release.target_asset_id)
+            .filter(AdminSkill.skill_id == skill_id)
             .first()
         )
+        invalidated: List[str] = []
         if row is not None:
             if previous:
                 row.skill_content = previous["skill_content"]
@@ -927,6 +999,20 @@ def rollback_skill_activation(
                 row.is_enabled = previous["is_enabled"]
             else:
                 row.is_enabled = False
+                # No prior version means the skill just stopped being loadable,
+                # so a profile assembled on top of it is now promising a
+                # capability that fails silently — same cross-layer rule as
+                # retirement. With a restored prior version the skill stays
+                # loadable and the profiles stay valid.
+                for profile_row in (
+                    db.query(EvolutionAgentProfile)
+                    .filter(EvolutionAgentProfile.is_active.is_(True))
+                    .all()
+                ):
+                    payload = profile_row.payload or {}
+                    if skill_id in (payload.get("skill_ids") or []):
+                        profile_row.is_active = False
+                        invalidated.append(profile_row.profile_id)
 
         release.stage = ROLLED_BACK
         release.rolled_back_at = datetime.now(timezone.utc)
@@ -938,11 +1024,50 @@ def rollback_skill_activation(
         candidate = db.get(EvolutionCandidate, release.candidate_id)
         if candidate is not None:
             candidate.status = ROLLED_BACK
+        candidate_id = release.candidate_id
         db.commit()
 
+    # The reverse edge of the promotion chain. Materialisation down-weighted the
+    # memories this skill was compiled from; rolling the skill back must restore
+    # them in the same motion, or the knowledge stays half-priced with no
+    # carrier — retrieval skips it because a skill supposedly covers it, and the
+    # skill is gone. Same ledger the retire path already replays.
+    from core.evolution.memory_apply import revert_memory_ops
+
+    restored = revert_memory_ops(candidate_id=candidate_id) if candidate_id else {}
+
+    # 血缘：这一版回滚到了哪一版。审计问「技能 v2 后来怎么了」时，答案在链上。
+    try:
+        from core.evolution import lineage
+
+        current_version = str((previous or {}).get("version") or "")
+        lineage.record_links(
+            [
+                (
+                    "skill",
+                    f"{skill_id}@rolled_back",
+                    lineage.REL_ROLLED_BACK_TO,
+                    "skill",
+                    f"{skill_id}@{current_version or 'disabled'}",
+                )
+            ],
+            candidate_id=candidate_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[activation] rollback lineage skipped: %s", exc)
+
+    logger.info(
+        "[activation] rolled back %s (release=%s memories restored=%d profiles invalidated=%s)",
+        skill_id,
+        release_id,
+        len(restored.get("reverted", [])),
+        invalidated,
+    )
     return {
         "release_id": release_id,
         "restored_previous": bool(previous),
+        "restored_memory_ops": restored.get("reverted", []),
+        "invalidated_profiles": invalidated,
         "reason": reason,
     }
 
@@ -1105,6 +1230,26 @@ def materialise_profile_candidate(
         candidate.approved_by = approver
         candidate.approved_at = datetime.now(timezone.utc)
         db.commit()
+
+        # 血缘：哪些技能被装配进了这个 profile。
+        try:
+            from core.evolution import lineage
+
+            lineage.record_links(
+                [
+                    (
+                        "skill",
+                        str(skill_id),
+                        lineage.REL_ASSEMBLED_INTO,
+                        "agent_profile",
+                        f"{profile.profile_id}@{profile.version}",
+                    )
+                    for skill_id in profile.skill_ids
+                ],
+                candidate_id=candidate_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[activation] profile lineage skipped: %s", exc)
 
         logger.info(
             "[activation] profile %s active for %s (tools=%s skills=%s)",

--- a/src/backend/core/evolution/applicability.py
+++ b/src/backend/core/evolution/applicability.py
@@ -1,0 +1,156 @@
+"""运行时 L3 适用性判断 + Replay 覆盖要求（P4）.
+
+manifest 是技能的机器可读边界：``applies_when`` / ``excludes_when`` /
+``dependencies`` 全部由 L3 证据编译而来。这里回答两个问题：
+
+* **运行时**：当前这次请求，这个技能适不适用？——排除条件命中即不适用；
+  声明了图谱依赖且依赖检查器可用时，依赖失效即不适用。检查是 fail-open 的：
+  拿不到上下文（没有 task_type、图谱不可达）时不拦，因为误拦一个可用技能
+  是能力损失，而技能被打开后还有正文的「不适用范围」兜底。
+* **回放时**：候选的回放集覆不覆盖它声称的行为面？——只用成功案例回放，
+  验证不了失败恢复；没有负样本，验证不了边界。覆盖不足的候选停在 draft，
+  而不是带着单面证据进入 shadow。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILE = "evolution_manifest.json"
+
+
+def load_manifest(extra_files: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The manifest from an ``AdminSkill.extra_files`` mapping, or ``None``."""
+    raw = (extra_files or {}).get(MANIFEST_FILE)
+    if not raw:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(str(raw))
+        return parsed if isinstance(parsed, dict) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def manifest_permits(
+    manifest: Optional[Dict[str, Any]],
+    *,
+    task_type: Optional[str] = None,
+    relation_active: Optional[Callable[[str], Optional[bool]]] = None,
+) -> Tuple[bool, str]:
+    """Whether a skill's manifest permits use in the current context.
+
+    ``relation_active(relation_id)`` is injected (usually a Neo4j lookup) and
+    may return ``None`` for "could not tell", which never blocks — only a
+    definite ``False`` does. No manifest means a hand-authored or pre-manifest
+    skill: always permitted, this gate governs only what evolution wrote.
+    """
+    if not manifest:
+        return True, "no_manifest"
+
+    if task_type:
+        for exclude in manifest.get("excludes_when") or []:
+            excluded = str(exclude.get("task_type") or "")
+            if excluded and excluded == task_type:
+                return False, f"excluded_task_type:{task_type}"
+
+        applies_types = [
+            str(entry.get("task_type") or "")
+            for entry in manifest.get("applies_when") or []
+            if entry.get("task_type")
+        ]
+        if applies_types and task_type not in applies_types:
+            return False, f"outside_declared_task_types:{task_type}"
+
+    if relation_active is not None:
+        for dependency in manifest.get("dependencies") or []:
+            relation_id = str(dependency.get("relation_id") or "")
+            if not relation_id:
+                continue
+            state = relation_active(relation_id)
+            if state is False:
+                # L3 说这个技能依赖某个实体关系；关系已失效 → 技能不适用。
+                return False, f"dependency_inactive:{relation_id}"
+
+    return True, "permitted"
+
+
+def filter_by_manifest(
+    skill_manifests: Dict[str, Optional[Dict[str, Any]]],
+    *,
+    task_type: Optional[str] = None,
+    relation_active: Optional[Callable[[str], Optional[bool]]] = None,
+) -> List[str]:
+    """Of ``{skill_id: manifest}``, the ids permitted in this context."""
+    permitted: List[str] = []
+    for skill_id, manifest in skill_manifests.items():
+        ok, reason = manifest_permits(
+            manifest, task_type=task_type, relation_active=relation_active
+        )
+        if ok:
+            permitted.append(skill_id)
+        else:
+            logger.info("[applicability] %s withheld: %s", skill_id, reason)
+    return permitted
+
+
+# ── Replay coverage ──────────────────────────────────────────────────────────
+
+
+def assess_replay_coverage(
+    pack: Any,
+    task_ids: Sequence[str],
+) -> Dict[str, Any]:
+    """Whether a replay set covers what the pack claims. ``pack`` is a
+    :class:`~core.evolution.evidence_contract.CapabilityEvidencePackV2`.
+
+    Required, each only when the pack actually contains that class of evidence:
+
+    * ≥1 成功 Episode（有效性的最低门槛）；
+    * pack 带失败恢复 → 回放集必须含失败 Episode；
+    * pack 带负样本 → 回放集必须含负样本 Episode；
+    * pack 的 L3 证据带依赖 → 回放集须同时覆盖「用到图谱」与「没用图谱」
+      两类场景（当证据里两类都存在时）。
+    """
+    chosen = {str(t) for t in task_ids}
+    missing: List[str] = []
+
+    episodes = list(getattr(pack, "episodes", []) or [])
+    by_id = {str(e.get("episode_id") or ""): e for e in episodes}
+    selected = [by_id[t] for t in chosen if t in by_id]
+
+    if not any(e.get("verdict") == "success" for e in selected):
+        missing.append("success_episode")
+
+    failure_ids = {
+        str(f.get("episode_id") or "")
+        for f in getattr(pack, "failure_recoveries", []) or []
+    } - {""}
+    if failure_ids and not (failure_ids & chosen):
+        missing.append("failure_recovery_episode")
+
+    negative_ids = {
+        str(n.get("episode_id") or "")
+        for n in getattr(pack, "negative_examples", []) or []
+    } - {""}
+    if negative_ids and not (negative_ids & chosen):
+        missing.append("negative_example_episode")
+
+    has_dependency = any(
+        str(r.get("role") or "") in ("dependency", "constraint")
+        for r in getattr(pack, "graph_context", []) or []
+    )
+    if has_dependency:
+        with_graph = {e["episode_id"] for e in episodes if e.get("used_graph")}
+        without_graph = {e["episode_id"] for e in episodes if not e.get("used_graph")}
+        if with_graph and not (with_graph & chosen):
+            missing.append("graph_dependency_episode")
+        if without_graph and not (without_graph & chosen):
+            missing.append("no_graph_dependency_episode")
+
+    return {"covered": not missing, "missing": missing}

--- a/src/backend/core/evolution/evidence_contract.py
+++ b/src/backend/core/evolution/evidence_contract.py
@@ -1,0 +1,383 @@
+"""分层证据契约 — 技能编译器 V2 的数据面（Layered-evidence skill compiler, P1）.
+
+一个技能候选从四类证据编译而来，四类证据各自决定技能的不同部分，且**只能**
+决定那一部分：
+
+* **L1 profile** — 个性化表现。只进策略引用（policy pointer），原始内容永远
+  不进入共享技能；个性化在运行时由 L1 绑定。
+* **L2 procedure** — 步骤、检查点、失败恢复。它不能独自决定适用范围。
+* **L3 graph** — 适用条件、依赖、约束、排除、别名。它永远不能变成执行步骤：
+  ``GRAPH_ROLES`` 是封闭集合，没有 ``step``，这是结构上防止图谱事实被误编译
+  成 SOP 的地方。
+* **Episode** — 有效性。成功率、真实工具序列、失败案例。单次成功只进观察池。
+
+Pack 是**内容寻址、不可变**的：同一份证据重复解析产生同一个 ``pack_id``，
+所以重复运行不会重复创建候选，而任何激活技能都能沿着 pack 反查到准确的
+L2 / L3 / Episode 标识。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Sequence
+
+PACK_SCHEMA_VERSION = "2"
+MANIFEST_SCHEMA_VERSION = "2"
+
+# ── Evidence layers ──────────────────────────────────────────────────────────
+
+LAYER_PROFILE = "profile"
+LAYER_PROCEDURE = "procedure"
+LAYER_GRAPH = "graph"
+LAYER_EPISODE = "episode"
+EVIDENCE_LAYERS = (LAYER_PROFILE, LAYER_PROCEDURE, LAYER_GRAPH, LAYER_EPISODE)
+
+# ── Graph roles: what an L3 relation may contribute to a skill ───────────────
+# A closed set, and ``step`` is deliberately absent: a graph fact may bound
+# where a skill applies, never tell the agent what to do.
+
+ROLE_APPLICABILITY = "applicability"
+ROLE_DEPENDENCY = "dependency"
+ROLE_CONSTRAINT = "constraint"
+ROLE_EXCLUSION = "exclusion"
+ROLE_ALIAS = "alias"
+GRAPH_ROLES = frozenset(
+    {ROLE_APPLICABILITY, ROLE_DEPENDENCY, ROLE_CONSTRAINT, ROLE_EXCLUSION, ROLE_ALIAS}
+)
+
+# How a predicate defaults into a role when the resolver has nothing better.
+_PREDICATE_ROLE = {
+    "depends_on": ROLE_DEPENDENCY,
+    "uses": ROLE_DEPENDENCY,
+    "requires": ROLE_DEPENDENCY,
+    "constrained_by": ROLE_CONSTRAINT,
+    "alias_of": ROLE_ALIAS,
+}
+
+
+def role_for_predicate(predicate: str) -> str:
+    return _PREDICATE_ROLE.get(str(predicate or "").strip().lower(), ROLE_APPLICABILITY)
+
+
+# ── EvidenceRef ──────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """统一证据引用：任何层的一条证据，都能被稳定反查。
+
+    ``external_id`` 是所属存储自己的稳定 id（Episode id / mref_* / grel_*）；
+    ``content_hash`` 是内容哈希，外部 id 失效时的兜底键。两者一起构成
+    「可审计」：证据来自哪一层、哪个租户/工作区/用户、可信度多少，都在引用里。
+    """
+
+    layer: str
+    external_id: str = ""
+    content_hash: str = ""
+    tenant_id: str = "default"
+    workspace_id: str = "default"
+    user_id: str = ""
+    confidentiality: str = "private"
+    confidence: float = 0.0
+    observed_at: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "layer": self.layer,
+            "external_id": self.external_id,
+            "content_hash": self.content_hash,
+            "tenant_id": self.tenant_id,
+            "workspace_id": self.workspace_id,
+            "user_id": self.user_id,
+            "confidentiality": self.confidentiality,
+            "confidence": round(float(self.confidence), 4),
+            "observed_at": self.observed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "EvidenceRef":
+        return cls(
+            layer=str(raw.get("layer") or ""),
+            external_id=str(raw.get("external_id") or ""),
+            content_hash=str(raw.get("content_hash") or ""),
+            tenant_id=str(raw.get("tenant_id") or "default"),
+            workspace_id=str(raw.get("workspace_id") or "default"),
+            user_id=str(raw.get("user_id") or ""),
+            confidentiality=str(raw.get("confidentiality") or "private"),
+            confidence=float(raw.get("confidence") or 0.0),
+            observed_at=str(raw.get("observed_at") or ""),
+        )
+
+
+# ── CapabilityEvidencePackV2 ─────────────────────────────────────────────────
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+@dataclass
+class CapabilityEvidencePackV2:
+    """一次技能编译允许看到的全部证据，分层、内容寻址、不可变。"""
+
+    candidate_scope: Dict[str, Any] = field(default_factory=dict)
+    intent_cluster: Dict[str, Any] = field(default_factory=dict)
+
+    # L1：只有策略引用，永远没有原始内容。
+    profile_policy_refs: List[Dict[str, Any]] = field(default_factory=list)
+    # L2：每条带 EvidenceRef 与内容（rule/why/applies_to）——内容进文档，引用进血缘。
+    procedures: List[Dict[str, Any]] = field(default_factory=list)
+    # L3：每条必须带 relation_id 与 role（GRAPH_ROLES 之一）。
+    graph_context: List[Dict[str, Any]] = field(default_factory=list)
+    # Episode：引用 + 结果 + 工具序列，供有效性与 replay 覆盖判断。
+    episodes: List[Dict[str, Any]] = field(default_factory=list)
+
+    successful_sequences: List[List[str]] = field(default_factory=list)
+    ordering_constraints: List[Dict[str, Any]] = field(default_factory=list)
+    failure_recoveries: List[Dict[str, Any]] = field(default_factory=list)
+    negative_examples: List[Dict[str, Any]] = field(default_factory=list)
+
+    required_tools: List[str] = field(default_factory=list)
+    forbidden_tools: List[str] = field(default_factory=list)
+
+    support: Dict[str, Any] = field(default_factory=dict)
+    schema_version: str = PACK_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_scope": self.candidate_scope,
+            "intent_cluster": self.intent_cluster,
+            "profile_policy_refs": self.profile_policy_refs,
+            "procedures": self.procedures,
+            "graph_context": self.graph_context,
+            "episodes": self.episodes,
+            "successful_sequences": self.successful_sequences,
+            "ordering_constraints": self.ordering_constraints,
+            "failure_recoveries": self.failure_recoveries,
+            "negative_examples": self.negative_examples,
+            "required_tools": self.required_tools,
+            "forbidden_tools": self.forbidden_tools,
+            "support": self.support,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "CapabilityEvidencePackV2":
+        return cls(
+            candidate_scope=raw.get("candidate_scope") or {},
+            intent_cluster=raw.get("intent_cluster") or {},
+            profile_policy_refs=raw.get("profile_policy_refs") or [],
+            procedures=raw.get("procedures") or [],
+            graph_context=raw.get("graph_context") or [],
+            episodes=raw.get("episodes") or [],
+            successful_sequences=raw.get("successful_sequences") or [],
+            ordering_constraints=raw.get("ordering_constraints") or [],
+            failure_recoveries=raw.get("failure_recoveries") or [],
+            negative_examples=raw.get("negative_examples") or [],
+            required_tools=raw.get("required_tools") or [],
+            forbidden_tools=raw.get("forbidden_tools") or [],
+            support=raw.get("support") or {},
+            schema_version=str(raw.get("schema_version") or PACK_SCHEMA_VERSION),
+        )
+
+    def content_hash(self) -> str:
+        """确定性哈希：同一证据 → 同一 pack，重复运行不重复建候选。"""
+        return "sha256:" + hashlib.sha256(
+            _canonical(self.to_dict()).encode("utf-8")
+        ).hexdigest()
+
+    @property
+    def pack_id(self) -> str:
+        return "pack_" + self.content_hash()[len("sha256:") :][:24]
+
+    # ── Validation ──────────────────────────────────────────────────────────
+
+    def validate(self) -> List[str]:
+        """结构校验，返回违规列表。空列表 = 合格。"""
+        violations: List[str] = []
+        for relation in self.graph_context:
+            role = str(relation.get("role") or "")
+            if role not in GRAPH_ROLES:
+                # ``step`` 落在这里：图谱事实永远不能变成执行步骤。
+                violations.append(f"graph_role_not_allowed:{role or 'missing'}")
+            if not str(relation.get("relation_id") or ""):
+                violations.append("graph_relation_missing_id")
+        for ref in self.profile_policy_refs:
+            if "content" in ref or "raw" in ref:
+                # L1 只能以策略引用形式出现；带原文即违规。
+                violations.append("profile_raw_content_in_pack")
+        scope_level = str((self.candidate_scope or {}).get("level") or "workspace")
+        if scope_level != "user":
+            for procedure in self.procedures:
+                conf = str((procedure.get("ref") or {}).get("confidentiality") or "")
+                if conf == "classified":
+                    violations.append("classified_procedure_in_shared_pack")
+        return violations
+
+    def graph_conflicts(self) -> List[Dict[str, Any]]:
+        """同一主体 + 功能型谓词出现不同 target → 冲突，候选不得自动激活。"""
+        functional = {"depends_on", "belongs_to", "responsible_for", "located_in"}
+        seen: Dict[tuple, str] = {}
+        conflicts: List[Dict[str, Any]] = []
+        for relation in self.graph_context:
+            predicate = str(relation.get("predicate") or "").lower()
+            if predicate not in functional:
+                continue
+            key = (str(relation.get("source") or ""), predicate)
+            target = str(relation.get("target") or "")
+            if not key[0] or not target:
+                continue
+            previous = seen.get(key)
+            if previous is not None and previous != target:
+                conflicts.append(
+                    {"source": key[0], "predicate": predicate, "targets": [previous, target]}
+                )
+            else:
+                seen[key] = target
+        return conflicts
+
+
+# ── Deterministic manifest（技能的机器可读边界，运行时读它而不是读正文） ─────
+
+
+def build_manifest(
+    pack: CapabilityEvidencePackV2,
+    *,
+    scope_level: str,
+    risk_tier: str,
+) -> Dict[str, Any]:
+    """由代码从 pack 生成确定性结构——LLM 只写正文，不决定这里的任何一项。
+
+    L3 只进 ``applies_when`` / ``excludes_when`` / ``dependencies`` /
+    ``required_graph_relations``，绝不进步骤。
+    """
+    applies: List[Dict[str, Any]] = []
+    excludes: List[Dict[str, Any]] = []
+    dependencies: List[Dict[str, Any]] = []
+    required_relations: List[str] = []
+
+    for relation in pack.graph_context:
+        role = str(relation.get("role") or "")
+        entry = {
+            "relation_id": str(relation.get("relation_id") or ""),
+            "source": str(relation.get("source") or ""),
+            "predicate": str(relation.get("predicate") or ""),
+            "target": str(relation.get("target") or ""),
+        }
+        if entry["relation_id"]:
+            required_relations.append(entry["relation_id"])
+        if role == ROLE_EXCLUSION:
+            excludes.append(entry)
+        elif role in (ROLE_DEPENDENCY, ROLE_CONSTRAINT):
+            dependencies.append({**entry, "role": role})
+        elif role == ROLE_APPLICABILITY:
+            applies.append(entry)
+        # alias 只用于实体归一，不进适用条件。
+
+    for task_type in pack.intent_cluster.get("task_types") or []:
+        applies.append({"task_type": str(task_type)})
+    for task_type in pack.intent_cluster.get("excluded_task_types") or []:
+        excludes.append({"task_type": str(task_type)})
+
+    conflicts = pack.graph_conflicts()
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "scope": scope_level,
+        "applies_when": applies,
+        "excludes_when": excludes,
+        "required_graph_relations": sorted(set(required_relations)),
+        "required_tools": list(pack.required_tools),
+        "forbidden_tools": list(pack.forbidden_tools),
+        "dependencies": dependencies,
+        "profile_policy_refs": list(pack.profile_policy_refs),
+        "evidence_pack_id": pack.pack_id,
+        "evidence_pack_hash": pack.content_hash(),
+        "risk_tier": risk_tier,
+        "graph_conflict": bool(conflicts),
+        "graph_conflicts": conflicts,
+    }
+
+
+# ── Cross-layer candidate validation（强制校验，任何一条失败即拒绝生成） ─────
+
+_SECRET_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),
+    re.compile(r"(?i)\b(api[_-]?key|token|secret|password|passwd)\s*[:=]\s*\S+"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{16,}"),
+    re.compile(r"[a-z][a-z0-9+.-]*://[^/\s:@]+:[^/\s:@]+@"),  # 带凭据的 URL
+)
+
+
+def _steps_section(body: str) -> str:
+    match = re.search(r"^## 步骤\s*$(.*?)(?=^## |\Z)", body or "", re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def validate_candidate_structure(
+    *,
+    pack: CapabilityEvidencePackV2,
+    manifest: Dict[str, Any],
+    document_tools: Sequence[str],
+    body: str,
+    scope_level: str,
+) -> List[str]:
+    """技能候选的分层边界校验。返回违规列表，空即通过。
+
+    每一条对应验收标准里的一项，缺一不可：
+
+    * 技能工具 ⊆ 证据中实际出现的工具（防止授权扩散）；
+    * L3 relation 没有被写成执行步骤；
+    * 共享技能不含 L1 原文；
+    * 无密钥 / Token / 凭据；
+    * L2 与 L3 矛盾时拒绝生成；
+    * manifest 的 pack 哈希可复算（引用可解析）。
+    """
+    violations = list(pack.validate())
+
+    evidence_tools = set(pack.required_tools)
+    widened = sorted(set(str(t) for t in document_tools) - evidence_tools)
+    if widened:
+        violations.append(f"tool_not_in_evidence:{widened}")
+
+    steps = _steps_section(body)
+    if steps:
+        for relation in pack.graph_context:
+            source = str(relation.get("source") or "")
+            target = str(relation.get("target") or "")
+            relationship = str(relation.get("relationship") or "")
+            # 图谱事实以「A ... 关系 ... B」的形态整体出现在步骤里，
+            # 即说明它被当成了 SOP 而不是边界。
+            if source and target and relationship and (
+                f"{source}{relationship}{target}" in steps.replace(" ", "")
+            ):
+                violations.append(
+                    f"graph_relation_written_as_step:{relation.get('relation_id')}"
+                )
+
+    for pattern in _SECRET_PATTERNS:
+        if pattern.search(body or ""):
+            violations.append("secret_material_in_body")
+            break
+
+    if scope_level != "user":
+        for ref in manifest.get("profile_policy_refs") or []:
+            if "content" in ref or "raw" in ref:
+                violations.append("profile_raw_content_in_shared_skill")
+
+    # L2 与 L3 矛盾：某个做法声明适用于 X，而图谱证据把 X 排除在外。
+    excluded_names = {
+        str(e.get("task_type") or e.get("target") or e.get("source") or "")
+        for e in manifest.get("excludes_when") or []
+    } - {""}
+    for procedure in pack.procedures:
+        applies_to = str(procedure.get("applies_to") or "")
+        if applies_to and applies_to in excluded_names:
+            violations.append(f"l2_l3_contradiction:{applies_to}")
+
+    if str(manifest.get("evidence_pack_hash") or "") != pack.content_hash():
+        violations.append("evidence_pack_hash_mismatch")
+
+    return violations

--- a/src/backend/core/evolution/evidence_resolver.py
+++ b/src/backend/core/evolution/evidence_resolver.py
@@ -1,0 +1,248 @@
+"""Evidence Resolver — 把分散在四个存储里的证据解析成一个不可变 pack（P2）.
+
+上游（意图聚类 / 工具序列模式）只知道 Episode 的 id 和它检索过什么；这里把
+它们变成 :class:`CapabilityEvidencePackV2`：
+
+* Episode 证据直接来自 episode views（PostgreSQL 已经装配好的形态）；
+* L2 procedures 由 loop 侧解析（内容 + mref），这里补上 :class:`EvidenceRef`；
+* L3 relations 来自 Episode 记录的检索事件（relation_id / predicate /
+  confidence 都在事件负载里），实体文本从 ref-shadow 的 preview 兜底解析——
+  Neo4j 不可用时证据仍然可反查，只是少了展示文本；
+* L1 永远只投影成策略引用。共享技能里出现任何一条 L1 原文都是违规，
+  由 ``pack.validate()`` 拒绝。
+
+隔离在这里执行：pack 只收 scope 覆盖的 Episode / 记忆 / 关系。产出内容寻址，
+同一批证据永远解析出同一个 ``pack_id``。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+from core.evolution.evidence_contract import (
+    LAYER_GRAPH,
+    LAYER_PROCEDURE,
+    CapabilityEvidencePackV2,
+    EvidenceRef,
+    role_for_predicate,
+)
+
+logger = logging.getLogger(__name__)
+
+# 一个 pack 携带的每层证据上限。够重建决策，又不至于让 pack 自己变成隐私面。
+_MAX_EPISODES = 20
+_MAX_RELATIONS = 20
+_MAX_PROCEDURES = 12
+_MAX_FAILURES = 8
+
+
+def _relation_display(
+    relation: Dict[str, Any], *, user_id: str, workspace_id: str
+) -> Dict[str, str]:
+    """(source, relationship, target) for one traced relation.
+
+    The trace event deliberately carries refs, not entity text. The shadow row's
+    preview is exactly ``"A → 关系 → B"``, so it recovers the display text
+    without touching Neo4j — and degrades to empty strings, never to a failure.
+    """
+    content_hash = str(relation.get("content_hash") or "")
+    if not content_hash:
+        return {"source": "", "relationship": "", "target": ""}
+    try:
+        from core.memory.ref_shadow import resolve_ref
+
+        row = resolve_ref(
+            user_id=user_id,
+            content_hash=content_hash,
+            layer=LAYER_GRAPH,
+            workspace_id=workspace_id,
+        )
+        preview = str(getattr(row, "content_preview", "") or "")
+        parts = [p.strip() for p in preview.split("→")]
+        if len(parts) == 3 and all(parts):
+            return {"source": parts[0], "relationship": parts[1], "target": parts[2]}
+    except Exception as exc:  # noqa: BLE001 - display text is best-effort
+        logger.debug("[evidence-resolver] relation display lookup failed: %s", exc)
+    return {"source": "", "relationship": "", "target": ""}
+
+
+def _episode_entry(view: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "episode_id": str(view.get("episode_id") or ""),
+        "chat_id": str(view.get("chat_id") or ""),
+        "user_id": str(view.get("user_id") or ""),
+        "verdict": str(view.get("verdict") or "unknown"),
+        "task_type": str(view.get("task_type") or "chat"),
+        "tool_sequence": [str(t) for t in (view.get("tool_sequence") or [])][:16],
+        "objective": str(view.get("objective") or "")[:160],
+        # Replay 覆盖判断需要区分「带 L3 依赖」与「不带依赖」两类场景。
+        "used_graph": bool(view.get("graph_relations") or view.get("graph_refs")),
+    }
+
+
+def resolve_capability_pack(
+    *,
+    views: Sequence[Dict[str, Any]],
+    intent_cluster: Optional[Dict[str, Any]] = None,
+    procedures: Sequence[Dict[str, Any]] = (),
+    ordering_constraints: Sequence[Dict[str, Any]] = (),
+    scope: Optional[Dict[str, str]] = None,
+    tenant_id: str = "default",
+) -> CapabilityEvidencePackV2:
+    """Resolve one candidate's evidence into an immutable, content-addressed pack.
+
+    ``views`` are the supporting episode views (already restricted to the
+    cluster / pattern). Tenant isolation is enforced here: an episode from a
+    different tenant is dropped, never silently included — a workspace skill
+    must not be compiled from another tenant's behaviour.
+    """
+    scope = dict(scope or {"level": "workspace"})
+    scope_level = str(scope.get("level") or "workspace")
+
+    episodes: List[Dict[str, Any]] = []
+    failures: List[Dict[str, Any]] = []
+    negatives: List[Dict[str, Any]] = []
+    sequences: List[List[str]] = []
+    tools: List[str] = []
+    users: set = set()
+    workspaces: set = set()
+    chats: set = set()
+    signatures: set = set()
+
+    for view in views:
+        view_tenant = str(view.get("tenant_id") or "default")
+        if view_tenant != (tenant_id or "default"):
+            # 跨租户证据直接丢弃：隔离是 resolver 的责任，不是调用方的默契。
+            continue
+        entry = _episode_entry(view)
+        episodes.append(entry)
+        users.add(entry["user_id"])
+        chats.add(entry["chat_id"] or entry["episode_id"])
+        workspaces.add(str(view.get("workspace_id") or "default"))
+        sequence = entry["tool_sequence"]
+        if sequence:
+            signatures.add("→".join(sequence))
+        if entry["verdict"] == "success":
+            if sequence and sequence not in sequences:
+                sequences.append(sequence)
+            for tool in sequence:
+                if tool not in tools:
+                    tools.append(tool)
+        elif entry["verdict"] == "failed":
+            failures.append(
+                {
+                    "episode_id": entry["episode_id"],
+                    "objective": entry["objective"],
+                    "tool_sequence": sequence[:12],
+                    "failed_at": str(view.get("failed_tool") or ""),
+                    "error": str(view.get("error") or "")[:200],
+                }
+            )
+            negatives.append(entry)
+
+    # ── L3：Episode 检索到过的图谱关系，带稳定 relation_id ────────────────────
+    graph_context: List[Dict[str, Any]] = []
+    seen_relations: set = set()
+    for view in views:
+        user_id = str(view.get("user_id") or "")
+        for relation in view.get("graph_relations") or []:
+            relation_id = str(relation.get("relation_id") or "")
+            content_hash = str(relation.get("content_hash") or "")
+            key = relation_id or content_hash
+            if not key or key in seen_relations:
+                continue
+            seen_relations.add(key)
+            predicate = str(relation.get("predicate") or "")
+            workspace_id = str(relation.get("workspace_id") or "default")
+            display = _relation_display(
+                relation, user_id=user_id, workspace_id=workspace_id
+            )
+            graph_context.append(
+                {
+                    "relation_id": relation_id,
+                    "content_hash": content_hash,
+                    "predicate": predicate,
+                    "role": role_for_predicate(predicate),
+                    "confidence": float(relation.get("confidence") or 0.0),
+                    "workspace_id": workspace_id,
+                    **display,
+                }
+            )
+            if len(graph_context) >= _MAX_RELATIONS:
+                break
+        if len(graph_context) >= _MAX_RELATIONS:
+            break
+
+    # ── L2：procedures 补齐 EvidenceRef（引用进血缘，内容进文档） ─────────────
+    typed_procedures: List[Dict[str, Any]] = []
+    for procedure in list(procedures)[:_MAX_PROCEDURES]:
+        ref = EvidenceRef(
+            layer=LAYER_PROCEDURE,
+            external_id=str(procedure.get("ref") or ""),
+            content_hash=str(procedure.get("content_hash") or ""),
+            tenant_id=tenant_id or "default",
+            workspace_id=str(procedure.get("workspace_id") or "default"),
+            user_id=str(procedure.get("user_id") or ""),
+            confidentiality=str(procedure.get("confidentiality") or "private"),
+        )
+        typed_procedures.append(
+            {
+                "ref": ref.to_dict(),
+                "rule": str(procedure.get("rule") or ""),
+                "why": str(procedure.get("why") or ""),
+                "applies_to": str(procedure.get("applies_to") or ""),
+                "user_id": ref.user_id,
+            }
+        )
+
+    # ── L1：只投影策略引用。个性化在运行时绑定，绝不进共享技能正文。──────────
+    profile_policy_refs: List[Dict[str, Any]] = []
+    if users - {""}:
+        profile_policy_refs.append(
+            {
+                "policy": "bind_user_profile_at_runtime",
+                "reason": "输出语言/语气等个性化由 L1 在运行时绑定，不写入技能",
+            }
+        )
+
+    cluster = dict(intent_cluster or {})
+    support = {
+        "occasions": len(chats - {""}) or len(episodes),
+        "success_rate": round(
+            sum(1 for e in episodes if e["verdict"] == "success") / len(episodes), 4
+        )
+        if episodes
+        else 0.0,
+        "plan_variety": len(signatures),
+        "workspace_count": len(workspaces - {""}) or 1,
+        "user_count": len(users - {""}),
+    }
+
+    return CapabilityEvidencePackV2(
+        candidate_scope={"level": scope_level, "tenant_id": tenant_id or "default", **{
+            k: v for k, v in scope.items() if k not in ("level",)
+        }},
+        intent_cluster={
+            "representative": str(cluster.get("representative") or "")[:160],
+            "task_types": sorted(
+                {e["task_type"] for e in episodes if e["task_type"]}
+            ),
+            "excluded_task_types": [
+                str(t)
+                for rule in ordering_constraints
+                for t in (rule.get("contradicted_in") or [])
+            ],
+        },
+        profile_policy_refs=profile_policy_refs,
+        procedures=typed_procedures,
+        graph_context=graph_context,
+        episodes=episodes[:_MAX_EPISODES],
+        successful_sequences=sequences[:6],
+        ordering_constraints=[dict(rule) for rule in ordering_constraints],
+        failure_recoveries=failures[:_MAX_FAILURES],
+        negative_examples=negatives[:_MAX_FAILURES],
+        required_tools=tools,
+        forbidden_tools=[],
+        support=support,
+    )

--- a/src/backend/core/evolution/exposure.py
+++ b/src/backend/core/evolution/exposure.py
@@ -126,26 +126,60 @@ def visible_evolved_skill_ids(
     return visible
 
 
+def _applicable_by_manifest(db, skill_ids: Set[str], *, task_type: str) -> Set[str]:
+    """Of ``skill_ids``, those whose evolution manifest permits ``task_type``.
+
+    The manifest is the machine-readable boundary compiled from L3 evidence;
+    a skill whose graph evidence excluded this task type must not be offered
+    for it. Skills without a manifest (hand-authored, pre-manifest) pass.
+    """
+    from core.db.models import AdminSkill
+    from core.evolution.applicability import load_manifest, manifest_permits
+
+    rows = (
+        db.query(AdminSkill.skill_id, AdminSkill.extra_files)
+        .filter(AdminSkill.skill_id.in_(sorted(skill_ids)))
+        .all()
+    )
+    manifests = {skill_id: load_manifest(extra) for skill_id, extra in rows}
+    permitted: Set[str] = set()
+    for skill_id in skill_ids:
+        ok, reason = manifest_permits(manifests.get(skill_id), task_type=task_type)
+        if ok:
+            permitted.add(skill_id)
+        else:
+            logger.info("[exposure] %s withheld by manifest: %s", skill_id, reason)
+    return permitted
+
+
 def filter_skill_ids(
     skill_ids: Sequence[str],
     *,
     user_id: str,
     tenant_id: str = "default",
+    task_type: str = "",
     db=None,
 ) -> List[str]:
     """Drop evolved skills this subject is not entitled to; keep everything else.
 
     Called on the request path, so it does nothing at all when the list contains
     no evolved ids — the common case, and one that must not cost a query.
+
+    ``task_type``, when the caller knows it, additionally applies the manifest's
+    L3-derived applicability boundary — a skill whose graph evidence excluded
+    this task type is withheld even though its release reaches the user.
     """
     ids = [sid for sid in skill_ids if sid]
     if not any(is_evolved_skill_id(sid) for sid in ids):
         return list(ids)
 
     def _resolve(session) -> Set[str]:
-        return visible_evolved_skill_ids(
+        allowed = visible_evolved_skill_ids(
             session, ids, user_id=user_id or "", tenant_id=tenant_id or "default"
         )
+        if allowed and task_type:
+            allowed = _applicable_by_manifest(session, allowed, task_type=task_type)
+        return allowed
 
     try:
         if db is not None:

--- a/src/backend/core/evolution/graph_scan.py
+++ b/src/backend/core/evolution/graph_scan.py
@@ -1,0 +1,272 @@
+"""L3 图谱演进 — 图谱不演进「怎么做」，演进结构与可信度（P5）.
+
+L2 的演进对象是流程性知识；L3 的演进对象是语义图谱本身：
+
+* 反复被检索、反复被观察的关系 → **强化**（weight 上调）；
+* 长期无人再观察的关系 → **降权**——但绝不删除，陈旧不等于错误；
+* 同一主体 + 功能型谓词出现不同 target → **冲突标记**，交人裁决；
+* 更新的关系明显取代旧关系 → **替代建议**，交人裁决；
+* Episode 反复依赖某实体而图谱没有对应边 → **缺边建议**，交人裁决；
+* alias_of 边存在 → **别名合并建议**，交人裁决。
+
+自动化边界（每一条都有明确理由）：
+
+* **自动执行**：同作用域内的强化与陈旧降权。两者都可逆、都不改变图谱语义。
+* **人工候选**：冲突 / 替代 / 合并 / 失效 / 缺边。它们改变图谱的**含义**，
+  错一次的代价是下游所有依赖该关系的技能边界一起错。
+* **永不因单次失败删除关系**：最强的自动操作是降权。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+OP_REINFORCE = "reinforce_relation"
+OP_CREATE = "create_relation"
+OP_MERGE_ALIAS = "merge_alias"
+OP_REWEIGHT = "reweight_relation"
+OP_SUPERSEDE = "supersede_relation"
+OP_DEACTIVATE = "deactivate_relation"
+OP_FLAG_CONTRADICTION = "flag_contradiction"
+OP_SUGGEST_MISSING = "suggest_missing_relation"
+
+# 只有这两类可以自动执行；其余全部生成人工候选。
+AUTO_OPS = frozenset({OP_REINFORCE, OP_REWEIGHT})
+
+# 谓词的「功能型」子集：同一主体在这些谓词上通常只有一个真值，
+# 出现两个 target 即为冲突信号（而不是多值事实）。
+FUNCTIONAL_PREDICATES = frozenset(
+    {"depends_on", "belongs_to", "responsible_for", "located_in"}
+)
+
+# 超过这个天数没有再观察到 → 陈旧，降权一档。
+STALE_DAYS = 90
+# 每次降权乘的系数与地板：地板之下不再自动动它，是否失效交人判断。
+DECAY_FACTOR = 0.5
+WEIGHT_FLOOR = 0.2
+# 强化的步进与上限。
+REINFORCE_STEP = 0.15
+WEIGHT_CEILING = 1.0
+# 实体被 Episode 反复提及这么多次、而图谱没有它的边 → 建议补边。
+MISSING_MENTION_THRESHOLD = 3
+
+
+@dataclass
+class GraphOp:
+    """One proposed change to the graph, with its automation verdict."""
+
+    operation: str
+    relation_id: str = ""
+    reason: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def auto(self) -> bool:
+        return self.operation in AUTO_OPS
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "operation": self.operation,
+            "relation_id": self.relation_id,
+            "reason": self.reason,
+            "auto": self.auto,
+            "payload": self.payload,
+        }
+
+
+def _parse_when(raw: Any) -> Optional[datetime]:
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def scan_graph_relations(
+    relations: Sequence[Dict[str, Any]],
+    *,
+    observed_relation_ids: Optional[Dict[str, int]] = None,
+    entity_mentions: Optional[Dict[str, int]] = None,
+    now: Optional[datetime] = None,
+) -> List[GraphOp]:
+    """Scan one scope's relations and propose evolution operations.
+
+    Pure: reads rows (the shape :func:`core.memory.graph.list_graph_relations`
+    returns) plus this cycle's observations, writes nothing. What may be applied
+    automatically is decided by :data:`AUTO_OPS`, not by the caller.
+    """
+    now = now or datetime.now(timezone.utc)
+    observed = observed_relation_ids or {}
+    ops: List[GraphOp] = []
+
+    by_functional_key: Dict[tuple, List[Dict[str, Any]]] = {}
+    known_entities: set = set()
+
+    for relation in relations:
+        relation_id = str(relation.get("relation_id") or "")
+        predicate = str(relation.get("predicate") or "").lower()
+        source = str(relation.get("source") or "")
+        target = str(relation.get("target") or "")
+        weight = float(relation.get("weight") or 1.0)
+        known_entities.update({source, target} - {""})
+
+        if predicate in FUNCTIONAL_PREDICATES and source:
+            by_functional_key.setdefault((source, predicate), []).append(relation)
+
+        hits = int(observed.get(relation_id, 0) or 0)
+        if hits > 0:
+            # 本周期又被真实使用了：强化。可自动——只上调权重，不改语义。
+            ops.append(
+                GraphOp(
+                    operation=OP_REINFORCE,
+                    relation_id=relation_id,
+                    reason=f"本周期被 {hits} 个 Episode 检索使用",
+                    payload={
+                        "weight": min(WEIGHT_CEILING, weight + REINFORCE_STEP * hits)
+                    },
+                )
+            )
+            continue
+
+        last_seen = _parse_when(relation.get("last_seen_at"))
+        if last_seen is not None and (now - last_seen) > timedelta(days=STALE_DAYS):
+            if weight > WEIGHT_FLOOR:
+                ops.append(
+                    GraphOp(
+                        operation=OP_REWEIGHT,
+                        relation_id=relation_id,
+                        reason=f"超过 {STALE_DAYS} 天未再观察到，降权而非删除",
+                        payload={"weight": max(WEIGHT_FLOOR, weight * DECAY_FACTOR)},
+                    )
+                )
+            else:
+                # 已经降到地板还没人再观察到：是否失效交人判断。
+                ops.append(
+                    GraphOp(
+                        operation=OP_DEACTIVATE,
+                        relation_id=relation_id,
+                        reason="权重已到地板且长期未观察，建议人工确认后停用",
+                        payload={"weight": weight},
+                    )
+                )
+
+        if predicate == "alias_of" and relation_id:
+            ops.append(
+                GraphOp(
+                    operation=OP_MERGE_ALIAS,
+                    relation_id=relation_id,
+                    reason=f"存在别名边 {source} → {target}，建议人工确认后合并实体",
+                    payload={"source": source, "target": target},
+                )
+            )
+
+    # ── 冲突与替代：同一 (source, 功能型谓词) 多个 target ─────────────────────
+    for (source, predicate), group in by_functional_key.items():
+        targets = {str(r.get("target") or "") for r in group} - {""}
+        if len(targets) < 2:
+            continue
+        ordered = sorted(
+            group,
+            key=lambda r: (_parse_when(r.get("last_seen_at")) or datetime.min.replace(tzinfo=timezone.utc)),
+        )
+        newest, oldest = ordered[-1], ordered[0]
+        newest_seen = _parse_when(newest.get("last_seen_at"))
+        oldest_seen = _parse_when(oldest.get("last_seen_at"))
+        stale_gap = (
+            newest_seen is not None
+            and oldest_seen is not None
+            and (newest_seen - oldest_seen) > timedelta(days=STALE_DAYS)
+        )
+        if stale_gap and int(newest.get("seen_count") or 0) >= int(
+            oldest.get("seen_count") or 0
+        ):
+            # 新关系明显接管：建议替代（人工）。旧边保留、可回滚。
+            ops.append(
+                GraphOp(
+                    operation=OP_SUPERSEDE,
+                    relation_id=str(oldest.get("relation_id") or ""),
+                    reason=(
+                        f"「{source} {predicate}」的目标疑似由"
+                        f"「{oldest.get('target')}」更替为「{newest.get('target')}」"
+                    ),
+                    payload={
+                        "superseded_by": str(newest.get("relation_id") or ""),
+                        "old_target": str(oldest.get("target") or ""),
+                        "new_target": str(newest.get("target") or ""),
+                    },
+                )
+            )
+        else:
+            ops.append(
+                GraphOp(
+                    operation=OP_FLAG_CONTRADICTION,
+                    relation_id=str(newest.get("relation_id") or ""),
+                    reason=(
+                        f"「{source} {predicate}」同时指向 {sorted(targets)}，证据无法自行裁决"
+                    ),
+                    payload={
+                        "source": source,
+                        "predicate": predicate,
+                        "targets": sorted(targets),
+                        "relation_ids": [str(r.get("relation_id") or "") for r in group],
+                    },
+                )
+            )
+
+    # ── 缺边建议：Episode 反复提及、图谱却没有的实体 ─────────────────────────
+    for entity, mentions in (entity_mentions or {}).items():
+        if int(mentions) >= MISSING_MENTION_THRESHOLD and entity not in known_entities:
+            ops.append(
+                GraphOp(
+                    operation=OP_SUGGEST_MISSING,
+                    reason=(
+                        f"实体「{entity}」在 {mentions} 个 Episode 中被依赖，图谱中没有对应边"
+                    ),
+                    payload={"entity": entity, "mentions": int(mentions)},
+                )
+            )
+
+    return ops
+
+
+def apply_graph_ops(
+    ops: Sequence[GraphOp],
+    *,
+    scope_user_id: str,
+) -> Dict[str, Any]:
+    """Apply the automatic subset; return the rest for human review.
+
+    The boundary lives here, not in the caller: an op outside :data:`AUTO_OPS`
+    is never written to the store no matter who asks.
+    """
+    applied: List[Dict[str, Any]] = []
+    manual: List[Dict[str, Any]] = []
+    for op in ops:
+        if not op.auto:
+            manual.append(op.to_dict())
+            continue
+        try:
+            from core.memory.graph import update_relation_state
+
+            ok = update_relation_state(
+                op.relation_id,
+                scope_user_id=scope_user_id,
+                weight=op.payload.get("weight"),
+            )
+        except Exception as exc:  # noqa: BLE001 - graph store is optional
+            logger.debug("[graph-scan] auto op failed: %s", exc)
+            ok = False
+        entry = op.to_dict()
+        entry["applied"] = bool(ok)
+        applied.append(entry)
+    return {"applied": applied, "manual": manual}

--- a/src/backend/core/evolution/ir.py
+++ b/src/backend/core/evolution/ir.py
@@ -178,15 +178,24 @@ class EvolutionIR:
 
         Excludes timestamps and evidence refs deliberately: the same edit
         proposed twice from different evidence is still the same edit, and
-        repeated evidence must not flood the review queue.
+        repeated evidence must not flood the review queue. The embedded
+        ``manifest`` is stripped for the same reason — it carries the evidence
+        pack's hash, and hashing it back in would turn every fresh episode into
+        a "new" candidate for an unchanged edit.
         """
+        changes = [
+            {k: v for k, v in change.items() if k != "manifest"}
+            if isinstance(change, dict)
+            else change
+            for change in self.changes
+        ]
         payload = json.dumps(
             {
                 "kind": self.target_kind,
                 "asset": self.target_asset_id,
                 "base": self.base_version,
                 "op": self.operation,
-                "changes": self.changes,
+                "changes": changes,
             },
             sort_keys=True,
             ensure_ascii=False,

--- a/src/backend/core/evolution/lineage.py
+++ b/src/backend/core/evolution/lineage.py
@@ -1,0 +1,255 @@
+"""证据与血缘账本 — pack / 归因决策 / 晋升链的持久化（compiler V2, P1）.
+
+三个持久化面共享同一批设计约束：
+
+* **幂等**。所有 id 都由内容派生：同一 pack、同一决策、同一条血缘边重复写入
+  落在同一行上，重复运行一个 cycle 不会让账本膨胀。
+* **尽力而为**。账本是可解释性基础设施，不是可用性风险——任何一次写入失败都
+  只降级为日志，绝不让候选生成或激活失败。
+* **不可变**。pack 与决策一经写入不再更新；血缘边只增不改。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from core.evolution.evidence_contract import CapabilityEvidencePackV2
+
+logger = logging.getLogger(__name__)
+
+# ── Promotion link relations ─────────────────────────────────────────────────
+
+REL_COMPILED_FROM = "compiled_from"      # L2 memory → skill
+REL_CONSTRAINED_BY = "constrained_by"    # L3 relation → skill
+REL_VALIDATED_BY = "validated_by"        # episode → skill
+REL_ASSEMBLED_INTO = "assembled_into"    # skill → agent profile
+REL_ROLLED_BACK_TO = "rolled_back_to"    # skill version → prior version
+REL_PERSONALIZED_BY = "personalized_by"  # L1 policy → skill (runtime binding)
+
+LINK_RELATIONS = frozenset(
+    {
+        REL_COMPILED_FROM,
+        REL_CONSTRAINED_BY,
+        REL_VALIDATED_BY,
+        REL_ASSEMBLED_INTO,
+        REL_ROLLED_BACK_TO,
+        REL_PERSONALIZED_BY,
+    }
+)
+
+
+def _digest(*parts: str) -> str:
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+# ── Evidence packs ───────────────────────────────────────────────────────────
+
+
+def persist_evidence_pack(pack: CapabilityEvidencePackV2) -> Dict[str, Any]:
+    """Store an immutable pack; same content → same row, never a duplicate."""
+    pack_hash = pack.content_hash()
+    pack_id = pack.pack_id
+    try:
+        from core.db.engine import SessionLocal
+        from core.db.models.evolution import EvolutionEvidencePack
+
+        with SessionLocal() as db:
+            existing = db.get(EvolutionEvidencePack, pack_id)
+            if existing is None:
+                db.add(
+                    EvolutionEvidencePack(
+                        pack_id=pack_id,
+                        schema_version=pack.schema_version,
+                        pack_hash=pack_hash,
+                        scope=pack.candidate_scope,
+                        pack=pack.to_dict(),
+                        support=pack.support,
+                    )
+                )
+                db.commit()
+                created = True
+            else:
+                created = False
+        return {"pack_id": pack_id, "pack_hash": pack_hash, "created": created}
+    except Exception as exc:  # noqa: BLE001 - the ledger must never fail the flow
+        logger.debug("[lineage] evidence pack persist skipped: %s", exc)
+        return {"pack_id": pack_id, "pack_hash": pack_hash, "created": False}
+
+
+def load_evidence_pack(pack_id: str) -> Optional[CapabilityEvidencePackV2]:
+    if not pack_id:
+        return None
+    try:
+        from core.db.engine import SessionLocal
+        from core.db.models.evolution import EvolutionEvidencePack
+
+        with SessionLocal() as db:
+            row = db.get(EvolutionEvidencePack, pack_id)
+            if row is None:
+                return None
+            return CapabilityEvidencePackV2.from_dict(row.pack or {})
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[lineage] evidence pack load failed: %s", exc)
+        return None
+
+
+# ── Credit decisions ─────────────────────────────────────────────────────────
+
+
+def record_credit_decision(credit: Dict[str, Any], *, episode_id: str = "") -> str:
+    """Persist one attribution verdict; returns its stable ``decision_id``.
+
+    The id is content-derived: the same verdict recorded twice (a retried
+    cycle, a re-run engine) is one row. Candidates reference this id, so the
+    stored copy inside the candidate becomes a cache, not the only record.
+    """
+    canonical = json.dumps(
+        {
+            "selected": credit.get("selected"),
+            "verdict": credit.get("verdict"),
+            "scores": credit.get("scores"),
+            "features": credit.get("features"),
+            "assigner_version": credit.get("assigner_version"),
+            "episode_id": episode_id,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    decision_id = "cred_" + _digest(canonical)[:24]
+    try:
+        from core.db.engine import SessionLocal
+        from core.db.models.evolution import EvolutionCreditDecision
+
+        with SessionLocal() as db:
+            if db.get(EvolutionCreditDecision, decision_id) is None:
+                db.add(
+                    EvolutionCreditDecision(
+                        decision_id=decision_id,
+                        episode_id=episode_id or None,
+                        selected=str(credit.get("selected") or "no_update"),
+                        verdict=str(credit.get("verdict") or ""),
+                        confidence=float(credit.get("confidence") or 0.0),
+                        scores=credit.get("scores") or {},
+                        features=credit.get("features") or {},
+                        explanation=str(credit.get("explanation") or "")[:2000],
+                        assigner_version=str(credit.get("assigner_version") or ""),
+                    )
+                )
+                db.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[lineage] credit decision persist skipped: %s", exc)
+    return decision_id
+
+
+# ── Promotion links ──────────────────────────────────────────────────────────
+
+
+def record_links(
+    edges: Sequence[Tuple[str, str, str, str, str]],
+    *,
+    candidate_id: str = "",
+) -> List[str]:
+    """Write lineage edges ``(source_kind, source_id, relation, target_kind, target_id)``.
+
+    Idempotent per edge; unknown relations are refused loudly rather than
+    stored, because a lineage graph with free-text edge labels answers nothing.
+    """
+    written: List[str] = []
+    try:
+        from core.db.engine import SessionLocal
+        from core.db.models.evolution import EvolutionPromotionLink
+
+        with SessionLocal() as db:
+            for source_kind, source_id, relation, target_kind, target_id in edges:
+                if relation not in LINK_RELATIONS:
+                    logger.warning("[lineage] unknown link relation refused: %s", relation)
+                    continue
+                if not source_id or not target_id:
+                    continue
+                link_id = "plink_" + _digest(
+                    source_kind, source_id, relation, target_kind, target_id
+                )[:24]
+                if db.get(EvolutionPromotionLink, link_id) is None:
+                    db.add(
+                        EvolutionPromotionLink(
+                            link_id=link_id,
+                            source_kind=source_kind,
+                            source_id=source_id,
+                            relation=relation,
+                            target_kind=target_kind,
+                            target_id=target_id,
+                            candidate_id=candidate_id or None,
+                        )
+                    )
+                written.append(link_id)
+            db.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[lineage] link persist skipped: %s", exc)
+        return []
+    return written
+
+
+def links_for_skill(
+    pack: CapabilityEvidencePackV2, *, skill_id: str, skill_version: str
+) -> List[Tuple[str, str, str, str, str]]:
+    """The full lineage a materialised skill owes its evidence pack."""
+    target = f"{skill_id}@{skill_version}" if skill_version else skill_id
+    edges: List[Tuple[str, str, str, str, str]] = []
+    for procedure in pack.procedures:
+        ref = procedure.get("ref") or {}
+        source_id = str(ref.get("external_id") or ref.get("content_hash") or "")
+        if source_id:
+            edges.append(("memory", source_id, REL_COMPILED_FROM, "skill", target))
+    for relation in pack.graph_context:
+        relation_id = str(relation.get("relation_id") or "")
+        if relation_id:
+            edges.append(("graph_relation", relation_id, REL_CONSTRAINED_BY, "skill", target))
+    for episode in pack.episodes:
+        episode_id = str(episode.get("episode_id") or "")
+        if episode_id:
+            edges.append(("episode", episode_id, REL_VALIDATED_BY, "skill", target))
+    for policy in pack.profile_policy_refs:
+        policy_id = str(policy.get("policy") or "")
+        if policy_id:
+            edges.append(("profile_policy", policy_id, REL_PERSONALIZED_BY, "skill", target))
+    return edges
+
+
+def lineage_of(target_kind: str, target_id: str) -> List[Dict[str, Any]]:
+    """Every recorded edge touching one asset, for the console."""
+    try:
+        from core.db.engine import SessionLocal
+        from core.db.models.evolution import EvolutionPromotionLink
+        from sqlalchemy import or_
+
+        with SessionLocal() as db:
+            rows = (
+                db.query(EvolutionPromotionLink)
+                .filter(
+                    or_(
+                        (EvolutionPromotionLink.target_kind == target_kind)
+                        & (EvolutionPromotionLink.target_id.like(f"{target_id}%")),
+                        (EvolutionPromotionLink.source_kind == target_kind)
+                        & (EvolutionPromotionLink.source_id.like(f"{target_id}%")),
+                    )
+                )
+                .order_by(EvolutionPromotionLink.created_at.asc())
+                .all()
+            )
+            return [
+                {
+                    "source_kind": row.source_kind,
+                    "source_id": row.source_id,
+                    "relation": row.relation,
+                    "target_kind": row.target_kind,
+                    "target_id": row.target_id,
+                    "candidate_id": row.candidate_id or "",
+                }
+                for row in rows
+            ]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[lineage] lineage query failed: %s", exc)
+        return []

--- a/src/backend/core/evolution/loop.py
+++ b/src/backend/core/evolution/loop.py
@@ -29,8 +29,8 @@ from core.db.models.evolution import (
 from core.evolution import promotion as P
 from core.evolution.credit import (
     T_MEMORY,
-    T_SKILL,
     T_ORCHESTRATION,
+    T_SKILL,
     CreditFeatures,
     aggregate_finding,
     assign_credit,
@@ -76,11 +76,13 @@ def _view_for(episode, events) -> Dict[str, Any]:
         EV_TOOL_CALLED,
     )
     from core.memory.ref_shadow import build_ref_id
-    from core.memory.retrieval_types import LAYER_FACT
+    from core.memory.retrieval_types import LAYER_FACT, LAYER_GRAPH
 
     tools: List[str] = []
     skills: List[str] = []
     memory_refs: List[str] = []
+    graph_refs: List[str] = []
+    graph_relations: List[Dict[str, Any]] = []
     skills_opened: List[Dict[str, Any]] = []
     selection_degraded = False
     error_count = 0
@@ -102,9 +104,7 @@ def _view_for(episode, events) -> Dict[str, Any]:
             skills_opened.append(
                 {
                     "skill_id": str(payload.get("skill_id") or ""),
-                    "tools_after_open": [
-                        str(t) for t in (payload.get("tools_after_open") or [])
-                    ],
+                    "tools_after_open": [str(t) for t in (payload.get("tools_after_open") or [])],
                 }
             )
         elif event.event_type == EV_MEMORY_RETRIEVED:
@@ -120,6 +120,34 @@ def _view_for(episode, events) -> Dict[str, Any]:
                         content_hash=content_hash,
                     )
                 )
+            # L3 is deliberately tracked separately from L2. A graph relation
+            # is declarative context, not a procedure, and must never enter the
+            # memory→skill compiler as though it were an instruction.
+            for relation in payload.get("graph") or []:
+                content_hash = str(relation.get("content_hash") or "")
+                if not content_hash:
+                    continue
+                graph_refs.append(
+                    build_ref_id(
+                        layer=LAYER_GRAPH,
+                        user_id=user_id,
+                        workspace_id=str(relation.get("workspace_id") or "default"),
+                        content_hash=content_hash,
+                    )
+                )
+                # The full reference, kept for the evidence resolver: a pack's
+                # L3 entry must carry the store's stable relation_id so an
+                # activated skill's graph evidence can be resolved back to the
+                # exact Neo4j edge — a bare ref id cannot do that.
+                graph_relations.append(
+                    {
+                        "relation_id": str(relation.get("relation_id") or ""),
+                        "content_hash": content_hash,
+                        "predicate": str(relation.get("predicate") or ""),
+                        "confidence": relation.get("confidence") or 0.0,
+                        "workspace_id": str(relation.get("workspace_id") or "default"),
+                    }
+                )
 
     outcome = episode.outcome or {}
     return {
@@ -134,6 +162,8 @@ def _view_for(episode, events) -> Dict[str, Any]:
         "skills_opened": skills_opened,
         "selection_degraded": selection_degraded,
         "memory_refs": memory_refs,
+        "graph_refs": graph_refs,
+        "graph_relations": graph_relations,
         "task_type": episode.task_type or "chat",
         "backfilled": bool(episode.backfilled),
         # Repeated tool errors are the observable form of "this run was stuck",
@@ -277,6 +307,16 @@ def _persist_candidate(
     evidence_refs: List[str],
 ) -> Optional[str]:
     """Store a candidate, collapsing duplicates rather than failing on them."""
+    from core.evolution import lineage
+
+    # Attribution outlives the candidate that happened to carry it: every
+    # decision that reaches persistence gets its own ledger row, and the stored
+    # copy inside the candidate becomes a cache keyed by ``decision_id``.
+    decision_id = lineage.record_credit_decision(
+        credit, episode_id=(evidence_refs[0] if evidence_refs else "")
+    )
+    credit = {**credit, "decision_id": decision_id}
+
     checksum = ir.change_checksum()
     try:
         with SessionLocal() as db:
@@ -397,9 +437,7 @@ def _memory_scan_findings(views: List[Dict[str, Any]]) -> List[Any]:
     findings: List[Any] = []
     for user_id, refs in retrieved.items():
         try:
-            _, user_findings = _run_async(
-                scan_user_memories(user_id, retrieved_refs=refs)
-            )
+            _, user_findings = _run_async(scan_user_memories(user_id, retrieved_refs=refs))
         except Exception as exc:  # noqa: BLE001
             logger.warning("[evolution-loop] memory scan failed for %s: %s", user_id, exc)
             continue
@@ -492,8 +530,12 @@ def _memory_candidates(
         )
         if candidate_id:
             created.append(
-                {"candidate_id": candidate_id, "kind": "memory", "user_id": user_id,
-                 "operations": len(user_ops)}
+                {
+                    "candidate_id": candidate_id,
+                    "kind": "memory",
+                    "user_id": user_id,
+                    "operations": len(user_ops),
+                }
             )
     return created
 
@@ -501,14 +543,24 @@ def _memory_candidates(
 def _intent_skill_candidates(
     extras: Dict[str, Any], views: List[Dict[str, Any]], *, dry_run: bool
 ) -> List[Dict[str, Any]]:
-    """Recurring intents, written up as skills by the generator.
+    """Recurring intents, compiled through the unified skill candidate engine.
 
     The intent finding says a capability is missing; it does not say what the
-    capability is. Turning it into an asset needs a document, which is what
-    :mod:`core.evolution.skill_gen` produces and validates. A finding without a
-    document has nowhere to go — which is exactly where these used to stop.
+    capability is. The engine resolves the cluster's evidence into an immutable
+    pack, derives the deterministic structure (tools, boundaries, dependencies),
+    has the model write only the document, and validates the layered contract —
+    the same chain the tool-sequence path uses, so identical evidence can no
+    longer produce structurally different skills depending on which engine
+    noticed it first.
     """
-    from core.evolution.skill_gen import generate_skill_document
+    from core.evolution.skill_candidate_engine import (
+        STATUS_CREATED,
+        STATUS_DRY_RUN,
+        STATUS_NOT_WRITTEN,
+        STATUS_REJECTED,
+        SkillCandidateSpec,
+        create_skill_candidate,
+    )
 
     findings = [
         f
@@ -541,81 +593,50 @@ def _intent_skill_candidates(
             continue
 
         asset_id = str(finding.get("asset_id") or "")
-        procedures = _procedures_for_cluster(cluster, views)
-        document, draft = _run_async(
-            generate_skill_document(
-                skill_id=asset_id,
-                episodes=episodes,
-                procedures=procedures,
-                rationale=str(finding.get("reason") or ""),
-            )
+        spec = SkillCandidateSpec(
+            asset_id=asset_id,
+            proposer="intent_engine",
+            hypothesis=str(finding.get("reason") or ""),
+            views=episodes,
+            intent_cluster=cluster,
+            procedures=_procedures_for_cluster(cluster, views),
+            operation="new",
+            base_version="v0",
+            risk_tier=RISK_HIGH,
+            scope={"level": "workspace"},
+            tenant_id=str(episodes[0].get("tenant_id") or "default"),
+            write_document=True,
         )
-        if document is None:
+        outcome = create_skill_candidate(
+            spec, credit=decision.to_dict(), dry_run=dry_run, run_async=_run_async
+        )
+        status = outcome.get("status")
+        if status == STATUS_NOT_WRITTEN:
             created.append(
                 {
                     "kind": "recurring_intent",
                     "asset_id": asset_id,
                     "written": False,
-                    "why_not": draft.to_dict(),
+                    "why_not": outcome.get("why_not") or {},
                 }
             )
-            continue
-
-        ir = EvolutionIR(
-            target_kind="skill",
-            target_asset_id=asset_id,
-            base_version="v0",
-            operation="new",
-            hypothesis=str(finding.get("reason") or ""),
-            changes=[
-                {
-                    "document": document,
-                    # Carried so demotion has a target: these are the memories
-                    # whose content went into the document, each with its owner,
-                    # because down-weighting happens in one person's store.
-                    "source_memories": [
-                        {"ref": p.get("ref", ""), "user_id": p.get("user_id", "")}
-                        for p in procedures
-                        if p.get("ref")
-                    ],
-                    "tool_sequence": [],
-                }
-            ],
-            evidence_refs=episode_ids[:20],
-            requested_tools=list(document.get("allowed_tools") or []),
-            risk_tier=RISK_HIGH,
-            scope={"level": "workspace"},
-            rollback=Rollback(
-                version_id="v0", triggers=["success -3pp", "risk_denial_rate +2pp"]
-            ),
-            evaluation_plan={"replay_set": "auto_holdout", "primary_metric": "task_success"},
-        )
-        try:
-            validate_ir(
-                ir,
-                credit_decision=decision.to_dict(),
-                base_tools=list(document.get("allowed_tools") or []),
+        elif status == STATUS_REJECTED:
+            logger.info(
+                "[evolution-loop] intent candidate rejected: %s %s",
+                outcome.get("code"),
+                outcome.get("violations") or "",
             )
-        except InvariantViolation as violation:
-            logger.info("[evolution-loop] intent candidate rejected: %s", violation.code)
-            continue
-        if dry_run:
+        elif status == STATUS_DRY_RUN:
             created.append({"dry_run": True, "kind": "recurring_intent", "asset_id": asset_id})
-            continue
-        candidate_id = _persist_candidate(
-            ir,
-            credit=decision.to_dict(),
-            proposer="intent_engine",
-            evidence_refs=episode_ids[:20],
-        )
-        if candidate_id:
+        elif status == STATUS_CREATED:
             created.append(
                 {
-                    "candidate_id": candidate_id,
+                    "candidate_id": outcome["candidate_id"],
                     "kind": "recurring_intent",
                     "asset_id": asset_id,
                     "written": True,
-                    "attempts": draft.attempts,
+                    "attempts": outcome.get("attempts", 0),
+                    "evidence_pack_id": outcome.get("pack_id", ""),
                 }
             )
     return created
@@ -706,9 +727,7 @@ def _decremental_candidates(extras: Dict[str, Any], *, dry_run: bool) -> List[Di
         decision = aggregate_finding(
             target=T_SKILL,
             explanation=str(item.get("explanation") or item.get("reason") or ""),
-            confidence=confidence_from_evidence(
-                int(item.get("offers", 0) or 0), saturates_at=20
-            ),
+            confidence=confidence_from_evidence(int(item.get("offers", 0) or 0), saturates_at=20),
             evidence_count=int(item.get("offers", 0) or 0),
         )
         if not decision.may_produce_candidate:
@@ -720,9 +739,14 @@ def _decremental_candidates(extras: Dict[str, Any], *, dry_run: bool) -> List[Di
             base_version="current",
             operation="deprecate",
             hypothesis=str(item.get("explanation") or item.get("reason") or ""),
-            changes=[{"retire_reason": item.get("reason"), "stats": {
-                k: v for k, v in item.items() if k not in ("asset_id", "explanation")
-            }}],
+            changes=[
+                {
+                    "retire_reason": item.get("reason"),
+                    "stats": {
+                        k: v for k, v in item.items() if k not in ("asset_id", "explanation")
+                    },
+                }
+            ],
             evidence_refs=[asset_id],
             risk_tier=RISK_MEDIUM,
             scope={"level": "workspace"},
@@ -745,8 +769,12 @@ def _decremental_candidates(extras: Dict[str, Any], *, dry_run: bool) -> List[Di
         )
         if candidate_id:
             created.append(
-                {"candidate_id": candidate_id, "kind": "retirement", "asset_id": asset_id,
-                 "reason": item.get("reason")}
+                {
+                    "candidate_id": candidate_id,
+                    "kind": "retirement",
+                    "asset_id": asset_id,
+                    "reason": item.get("reason"),
+                }
             )
     return created
 
@@ -772,9 +800,7 @@ def _orchestration_candidates(
     base_tools = [str(t) for t in get_enabled_ids("tools")] + [
         str(t) for t in get_enabled_ids("mcp")
     ]
-    offered_tools = {
-        str(view.get("task_type") or "chat"): base_tools for view in views
-    }
+    offered_tools = {str(view.get("task_type") or "chat"): base_tools for view in views}
     proposals, subagents = generate_orchestration_proposals(
         views, offered_tools=offered_tools, parent_tools=base_tools
     )
@@ -832,7 +858,9 @@ def _orchestration_candidates(
             created.append({"dry_run": True, "kind": "agent_profile", "task_type": task_type})
             continue
         candidate_id = _persist_candidate(
-            ir, credit=decision.to_dict(), proposer="orchestration_engine",
+            ir,
+            credit=decision.to_dict(),
+            proposer="orchestration_engine",
             evidence_refs=evidence,
         )
         if candidate_id:
@@ -875,7 +903,9 @@ def _orchestration_candidates(
             created.append({"dry_run": True, "kind": "subagent", "name": subagent.name})
             continue
         candidate_id = _persist_candidate(
-            ir, credit=decision.to_dict(), proposer="orchestration_engine",
+            ir,
+            credit=decision.to_dict(),
+            proposer="orchestration_engine",
             evidence_refs=subagent.evidence_refs,
         )
         if candidate_id:
@@ -913,9 +943,7 @@ def _prompt_candidates(views: List[Dict[str, Any]], *, dry_run: bool) -> List[Di
     if not decision.may_produce_candidate:
         return []
 
-    asset_id = "auto-prompt-" + hashlib.sha256(
-        payload["fragment"].encode("utf-8")
-    ).hexdigest()[:12]
+    asset_id = "auto-prompt-" + hashlib.sha256(payload["fragment"].encode("utf-8")).hexdigest()[:12]
     ir = EvolutionIR(
         target_kind="prompt",
         target_asset_id=asset_id,
@@ -938,7 +966,9 @@ def _prompt_candidates(views: List[Dict[str, Any]], *, dry_run: bool) -> List[Di
     if dry_run:
         return [{"dry_run": True, "kind": "prompt", "asset_id": asset_id}]
     candidate_id = _persist_candidate(
-        ir, credit=decision.to_dict(), proposer="prompt_engine",
+        ir,
+        credit=decision.to_dict(),
+        proposer="prompt_engine",
         evidence_refs=evidence.episode_ids[:20],
     )
     return (
@@ -971,10 +1001,113 @@ def _active_prompt_fragments() -> List[str]:
         return []
 
 
-def _run_other_engines(
+def _graph_evolution_candidates(
     views: List[Dict[str, Any]], *, dry_run: bool
-) -> Dict[str, Any]:
-    """Memory, decremental, intent, orchestration and prompt — each with an exit.
+) -> List[Dict[str, Any]]:
+    """L3 的演进：强化/降权自动执行，语义变更走人工候选。
+
+    Per user, because the graph is per user scope: a contradiction between two
+    people's graphs is not a contradiction at all.
+    """
+    from core.config.settings import settings
+
+    if not (settings.memory.enabled and settings.memory.graph_enabled):
+        return []
+
+    from core.evolution.graph_scan import apply_graph_ops, scan_graph_relations
+
+    observed_by_user: Dict[str, Dict[str, int]] = {}
+    for view in views:
+        user_id = str(view.get("user_id") or "")
+        if not user_id:
+            continue
+        bucket = observed_by_user.setdefault(user_id, {})
+        for relation in view.get("graph_relations") or []:
+            relation_id = str(relation.get("relation_id") or "")
+            if relation_id:
+                bucket[relation_id] = bucket.get(relation_id, 0) + 1
+
+    created: List[Dict[str, Any]] = []
+    for user_id, observed in observed_by_user.items():
+        try:
+            from core.memory.graph import list_graph_relations
+
+            relations = _run_async(list_graph_relations(user_id, limit=200))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[evolution-loop] graph listing failed for %s: %s", user_id, exc)
+            continue
+        if not relations:
+            continue
+
+        ops = scan_graph_relations(relations, observed_relation_ids=observed)
+        if not ops:
+            continue
+        if dry_run:
+            created.append(
+                {"dry_run": True, "kind": "graph", "user_id": user_id, "ops": len(ops)}
+            )
+            continue
+
+        outcome = apply_graph_ops(ops, scope_user_id=user_id)
+        manual = outcome.get("manual") or []
+        entry: Dict[str, Any] = {
+            "kind": "graph",
+            "user_id": user_id,
+            "auto_applied": len(outcome.get("applied") or []),
+            "manual_proposed": len(manual),
+        }
+        if manual:
+            decision = aggregate_finding(
+                target=T_MEMORY,
+                explanation="；".join(str(op.get("reason") or "") for op in manual[:3]),
+                confidence=confidence_from_evidence(len(manual), saturates_at=6),
+                evidence_count=len(manual),
+            )
+            if decision.may_produce_candidate:
+                asset_id = "graph-" + hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:12]
+                ir = EvolutionIR(
+                    target_kind="memory",
+                    target_asset_id=asset_id,
+                    base_version="current",
+                    operation="update",
+                    hypothesis=(
+                        f"图谱有 {len(manual)} 处语义变更需要人工裁决："
+                        + "；".join(str(op.get("reason") or "") for op in manual[:3])
+                    ),
+                    changes=[{"user_id": user_id, "graph_ops": manual}],
+                    evidence_refs=[
+                        str(op.get("relation_id") or "") for op in manual if op.get("relation_id")
+                    ][:20],
+                    risk_tier=RISK_MEDIUM,
+                    scope={"level": "user", "user_id": user_id},
+                    rollback=Rollback(version_id="current", triggers=["manual"]),
+                    evaluation_plan={"replay_set": "personal", "primary_metric": "task_success"},
+                )
+                try:
+                    validate_ir(
+                        ir,
+                        credit_decision=decision.to_dict(),
+                        allowed_scopes=["user", "workspace"],
+                    )
+                except InvariantViolation as violation:
+                    logger.info(
+                        "[evolution-loop] graph candidate rejected: %s", violation.code
+                    )
+                else:
+                    candidate_id = _persist_candidate(
+                        ir,
+                        credit=decision.to_dict(),
+                        proposer="graph_engine",
+                        evidence_refs=list(ir.evidence_refs),
+                    )
+                    if candidate_id:
+                        entry["candidate_id"] = candidate_id
+        created.append(entry)
+    return created
+
+
+def _run_other_engines(views: List[Dict[str, Any]], *, dry_run: bool) -> Dict[str, Any]:
+    """Memory, decremental, intent, orchestration, prompt and graph — each with an exit.
 
     Independently guarded: a failure in one engine must not cost the others
     their findings, because they answer different questions and an operator
@@ -992,6 +1125,7 @@ def _run_other_engines(
         ("decremental", lambda: _decremental_candidates(extras, dry_run=dry_run)),
         ("orchestration", lambda: _orchestration_candidates(views, dry_run=dry_run)),
         ("prompt", lambda: _prompt_candidates(views, dry_run=dry_run)),
+        ("graph", lambda: _graph_evolution_candidates(views, dry_run=dry_run)),
     ):
         try:
             produced.extend(fn())
@@ -1011,9 +1145,7 @@ def _run_other_engines(
     return {"extras": extras, "engine_candidates": produced}
 
 
-def run_evolution_cycle(
-    *, limit: int = 500, dry_run: bool = False
-) -> Dict[str, Any]:
+def run_evolution_cycle(*, limit: int = 500, dry_run: bool = False) -> Dict[str, Any]:
     """One fleet-wide pass: discover → attribute → promote → validate → persist.
 
     Returns a report rather than raising: this runs as a background job and a
@@ -1037,9 +1169,7 @@ def run_evolution_cycle(
 
     readiness = check_readiness()
     if not readiness.ready:
-        logger.warning(
-            "[evolution-loop] not ready, refusing to run: %s", readiness.blocking
-        )
+        logger.warning("[evolution-loop] not ready, refusing to run: %s", readiness.blocking)
         return {
             "episodes": 0,
             "patterns": 0,
@@ -1075,8 +1205,17 @@ def run_evolution_cycle(
     constraints = P.extract_ordering_constraints(views)
     report["ordering_constraints"] = [c.to_dict() for c in constraints]
 
+    from core.evolution.skill_candidate_engine import (
+        STATUS_CREATED,
+        STATUS_DRY_RUN,
+        STATUS_REJECTED,
+        SkillCandidateSpec,
+        create_skill_candidate,
+    )
+
     existing_signatures: Dict[str, str] = {}
     covered_tool_sets: List[List[str]] = []
+    by_episode_id = {str(v.get("episode_id") or ""): v for v in views}
 
     for pattern in patterns:
         decision = assign_credit(_features_for(pattern))
@@ -1102,64 +1241,55 @@ def run_evolution_cycle(
         asset_id = proposal.patch_target or (
             "auto-" + hashlib.sha256(proposal.signature.encode("utf-8")).hexdigest()[:12]
         )
-        ir = EvolutionIR(
-            target_kind="skill",
-            target_asset_id=asset_id,
-            base_version="v0" if not proposal.patch_target else "current",
-            operation="patch" if proposal.patch_target else "new",
+        sequence = [str(t) for t in proposal.payload.get("tool_sequence", [])]
+        supporting = [
+            by_episode_id[e]
+            for e in (proposal.payload.get("episode_ids") or [])
+            if e in by_episode_id
+        ]
+        spec = SkillCandidateSpec(
+            asset_id=asset_id,
+            proposer="promotion_chain",
             hypothesis=proposal.rationale,
-            changes=[
-                {
-                    "tool_sequence": proposal.payload.get("tool_sequence", []),
-                    # Attach every rule whose tools this skill touches, and
-                    # carry its scope along with it.
-                    #
-                    # Attaching must not apply the usability policy: doing so
-                    # dropped exactly the context-dependent rules the scoping
-                    # exists to preserve — a rule contradicted in one task type
-                    # is still valid in the ones where it held, and that
-                    # decision belongs at use time, where the context is known.
-                    "ordering_constraints": [
-                        c.to_dict()
-                        for c in constraints
-                        if c.before in proposal.payload.get("tool_sequence", [])
-                        and c.after in proposal.payload.get("tool_sequence", [])
-                    ],
-                }
+            views=supporting,
+            tool_sequence=sequence,
+            # Attach every rule whose tools this skill touches, and carry its
+            # scope along with it. Attaching must not apply the usability
+            # policy: doing so dropped exactly the context-dependent rules the
+            # scoping exists to preserve — a rule contradicted in one task type
+            # is still valid in the ones where it held, and that decision
+            # belongs at use time, where the context is known.
+            ordering_constraints=[
+                c.to_dict()
+                for c in constraints
+                if c.before in sequence and c.after in sequence
             ],
-            evidence_refs=proposal.payload.get("episode_ids", []),
+            operation="patch" if proposal.patch_target else "new",
+            base_version="current" if proposal.patch_target else "v0",
             # A brand-new capability is riskier than tweaking an existing one.
             risk_tier=RISK_MEDIUM if proposal.patch_target else RISK_HIGH,
             scope={"level": "workspace"},
-            rollback=Rollback(
-                version_id="v0" if not proposal.patch_target else "current",
-                triggers=["success -3pp", "risk_denial_rate +2pp"],
+            tenant_id=str(
+                (supporting[0].get("tenant_id") if supporting else "") or "default"
             ),
-            evaluation_plan={"replay_set": "auto_holdout", "primary_metric": "task_success"},
+            write_document=False,
         )
-
-        try:
-            validate_ir(ir, credit_decision=decision.to_dict(), base_tools=None)
-        except InvariantViolation as violation:
+        outcome = create_skill_candidate(spec, credit=decision.to_dict(), dry_run=dry_run)
+        status = outcome.get("status")
+        if status == STATUS_REJECTED:
             report["rejected"].append(
-                {"signature": proposal.signature, "code": violation.code}
+                {"signature": proposal.signature, "code": outcome.get("code")}
             )
-            continue
-
-        if dry_run:
+        elif status == STATUS_DRY_RUN:
             report["candidates"].append({"dry_run": True, "signature": proposal.signature})
-            continue
-
-        candidate_id = _persist_candidate(
-            ir,
-            credit=decision.to_dict(),
-            proposer="promotion_chain",
-            evidence_refs=proposal.payload.get("episode_ids", []),
-        )
-        if candidate_id:
-            covered_tool_sets.append(list(proposal.payload.get("tool_sequence") or []))
+        elif status == STATUS_CREATED:
+            covered_tool_sets.append(sequence)
             report["candidates"].append(
-                {"candidate_id": candidate_id, "signature": proposal.signature}
+                {
+                    "candidate_id": outcome["candidate_id"],
+                    "signature": proposal.signature,
+                    "evidence_pack_id": outcome.get("pack_id", ""),
+                }
             )
 
     # ── Ordering rules that no sequence candidate carries ────────────────────
@@ -1177,82 +1307,62 @@ def run_evolution_cycle(
             report["no_update"] += 1
         else:
             rule_payload = [c.to_dict() for c in orphan_rules]
-            signature = "|".join(
-                sorted(f"{c.before}<{c.after}" for c in orphan_rules)
-            )
-            asset_id = "auto-rules-" + hashlib.sha256(
-                signature.encode("utf-8")
-            ).hexdigest()[:12]
-            episode_ids = sorted(
-                {
-                    view["episode_id"]
-                    for view in views
-                    if view.get("verdict") == "success"
-                    and any(
-                        c.before in (view.get("tool_sequence") or [])
-                        and c.after in (view.get("tool_sequence") or [])
-                        for c in orphan_rules
-                    )
-                }
-            )[:20]
-            rule_ir = EvolutionIR(
-                target_kind="skill",
-                target_asset_id=asset_id,
-                base_version="v0",
-                operation="new",
+            signature = "|".join(sorted(f"{c.before}<{c.after}" for c in orphan_rules))
+            asset_id = "auto-rules-" + hashlib.sha256(signature.encode("utf-8")).hexdigest()[:12]
+            supporting_views = [
+                view
+                for view in views
+                if view.get("verdict") == "success"
+                and any(
+                    c.before in (view.get("tool_sequence") or [])
+                    and c.after in (view.get("tool_sequence") or [])
+                    for c in orphan_rules
+                )
+            ]
+            rule_spec = SkillCandidateSpec(
+                asset_id=asset_id,
+                proposer="promotion_chain",
                 hypothesis=(
-                    f"{len(orphan_rules)} 条工具顺序约束在 {len(episode_ids)} 条成功执行中"
+                    f"{len(orphan_rules)} 条工具顺序约束在 {len(supporting_views)} 条成功执行中"
                     "稳定成立且跨多种工具组合复现，但规划阶段每次仍可能排错"
                 ),
-                changes=[
-                    {
-                        # Deliberately empty: this asset claims no fixed sequence,
-                        # only constraints. Materialisation renders it as rules.
-                        "tool_sequence": [],
-                        "ordering_constraints": rule_payload,
-                    }
-                ],
-                evidence_refs=episode_ids,
+                views=supporting_views,
+                # Deliberately no tool sequence: this asset claims no fixed
+                # order of its own, only constraints. Materialisation renders
+                # it as rules.
+                tool_sequence=[],
+                ordering_constraints=rule_payload,
+                operation="new",
+                base_version="v0",
                 risk_tier=RISK_HIGH,
                 scope={"level": "workspace"},
-                rollback=Rollback(
-                    version_id="v0",
-                    triggers=["success -3pp", "risk_denial_rate +2pp"],
+                tenant_id=str(
+                    (supporting_views[0].get("tenant_id") if supporting_views else "")
+                    or "default"
                 ),
-                evaluation_plan={
-                    "replay_set": "auto_holdout",
-                    "primary_metric": "task_success",
-                },
+                write_document=False,
             )
-            try:
-                validate_ir(
-                    rule_ir, credit_decision=rule_decision.to_dict(), base_tools=None
-                )
-            except InvariantViolation as violation:
-                report["rejected"].append(
-                    {"signature": signature, "code": violation.code}
-                )
+            outcome = create_skill_candidate(
+                rule_spec, credit=rule_decision.to_dict(), dry_run=dry_run
+            )
+            status = outcome.get("status")
+            if status == STATUS_REJECTED:
+                report["rejected"].append({"signature": signature, "code": outcome.get("code")})
             else:
                 report["proposals"] += 1
-                if dry_run:
+                if status == STATUS_DRY_RUN:
                     report["candidates"].append(
                         {"dry_run": True, "signature": signature, "kind": "ordering_rules"}
                     )
-                else:
-                    rule_candidate_id = _persist_candidate(
-                        rule_ir,
-                        credit=rule_decision.to_dict(),
-                        proposer="promotion_chain",
-                        evidence_refs=episode_ids,
+                elif status == STATUS_CREATED:
+                    report["candidates"].append(
+                        {
+                            "candidate_id": outcome["candidate_id"],
+                            "signature": signature,
+                            "kind": "ordering_rules",
+                            "evidence_pack_id": outcome.get("pack_id", ""),
+                        }
                     )
-                    if rule_candidate_id:
-                        report["candidates"].append(
-                            {
-                                "candidate_id": rule_candidate_id,
-                                "signature": signature,
-                                "kind": "ordering_rules",
-                            }
-                        )
 
     # The other two engines, plus orchestration. Every finding below becomes a
     # candidate in the same table, behind the same security gate and the same
@@ -1302,6 +1412,30 @@ def _record_evaluation(candidate_id: str, report: Any, eval_type: str) -> None:
         logger.warning("[evolution-loop] recording evaluation failed: %s", exc)
 
 
+def _replay_coverage_for(candidate_id: str, task_ids: List[str]) -> Optional[Dict[str, Any]]:
+    """Coverage assessment for candidates that carry an evidence pack.
+
+    Returns ``None`` for pre-pack candidates — the gate governs only what the
+    unified engine produced, so legacy candidates keep their old semantics.
+    """
+    try:
+        from core.evolution import lineage
+        from core.evolution.applicability import assess_replay_coverage
+
+        with SessionLocal() as db:
+            candidate = db.get(EvolutionCandidate, candidate_id)
+            pack_id = str(getattr(candidate, "evidence_pack_id", "") or "")
+        if not pack_id:
+            return None
+        pack = lineage.load_evidence_pack(pack_id)
+        if pack is None:
+            return None
+        return assess_replay_coverage(pack, task_ids)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[evolution-loop] replay coverage check skipped: %s", exc)
+        return None
+
+
 def evaluate_candidate(
     candidate_id: str,
     run_arm: Any,
@@ -1314,12 +1448,7 @@ def evaluate_candidate(
     reachable from here — shadow and canary need real traffic, and activation
     needs a human, so this can never quietly ship anything.
     """
-    from core.evolution.release import (
-        DRAFT,
-        REJECTED,
-        REPLAY_PASSED,
-        is_legal_transition,
-    )
+    from core.evolution.release import DRAFT, REJECTED, REPLAY_PASSED, is_legal_transition
     from core.evolution.replay import VERDICT_IMPROVED, VERDICT_REGRESSED, run_tiered_replay
 
     tiered = run_tiered_replay(task_ids, run_arm)
@@ -1328,6 +1457,25 @@ def evaluate_candidate(
         return None
 
     _record_evaluation(candidate_id, report, "replay" if tiered.passed_sentinel else "sentinel")
+
+    # Replay 覆盖闸门：带证据 pack 的候选，其回放集必须覆盖 pack 声称的行为面
+    # （成功 / 失败恢复 / 负样本 / 图谱依赖两类场景）。只用成功案例喂出来的
+    # "improved" 是单面证据，不允许换来 replay_passed；回归照常生效——安全
+    # 方向的结论不需要覆盖完整也成立。
+    coverage: Optional[Dict[str, Any]] = None
+    if report.verdict == VERDICT_IMPROVED:
+        coverage = _replay_coverage_for(candidate_id, task_ids)
+        if coverage is not None and not coverage.get("covered", True):
+            return {
+                "candidate_id": candidate_id,
+                "verdict": report.verdict,
+                "status": DRAFT,
+                "transition": "held_insufficient_coverage",
+                "coverage": coverage,
+                "tasks_run": tiered.tasks_run,
+                "effect_size": report.effect_size,
+                "p_value": report.p_value,
+            }
 
     try:
         with SessionLocal() as db:

--- a/src/backend/core/evolution/runtime_binding.py
+++ b/src/backend/core/evolution/runtime_binding.py
@@ -160,15 +160,29 @@ def _memory_refs(memory_enabled: bool, workspace_id: str) -> List[AssetRef]:
 
     # The memory *policy* is what evolves; the memory contents are evidence, not
     # a pinned version. Recording the policy knobs is what lets a later replay
-    # reproduce the same retrieval behaviour.
+    # reproduce the same retrieval behaviour. Per-layer, because attribution
+    # needs to distinguish "L3 offered nothing" from "L3 was switched off" —
+    # a single opaque flag cannot answer which policy a given Episode ran under.
+    effective = bool(memory_enabled and settings.memory.enabled)
     return [
         AssetRef(
             kind=ASSET_MEMORY,
             asset_id=f"policy:{workspace_id or 'default'}",
-            version="v1",
+            version="v2",
             detail={
-                "enabled": bool(memory_enabled and settings.memory.enabled),
+                "enabled": effective,
                 "retrieval_budget_ms": settings.memory.retrieval_budget_ms,
+                "layers": {
+                    "profile": {"enabled": effective},
+                    "fact": {
+                        "enabled": effective,
+                        "layered": bool(settings.memory.layered_enabled),
+                        "dedup_min_score": settings.memory.procedure_dedup_min_score,
+                    },
+                    "graph": {
+                        "enabled": bool(effective and settings.memory.graph_enabled),
+                    },
+                },
             },
         )
     ]

--- a/src/backend/core/evolution/settlement.py
+++ b/src/backend/core/evolution/settlement.py
@@ -49,15 +49,16 @@ SETTLE_EMPTY = "empty"
 # Layers a written memory can belong to.
 LAYER_PROFILE = "L1"
 LAYER_PROCEDURE = "L2"
+LAYER_GRAPH = "L3"
 
 
 @dataclass
 class MemoryEntry:
     """One memory written this turn, as shown on the card.
 
-    ``handle`` is what makes the entry actionable: a mem0 id for an L2 procedure,
-    a profile field key for an L1 entry. An entry without one cannot be edited or
-    deleted, so it is never emitted.
+    ``handle`` is what makes the entry actionable: a profile field key for L1,
+    a mem0 id for L2, or a Neo4j relation id for L3. An entry without one cannot
+    be corrected or deleted, so it is never emitted.
     """
 
     layer: str

--- a/src/backend/core/evolution/skill_candidate_engine.py
+++ b/src/backend/core/evolution/skill_candidate_engine.py
@@ -1,0 +1,294 @@
+"""统一技能候选引擎 — 所有技能候选的唯一生产入口（P2/P3）.
+
+在此之前，技能候选有两条平行的构造路径：意图聚类（loop 的 intent 路径，LLM
+写文档）和重复工具序列（loop 的 promotion 路径，只存序列）。同类证据从两条
+路径进来会产出结构不同的技能——一条有 manifest 一条没有、校验一条严一条松。
+
+这里把两条路径收敛到同一条编译链：
+
+    证据 views → Evidence Resolver（不可变 pack）
+              → build_manifest（代码生成确定性结构：工具/边界/依赖/风险）
+              → （可选）LLM 撰写 SKILL.md（skill_gen 三段式）
+              → validate_candidate_structure（分层边界强制校验）
+              → EvolutionIR → validate_ir（安全不变量）
+              → 持久化（candidate + evidence_pack + credit decision）
+
+LLM 只出现在其中一步，且只写正文；工具授权、作用域、证据来源、发布风险全部
+由代码决定——这是「两段式生成」的边界所在。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from core.evolution.evidence_contract import (
+    CapabilityEvidencePackV2,
+    build_manifest,
+    validate_candidate_structure,
+)
+from core.evolution.evidence_resolver import resolve_capability_pack
+from core.evolution.ir import (
+    RISK_HIGH,
+    EvolutionIR,
+    InvariantViolation,
+    Rollback,
+    new_candidate_id,
+    validate_ir,
+)
+
+logger = logging.getLogger(__name__)
+
+STATUS_CREATED = "created"
+STATUS_DRY_RUN = "dry_run"
+STATUS_NOT_WRITTEN = "not_written"
+STATUS_REJECTED = "rejected"
+
+
+@dataclass
+class SkillCandidateSpec:
+    """One skill candidate, described by its evidence rather than its shape."""
+
+    asset_id: str
+    proposer: str
+    hypothesis: str
+    views: List[Dict[str, Any]] = field(default_factory=list)
+    intent_cluster: Dict[str, Any] = field(default_factory=dict)
+    procedures: List[Dict[str, Any]] = field(default_factory=list)
+    tool_sequence: List[str] = field(default_factory=list)
+    ordering_constraints: List[Dict[str, Any]] = field(default_factory=list)
+    operation: str = "new"
+    base_version: str = "v0"
+    risk_tier: str = RISK_HIGH
+    scope: Dict[str, str] = field(default_factory=lambda: {"level": "workspace"})
+    tenant_id: str = "default"
+    # 意图路径写文档；序列/规则路径不写（它们的价值在结构，不在正文）。
+    write_document: bool = True
+    rollback_triggers: List[str] = field(
+        default_factory=lambda: ["success -3pp", "risk_denial_rate +2pp"]
+    )
+
+
+def create_skill_candidate(
+    spec: SkillCandidateSpec,
+    *,
+    credit: Dict[str, Any],
+    dry_run: bool = False,
+    run_async: Optional[Callable[[Any], Any]] = None,
+) -> Dict[str, Any]:
+    """Compile one skill candidate through the unified chain.
+
+    Returns a result dict with ``status`` ∈ {created, dry_run, not_written,
+    rejected} — callers format their own report entries from it. Never raises:
+    this runs inside a background cycle where one bad candidate must not cost
+    the rest of the batch.
+    """
+    pack = resolve_capability_pack(
+        views=spec.views,
+        intent_cluster=spec.intent_cluster,
+        procedures=spec.procedures,
+        ordering_constraints=spec.ordering_constraints,
+        scope=spec.scope,
+        tenant_id=spec.tenant_id,
+    )
+    # 序列路径的工具来自模式本身而非成功 Episode 的并集时，以模式为准，
+    # 但仍必须是 Episode 证据的子集——这在结构校验里强制。
+    if spec.tool_sequence and not pack.required_tools:
+        pack.required_tools = [str(t) for t in spec.tool_sequence]
+
+    scope_level = str(spec.scope.get("level") or "workspace")
+    manifest = build_manifest(pack, scope_level=scope_level, risk_tier=spec.risk_tier)
+
+    document: Optional[Dict[str, Any]] = None
+    draft_info: Dict[str, Any] = {}
+    if spec.write_document:
+        if run_async is None:
+            return {"status": STATUS_REJECTED, "code": "no_async_runner"}
+        import core.evolution.skill_gen as skill_gen
+
+        document, draft = run_async(
+            skill_gen.generate_skill_document(
+                skill_id=spec.asset_id,
+                episodes=spec.views,
+                ordering_constraints=spec.ordering_constraints,
+                procedures=[
+                    {
+                        "rule": p.get("rule", ""),
+                        "why": p.get("why", ""),
+                        "applies_to": p.get("applies_to", ""),
+                    }
+                    for p in spec.procedures
+                ],
+                rationale=spec.hypothesis,
+            )
+        )
+        draft_info = draft.to_dict()
+        if document is None:
+            return {
+                "status": STATUS_NOT_WRITTEN,
+                "why_not": draft_info,
+                "pack_id": pack.pack_id,
+            }
+
+    document_tools = (
+        [str(t) for t in (document.get("allowed_tools") or [])]
+        if document
+        else [str(t) for t in spec.tool_sequence]
+    )
+    body = str((document or {}).get("content") or "")
+    violations = validate_candidate_structure(
+        pack=pack,
+        manifest=manifest,
+        document_tools=document_tools,
+        body=body,
+        scope_level=scope_level,
+    )
+    if violations:
+        logger.info(
+            "[skill-engine] candidate %s rejected by structure validation: %s",
+            spec.asset_id,
+            violations,
+        )
+        return {
+            "status": STATUS_REJECTED,
+            "code": "structure_violation",
+            "violations": violations,
+            "pack_id": pack.pack_id,
+        }
+
+    change: Dict[str, Any] = {
+        "tool_sequence": [] if document else [str(t) for t in spec.tool_sequence],
+        "ordering_constraints": [dict(r) for r in spec.ordering_constraints],
+        "manifest": manifest,
+    }
+    if document is not None:
+        change["document"] = document
+        change["source_memories"] = [
+            {
+                "ref": str((p.get("ref") or {}).get("external_id") or ""),
+                "user_id": str(p.get("user_id") or ""),
+            }
+            for p in pack.procedures
+            if (p.get("ref") or {}).get("external_id")
+        ]
+
+    episode_ids = [str(e.get("episode_id") or "") for e in pack.episodes if e.get("episode_id")]
+    ir = EvolutionIR(
+        target_kind="skill",
+        target_asset_id=spec.asset_id,
+        base_version=spec.base_version,
+        operation=spec.operation,
+        hypothesis=spec.hypothesis,
+        changes=[change],
+        evidence_refs=episode_ids[:20],
+        requested_tools=document_tools,
+        risk_tier=spec.risk_tier,
+        scope=dict(spec.scope),
+        rollback=Rollback(version_id=spec.base_version, triggers=list(spec.rollback_triggers)),
+        evaluation_plan={
+            "replay_set": "auto_holdout",
+            "primary_metric": "task_success",
+            # Replay 覆盖要求由 pack 派生，评估器据此拒绝覆盖不足的回放集。
+            "coverage": {
+                "needs_failure_case": bool(pack.failure_recoveries),
+                "needs_negative_example": bool(pack.negative_examples),
+                "needs_graph_dependency_case": bool(manifest.get("dependencies")),
+            },
+        },
+    )
+    try:
+        validate_ir(
+            ir,
+            credit_decision=credit,
+            base_tools=document_tools if document else None,
+        )
+    except InvariantViolation as violation:
+        return {
+            "status": STATUS_REJECTED,
+            "code": violation.code,
+            "pack_id": pack.pack_id,
+        }
+
+    if dry_run:
+        return {"status": STATUS_DRY_RUN, "pack_id": pack.pack_id, "draft": draft_info}
+
+    candidate_id = _persist(ir, pack=pack, credit=credit, proposer=spec.proposer)
+    if not candidate_id:
+        return {"status": STATUS_REJECTED, "code": "persist_failed", "pack_id": pack.pack_id}
+    return {
+        "status": STATUS_CREATED,
+        "candidate_id": candidate_id,
+        "pack_id": pack.pack_id,
+        "pack_hash": pack.content_hash(),
+        "attempts": int(draft_info.get("attempts") or 0),
+        "manifest": manifest,
+    }
+
+
+def _persist(
+    ir: EvolutionIR,
+    *,
+    pack: CapabilityEvidencePackV2,
+    credit: Dict[str, Any],
+    proposer: str,
+) -> Optional[str]:
+    """Candidate + pack + credit decision, in that dependency order.
+
+    The pack and the decision are content-addressed, so a duplicate candidate
+    (same checksum) simply reuses the rows the first one wrote.
+    """
+    from core.db.engine import SessionLocal
+    from core.db.models.evolution import EvolutionCandidate
+    from core.evolution import lineage
+    from core.evolution.release import DRAFT
+
+    pack_outcome = lineage.persist_evidence_pack(pack)
+    decision_id = lineage.record_credit_decision(
+        credit, episode_id=(ir.evidence_refs[0] if ir.evidence_refs else "")
+    )
+    stored_credit = {**credit, "decision_id": decision_id}
+
+    checksum = ir.change_checksum()
+    try:
+        with SessionLocal() as db:
+            existing = (
+                db.query(EvolutionCandidate)
+                .filter(
+                    EvolutionCandidate.target_kind == ir.target_kind,
+                    EvolutionCandidate.target_asset_id == ir.target_asset_id,
+                    EvolutionCandidate.base_version_id == (ir.base_version or None),
+                    EvolutionCandidate.change_checksum == checksum,
+                )
+                .first()
+            )
+            if existing is not None:
+                # 同一修改再次被提出：一条评审项，不是两条。pack 引用留旧值，
+                # 因为旧行的证据仍然可解析。
+                return existing.candidate_id
+
+            candidate_id = new_candidate_id()
+            db.add(
+                EvolutionCandidate(
+                    candidate_id=candidate_id,
+                    target_kind=ir.target_kind,
+                    target_asset_id=ir.target_asset_id,
+                    base_version_id=ir.base_version or None,
+                    operation=ir.operation,
+                    ir=ir.to_dict(),
+                    hypothesis=ir.hypothesis,
+                    change_checksum=checksum,
+                    evidence_refs=list(ir.evidence_refs),
+                    evidence_pack_id=pack_outcome.get("pack_id") or None,
+                    credit_decision=stored_credit,
+                    risk_tier=ir.risk_tier,
+                    scope=ir.scope,
+                    status=DRAFT,
+                    proposer=proposer,
+                )
+            )
+            db.commit()
+            return candidate_id
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[skill-engine] persisting candidate failed: %s", exc)
+        return None

--- a/src/backend/core/evolution/user_settings.py
+++ b/src/backend/core/evolution/user_settings.py
@@ -167,6 +167,43 @@ def personal_action(candidate) -> Optional[Dict[str, str]]:
     return None
 
 
+def _personally_activated_ids(db, user_id: str, candidate_ids: List[str]) -> set:
+    """Candidates this user has already turned into a live personal release.
+
+    A personal activation deliberately leaves the candidate's status untouched
+    so others (and an administrator) can still act on it — which means status
+    alone cannot tell "this user already accepted it". The release record can:
+    it is scoped to the owner at activation. Terminal stages (rolled back /
+    retired / rejected) do not count, so a user who undid a personal skill is
+    offered it again rather than locked out.
+    """
+    if not candidate_ids:
+        return set()
+    out = set()
+    try:
+        from core.db.models.evolution import EvolutionRelease
+        from core.evolution.release import TERMINAL_STAGES
+
+        for release in (
+            db.query(EvolutionRelease)
+            .filter(EvolutionRelease.candidate_id.in_(candidate_ids))
+            .all()
+        ):
+            scope = release.scope_filter or {}
+            if str(scope.get("owner_user_id") or "") != user_id:
+                continue
+            if str(release.stage or "") in TERMINAL_STAGES:
+                continue
+            out.add(release.candidate_id)
+    except Exception as exc:
+        # Degrade to "exclude nothing": a broken release lookup must not empty
+        # the whole queue, and re-offering an accepted candidate is the safer
+        # failure (a repeat activation is idempotent in effect).
+        logger.warning("[evo-settings] personal release lookup failed: %s", exc)
+        db.rollback()
+    return out
+
+
 def pending_for_user(user_id: str, *, limit: int = 20) -> List[Dict[str, Any]]:
     """Candidates this user may approve for themselves.
 
@@ -192,14 +229,25 @@ def pending_for_user(user_id: str, *, limit: int = 20) -> List[Dict[str, Any]]:
             if not own_ids:
                 return []
 
-            out: List[Dict[str, Any]] = []
-            for candidate in (
+            candidates = (
                 db.query(EvolutionCandidate)
                 .filter(EvolutionCandidate.status.in_(("draft", "replay_passed")))
                 .order_by(EvolutionCandidate.created_at.desc())
                 .limit(200)
                 .all()
-            ):
+            )
+            # A skill candidate the user already accepted stays draft/replay_passed
+            # by design (its life continues for others), so without this it would
+            # reappear on every refresh — an "enable" button for something already
+            # enabled, whose second press just stamps out a duplicate release.
+            already_mine = _personally_activated_ids(
+                db, user_id, [c.candidate_id for c in candidates]
+            )
+
+            out: List[Dict[str, Any]] = []
+            for candidate in candidates:
+                if candidate.candidate_id in already_mine:
+                    continue
                 refs = set(candidate.evidence_refs or [])
                 if not refs:
                     continue
@@ -302,6 +350,12 @@ def approve_for_user(candidate_id: str, user_id: str) -> Dict[str, Any]:
     allowed = {c["candidate_id"]: c for c in pending_for_user(user_id, limit=200)}
     row = allowed.get(candidate_id)
     if row is None:
+        # Distinguish "already yours" from "not yours to approve" — a stale tab
+        # or double click lands here, and telling that user they lack permission
+        # over a skill they just installed reads as a failure.
+        with SessionLocal() as db:
+            if candidate_id in _personally_activated_ids(db, user_id, [candidate_id]):
+                raise PermissionError("该候选你已启用过，对应能力已在你的技能列表中，无需重复启用")
         raise PermissionError(
             "该候选无法由你单独批准：可能主要来自他人的对话证据，或属于影响全体成员的编排/退役变更，需管理员审批"
         )

--- a/src/backend/core/llm/agent_factory.py
+++ b/src/backend/core/llm/agent_factory.py
@@ -1688,6 +1688,17 @@ async def create_agent_executor(
         )
     elif isolated:
         _max_iters = _DEFAULT_SUBAGENT_ITERS
+    else:
+        # Main-agent env override for long-running tasks. Wins over the profile
+        # value: the profile validation range tops out at 80 turns, far below
+        # what e.g. a multi-hour report-generation run needs. Read per-call so
+        # ops can adjust without code changes (container restart still needed).
+        _env_iters = (os.getenv("CHAT_MAIN_MAX_ITERS") or "").strip()
+        if _env_iters:
+            try:
+                _max_iters = max(3, int(_env_iters))
+            except ValueError:
+                _log.warning("[factory] 非法 CHAT_MAIN_MAX_ITERS=%r，忽略", _env_iters)
 
     # ── Create the Agent (AgentScope 2.0) ──
     # Note: long_term_memory is not passed — mem0 is fully stripped from the SSE

--- a/src/backend/core/llm/middlewares.py
+++ b/src/backend/core/llm/middlewares.py
@@ -19,6 +19,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import time
 from contextvars import ContextVar
 from pathlib import Path
@@ -640,15 +641,51 @@ class IterBudgetReminderMiddleware(MiddlewareBase):
             self._maybe_remind(agent)
         except Exception as exc:  # noqa: BLE001
             logger.warning("[iter_budget] failed: %s", exc)
+        try:
+            input_kwargs = self._maybe_force_text(agent, input_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[iter_budget] force-text failed: %s", exc)
         async for evt in next_handler(**input_kwargs):
             yield evt
 
-    def _maybe_remind(self, agent: Agent) -> None:
+    def _remaining(self, agent: Agent) -> tuple[int, int]:
+        """Return (max_iters, remaining-including-current-round)."""
         max_iters = int(getattr(agent.react_config, "max_iters", 0) or 0)
+        cur_iter = int(getattr(agent.state, "cur_iter", 0) or 0)
+        return max_iters, max_iters - cur_iter
+
+    def _maybe_force_text(self, agent: Agent, input_kwargs: dict) -> dict:
+        """Final round: force tool_choice="none" so the model can only produce text.
+
+        The reminder alone is advisory — a model that still emits a tool call in
+        the final round trips AgentScope's hard limit and the whole turn's output
+        is discarded. Forcing text turns the hard error into a guaranteed clean
+        exit (the loop sees no tool calls and yields the reply Msg). Skipped for
+        micro budgets (same guard as the reminder) and when a caller already
+        pinned an explicit tool_choice. Kill-switch: CHAT_FINAL_ITER_FORCE_TEXT=false.
+        """
+        if (os.getenv("CHAT_FINAL_ITER_FORCE_TEXT") or "true").strip().lower() in (
+            "0", "false", "off", "no",
+        ):
+            return input_kwargs
+        max_iters, remaining = self._remaining(agent)
+        if max_iters <= self._threshold + 1 or remaining > 1:
+            return input_kwargs
+        if input_kwargs.get("tool_choice") is not None:
+            return input_kwargs
+        from agentscope.tool import ToolChoice
+
+        logger.info(
+            "[iter_budget] final round (max_iters=%d): forcing tool_choice=none for clean delivery",
+            max_iters,
+        )
+        return {**input_kwargs, "tool_choice": ToolChoice(mode="none")}
+
+    def _maybe_remind(self, agent: Agent) -> None:
+        max_iters, remaining = self._remaining(agent)
         if max_iters <= self._threshold + 1:
             return
         cur_iter = int(getattr(agent.state, "cur_iter", 0) or 0)
-        remaining = max_iters - cur_iter  # includes the current round
         if remaining > self._threshold:
             return
         key = (getattr(agent.state, "reply_id", "") or "", cur_iter)

--- a/src/backend/core/memory/__init__.py
+++ b/src/backend/core/memory/__init__.py
@@ -2,8 +2,8 @@
 
 Layered by information stability and access frequency:
 - **L1 Profile** (`profile`): bounded markdown profile, frozen-injected at session start
-- **L2 Fact** (`service`): mem0 + Milvus vector facts, retrieved on demand
-- **L3 Graph** (via `service`/Neo4j): relationship graph, invoked on demand via tools
+- **L2 Procedure** (`service`): mem0 + Milvus reusable procedures, retrieved on demand
+- **L3 Graph** (`graph` + Neo4j): stable entity relationships, retrieved on demand
 - **Session helper layer** (`chats.metadata.session_memory`): per-session task working set
 - **Audit sidechannel** (`audit`): audit trail for all reads and writes
 
@@ -14,25 +14,21 @@ Non-blocking guarantee: memory I/O is never synchronously awaited on the main SS
 Public API (downstream should import from `core.memory`):
 """
 
-from core.memory.context import (
-    MemoryContext,
-    resolve_workspace_id,
-    resolve_allowed_levels,
-)
-from core.memory.sanitizer import (
-    SanitizeResult,
-    sanitize,
-    invalidate_rules_cache,
-    REDACT_PATTERNS,
-    CLASSIFIED_TERMS,
-)
 from core.memory.audit import record as audit_record
 from core.memory.audit import record_batch as audit_record_batch
+from core.memory.context import MemoryContext, resolve_allowed_levels, resolve_workspace_id
 from core.memory.pipeline import (
     CircuitBreaker,
+    get_background_semaphore,
     milvus_breaker,
     schedule_post_response_tasks,
-    get_background_semaphore,
+)
+from core.memory.sanitizer import (
+    CLASSIFIED_TERMS,
+    REDACT_PATTERNS,
+    SanitizeResult,
+    invalidate_rules_cache,
+    sanitize,
 )
 
 __all__ = [

--- a/src/backend/core/memory/extractors/gate.py
+++ b/src/backend/core/memory/extractors/gate.py
@@ -36,6 +36,7 @@ PROMPT = """你是一个记忆写入门卫。判断这轮对话中是否包含**
 - identity: 用户的身份信息（姓名、部门、岗位、单位、联系方式）
 - preference: 稳定的表达偏好（格式、详略、语言风格、明确禁忌）
 - procedural: 可复用的做事方式（步骤顺序、口径定义、校验红线、交付约定）
+- graph: 稳定的实体关系（隶属、负责、依赖、使用、组成、别名、分类）
 - task: 本轮明确提出的多步任务目标（仅本会话内使用）
 
 【判定标准 —— 宁缺毋滥】
@@ -81,8 +82,9 @@ async def llm_write_gate(
     )
     raw = await run_llm_with_prompt(prompt, timeout_s=timeout_s, max_tokens=150)
     if raw is None:
-        logger.info("[memory_gate] LLM unavailable, failing open (%d candidates pass)",
-                    len(candidates))
+        logger.info(
+            "[memory_gate] LLM unavailable, failing open (%d candidates pass)", len(candidates)
+        )
         return candidates
 
     parsed = parse_json(raw, require_key="classes")
@@ -100,7 +102,10 @@ async def llm_write_gate(
     verdict = candidates & approved
     if verdict != candidates:
         dropped = sorted(c.value for c in candidates - verdict)
-        logger.info("[memory_gate] narrowed %s → %s (dropped %s)",
-                    sorted(c.value for c in candidates),
-                    sorted(c.value for c in verdict), dropped)
+        logger.info(
+            "[memory_gate] narrowed %s → %s (dropped %s)",
+            sorted(c.value for c in candidates),
+            sorted(c.value for c in verdict),
+            dropped,
+        )
     return verdict

--- a/src/backend/core/memory/extractors/graph.py
+++ b/src/backend/core/memory/extractors/graph.py
@@ -1,0 +1,77 @@
+"""L3 graph extractor for stable declarative relationships.
+
+The graph is deliberately complementary to the procedural L2 store. It records
+who/what is connected to whom/what, while L2 records how a task should be done.
+Only relationships asserted or explicitly confirmed by the user are eligible;
+assistant-only claims are not evidence.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from core.memory.extractors._base import fill_prompt, parse_json, run_llm_with_prompt
+from core.memory.graph import PREDICATE_LABELS
+
+PROMPT = """你是一个 L3 知识图谱关系抽取器。只抽取用户明确陈述或明确确认的、跨会话仍有价值的稳定实体关系。
+
+【L3 与其它层的边界】
+- L1 是用户身份和表达偏好，不在这里重复保存。
+- L2 是“怎么做”的步骤、顺序、口径和红线，不在这里重复保存。
+- L3 是“谁/什么 与 谁/什么 有什么关系”的声明式知识。
+
+【允许的关系 predicate】
+{predicates}
+
+【适合写入 L3】
+- 组织、团队、人员、项目之间的隶属或负责关系
+- 系统、项目、文档、指标之间的依赖、使用、组成、产出关系
+- 稳定的别名、分类、地理归属和领域概念关系
+
+【绝对不写入】
+- 助手单方面提出、用户没有确认的事实
+- 置信度低于 0.65、指代不清或实体边界不确定的关系
+- 会快速变化的数值、价格、状态、排名、新闻
+- 一次性任务步骤或本轮临时要求
+- 密码、Token、手机号、邮箱、证件号、内网地址等敏感信息
+- 模型凭常识猜出的关系
+
+【实体类型】
+person / organization / team / project / system / document / metric / concept / place / other
+
+【输出格式（严格 JSON，无代码块）】
+{{"relations": [{{
+  "source": "实体A",
+  "source_type": "project",
+  "predicate": "depends_on",
+  "target": "实体B",
+  "target_type": "system",
+  "confidence": 0.9
+}}]}}
+
+没有可靠关系时输出：{{"relations": []}}
+
+今天是 {curr_date}。
+
+对话：
+[USER] {user_msg}
+[ASSISTANT] {assistant_msg}
+
+仅返回合法 JSON。"""
+
+
+async def extract(user_msg: str, assistant_msg: str, timeout_s: int) -> Optional[dict]:
+    predicates = "\n".join(f"- {key}: {label}" for key, label in PREDICATE_LABELS.items())
+    prompt = fill_prompt(
+        PROMPT,
+        user_msg,
+        assistant_msg,
+        extra={"predicates": predicates},
+    )
+    raw = await run_llm_with_prompt(prompt, timeout_s=timeout_s, max_tokens=900)
+    if raw is None:
+        return None
+    parsed = parse_json(raw, require_key="relations")
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("relations"), list):
+        return None
+    return parsed

--- a/src/backend/core/memory/extractors/router.py
+++ b/src/backend/core/memory/extractors/router.py
@@ -24,6 +24,7 @@ import re
 from enum import Enum
 from typing import Optional
 
+from core.config.settings import settings
 from core.memory.context import MemoryContext
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ class ExtractorType(Enum):
     PREFERENCE = "preference"
     TASK = "task"
     PROCEDURAL = "procedural"
+    GRAPH = "graph"
 
 
 # ─── Keyword trigger conditions ─────────────────────────────────────────────────────────
@@ -93,6 +95,12 @@ def classify_conversation(user_msg: str, assistant_msg: str) -> set[ExtractorTyp
         and len((assistant_msg or "").strip()) >= _SUBSTANTIVE_ASSISTANT_CHARS
     ):
         classes.add(ExtractorType.PROCEDURAL)
+        # L3 has the same substance floor as L2, but is deployment-gated. The
+        # extractor itself decides whether the turn contains a stable entity
+        # relation; keywords cannot do that without silently losing aliases,
+        # dependencies, and ownership statements phrased in new ways.
+        if settings.memory.graph_enabled:
+            classes.add(ExtractorType.GRAPH)
 
     return classes
 
@@ -114,13 +122,14 @@ async def run_extractors_with_timeout(
     if not classes:
         return {}
 
-    from core.memory.extractors import identity, preference, procedural, task
+    from core.memory.extractors import graph, identity, preference, procedural, task
 
     runners: dict[ExtractorType, callable] = {
         ExtractorType.IDENTITY: identity.extract,
         ExtractorType.PREFERENCE: preference.extract,
         ExtractorType.TASK: task.extract,
         ExtractorType.PROCEDURAL: procedural.extract,
+        ExtractorType.GRAPH: graph.extract,
     }
 
     async def _wrap(et: ExtractorType):

--- a/src/backend/core/memory/extractors/writers.py
+++ b/src/backend/core/memory/extractors/writers.py
@@ -4,6 +4,7 @@ Dispatches the {ExtractorType: dict} returned by `run_extractors_with_timeout()`
 to the corresponding layer:
 - IDENTITY / PREFERENCE → L1 Profile (one addressable field each)
 - PROCEDURAL → L2 Milvus (core.memory.service.save_procedure_entry)
+- GRAPH → L3 Neo4j (core.memory.graph.write_graph_relations)
 - TASK → Session auxiliary layer (chats.metadata.session_memory)
 
 Every writer must:
@@ -24,10 +25,11 @@ import logging
 from typing import Optional
 
 from core.config.settings import settings
-from core.memory.extractors.router import ExtractorType
 from core.memory.audit import record as audit_record
 from core.memory.audit import record_batch as audit_record_batch
 from core.memory.context import MemoryContext
+from core.memory.extractors.router import ExtractorType
+from core.memory.graph import parse_relation, parse_relations, write_graph_relations
 from core.memory.pipeline import milvus_breaker
 from core.memory.sanitizer import sanitize
 from core.memory.service import (
@@ -41,6 +43,7 @@ logger = logging.getLogger(__name__)
 # Layers a written item can belong to, as reported to the turn card.
 LAYER_PROFILE = "L1"
 LAYER_PROCEDURE = "L2"
+LAYER_GRAPH = "L3"
 
 
 async def write_layered(
@@ -58,6 +61,7 @@ async def write_layered(
     preference_data = results.get(ExtractorType.PREFERENCE)
     task_data = results.get(ExtractorType.TASK)
     procedural_data = results.get(ExtractorType.PROCEDURAL)
+    graph_data = results.get(ExtractorType.GRAPH)
 
     written: list[dict] = []
 
@@ -71,6 +75,12 @@ async def write_layered(
     if procedural_data:
         written += await _write_procedures_to_milvus(procedural_data, ctx)
 
+    # GRAPH → L3 Neo4j. Declarative entity relations stay separate from the
+    # procedural L2 store and therefore cannot be compiled into a skill body as
+    # though a relationship were an instruction.
+    if graph_data:
+        written += await _write_relations_to_neo4j(graph_data, ctx)
+
     # TASK → Session auxiliary layer. Scoped to this conversation, so it is not
     # a long-term memory and never appears on the card.
     if task_data:
@@ -79,10 +89,85 @@ async def write_layered(
     return written
 
 
+async def _write_relations_to_neo4j(data: dict, ctx: MemoryContext) -> list[dict]:
+    """Sanitize and persist stable entity relations in L3."""
+    if not settings.memory.graph_enabled:
+        return []
+
+    candidates = parse_relations(data.get("relations") or [])
+    if not candidates:
+        return []
+
+    accepted = []
+    rejected_audit: list[dict] = []
+    for relation in candidates:
+        source = sanitize(relation.source)
+        target = sanitize(relation.target)
+        # A redacted node has no useful identity ("[REDACTED:email] depends on
+        # X"), so both hard rejects and redactions are withheld from the graph.
+        hits = list(source.hits) + list(target.hits)
+        if source.reject or target.reject or hits:
+            rejected_audit.append(
+                {
+                    "action": "write_rejected",
+                    "layer": LAYER_GRAPH,
+                    "confidentiality": "internal",
+                    "content": relation.text,
+                    "reason": f"sanitizer: {','.join(hits) or 'classified'}",
+                }
+            )
+            continue
+        clean = parse_relation(
+            {
+                **relation.to_dict(),
+                "source": source.text,
+                "target": target.text,
+            }
+        )
+        if clean is not None:
+            accepted.append(clean)
+
+    if rejected_audit:
+        await audit_record_batch(ctx, rejected_audit)
+    if not accepted:
+        return []
+
+    rows = await write_graph_relations(ctx, accepted)
+    if not rows:
+        return []
+
+    await audit_record_batch(
+        ctx,
+        [
+            {
+                "action": "write",
+                "layer": LAYER_GRAPH,
+                "memory_id": row["relation_id"],
+                "content": (f"{row['source']} → {row['relationship']} → {row['target']}"),
+                "reason": "graph_extractor",
+            }
+            for row in rows
+        ],
+    )
+    logger.info("[writer:graph] wrote or reinforced %d relations to L3", len(rows))
+    return [
+        {
+            "layer": LAYER_GRAPH,
+            "kind": "graph_relation",
+            "handle": row["relation_id"],
+            "text": f"{row['source']} → {row['relationship']} → {row['target']}",
+            "action": "reinforce" if int(row.get("seen_count") or 1) > 1 else "write",
+        }
+        for row in rows
+    ]
+
+
 async def _write_profile_from_identity(data: dict, ctx: MemoryContext) -> list[dict]:
     """Batch-upsert identity fields under `identity.<field>` — duplicate values short-circuit, new values overwrite old, single transaction."""
     return await _upsert_profile_facts(
-        data, ctx, namespace="identity",
+        data,
+        ctx,
+        namespace="identity",
         value_fn=lambda f: str(f.get("value", "")),
         confidentiality_aware=True,
     )
@@ -91,7 +176,9 @@ async def _write_profile_from_identity(data: dict, ctx: MemoryContext) -> list[d
 async def _write_profile_from_preference(data: dict, ctx: MemoryContext) -> list[dict]:
     """Batch-upsert preference fields under `preference.<field>`; strength is merged into value."""
     return await _upsert_profile_facts(
-        data, ctx, namespace="preference",
+        data,
+        ctx,
+        namespace="preference",
         value_fn=lambda f: f"{f.get('value', '')}（{f.get('strength', 'weak')}）",
         confidentiality_aware=False,
     )
@@ -133,8 +220,7 @@ async def _upsert_profile_facts(
     try:
         applied = await upsert_fields(target_ctx, fields)
     except Exception as exc:
-        logger.warning("[writer:%s] batch upsert failed (n=%d): %s",
-                       namespace, len(fields), exc)
+        logger.warning("[writer:%s] batch upsert failed (n=%d): %s", namespace, len(fields), exc)
         return []
     return [
         {
@@ -170,8 +256,10 @@ async def _write_procedures_to_milvus(data: dict, ctx: MemoryContext) -> list[di
     worse than not showing it.
     """
     if milvus_breaker.is_open():
-        logger.info("[writer:procedural] milvus breaker open, skipping %d procedures",
-                    len(data.get("procedures") or []))
+        logger.info(
+            "[writer:procedural] milvus breaker open, skipping %d procedures",
+            len(data.get("procedures") or []),
+        )
         return []
 
     procedures = data.get("procedures") or []
@@ -188,11 +276,14 @@ async def _write_procedures_to_milvus(data: dict, ctx: MemoryContext) -> list[di
             continue
         san = sanitize(rule)
         if san.reject:
-            rejected_audit.append({
-                "action": "write_rejected", "layer": "L2",
-                "confidentiality": "internal",
-                "reason": f"sanitizer: {','.join(san.hits)}",
-            })
+            rejected_audit.append(
+                {
+                    "action": "write_rejected",
+                    "layer": "L2",
+                    "confidentiality": "internal",
+                    "reason": f"sanitizer: {','.join(san.hits)}",
+                }
+            )
             continue
         why = (item.get("why") or "")[:200]
         applies_to = (item.get("applies_to") or "")[:80]
@@ -205,15 +296,17 @@ async def _write_procedures_to_milvus(data: dict, ctx: MemoryContext) -> list[di
         if similar:
             reinforced = await reinforce_procedure_entry(similar, strength=strength)
             if reinforced:
-                written.append({
-                    "layer": LAYER_PROCEDURE,
-                    "kind": "procedure",
-                    "handle": similar["id"],
-                    "text": similar.get("memory") or san.text,
-                    "why": why,
-                    "applies_to": applies_to,
-                    "action": "reinforce",
-                })
+                written.append(
+                    {
+                        "layer": LAYER_PROCEDURE,
+                        "kind": "procedure",
+                        "handle": similar["id"],
+                        "text": similar.get("memory") or san.text,
+                        "why": why,
+                        "applies_to": applies_to,
+                        "action": "reinforce",
+                    }
+                )
             continue
 
         # Gate 2: strength decides the lifetime, not whether we listen at all.
@@ -247,15 +340,17 @@ async def _write_procedures_to_milvus(data: dict, ctx: MemoryContext) -> list[di
         milvus_breaker.record_success()
         if not memory_id:
             continue
-        written.append({
-            "layer": LAYER_PROCEDURE,
-            "kind": "procedure",
-            "handle": memory_id,
-            "text": san.text,
-            "why": why,
-            "applies_to": applies_to,
-            "action": "write",
-        })
+        written.append(
+            {
+                "layer": LAYER_PROCEDURE,
+                "kind": "procedure",
+                "handle": memory_id,
+                "text": san.text,
+                "why": why,
+                "applies_to": applies_to,
+                "action": "write",
+            }
+        )
 
     if rejected_audit:
         await audit_record_batch(ctx, rejected_audit)
@@ -277,9 +372,10 @@ async def _write_session_task(data: dict, ctx: MemoryContext) -> int:
         return 0
 
     try:
+        import asyncio
+
         from core.db.engine import SessionLocal
         from core.db.models import ChatSession
-        import asyncio
 
         def _update():
             with SessionLocal() as session:

--- a/src/backend/core/memory/graph.py
+++ b/src/backend/core/memory/graph.py
@@ -1,0 +1,544 @@
+"""Neo4j-backed L3 graph memory.
+
+mem0ai 2.x removed graph-store support from its open-source ``Memory`` class.
+The project still owns a Neo4j service and an L3 product contract, so this
+module keeps that contract local and explicit instead of passing an ignored
+``graph_store`` key to mem0.
+
+L3 stores stable, declarative relationships (entity -- predicate -- entity).
+It deliberately does not store procedures (L2), profile preferences (L1),
+volatile measurements, or raw conversation text.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+import threading
+import unicodedata
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
+
+from core.config.settings import settings
+from core.memory.context import MemoryContext
+
+logger = logging.getLogger(__name__)
+
+
+PREDICATE_LABELS: Dict[str, str] = {
+    "is_a": "属于类别",
+    "part_of": "组成",
+    "belongs_to": "隶属于",
+    "responsible_for": "负责",
+    "depends_on": "依赖",
+    "uses": "使用",
+    "alias_of": "别名为",
+    "located_in": "位于",
+    "produces": "产出",
+    "constrained_by": "受约束于",
+    "related_to": "关联",
+}
+ALLOWED_ENTITY_TYPES = frozenset(
+    {
+        "person",
+        "organization",
+        "team",
+        "project",
+        "system",
+        "document",
+        "metric",
+        "concept",
+        "place",
+        "other",
+    }
+)
+
+_MAX_ENTITY_CHARS = 120
+_MAX_RELATIONS_PER_TURN = 12
+_MIN_CONFIDENCE = 0.65
+_SAFE_NAME = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class GraphRelation:
+    """One validated L3 relation before persistence."""
+
+    source: str
+    predicate: str
+    target: str
+    source_type: str = "other"
+    target_type: str = "other"
+    confidence: float = 0.8
+
+    @property
+    def relationship(self) -> str:
+        return PREDICATE_LABELS[self.predicate]
+
+    @property
+    def text(self) -> str:
+        return f"{self.source} → {self.relationship} → {self.target}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source": self.source,
+            "source_type": self.source_type,
+            "predicate": self.predicate,
+            "relationship": self.relationship,
+            "target": self.target,
+            "target_type": self.target_type,
+            "confidence": self.confidence,
+        }
+
+
+def parse_relation(raw: Any) -> Optional[GraphRelation]:
+    """Validate an extractor item and return its canonical representation."""
+    if not isinstance(raw, dict):
+        return None
+    source = _clean_name(raw.get("source"))
+    target = _clean_name(raw.get("target"))
+    predicate = str(raw.get("predicate") or "").strip().lower()
+    if not source or not target or source == target or predicate not in PREDICATE_LABELS:
+        return None
+
+    source_type = str(raw.get("source_type") or "other").strip().lower()
+    target_type = str(raw.get("target_type") or "other").strip().lower()
+    if source_type not in ALLOWED_ENTITY_TYPES:
+        source_type = "other"
+    if target_type not in ALLOWED_ENTITY_TYPES:
+        target_type = "other"
+    try:
+        confidence = float(raw.get("confidence", 0.8))
+    except (TypeError, ValueError):
+        confidence = 0.8
+    confidence = max(0.0, min(1.0, confidence))
+    if confidence < _MIN_CONFIDENCE:
+        return None
+    return GraphRelation(
+        source=source,
+        predicate=predicate,
+        target=target,
+        source_type=source_type,
+        target_type=target_type,
+        confidence=confidence,
+    )
+
+
+def parse_relations(raw_items: Sequence[Any]) -> list[GraphRelation]:
+    """Validate, de-duplicate, and bound one turn's extracted relations."""
+    relations: list[GraphRelation] = []
+    seen: set[tuple[str, str, str]] = set()
+    for raw in raw_items or []:
+        relation = parse_relation(raw)
+        if relation is None:
+            continue
+        key = (
+            _entity_key(relation.source, relation.source_type),
+            relation.predicate,
+            _entity_key(relation.target, relation.target_type),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        relations.append(relation)
+        if len(relations) >= _MAX_RELATIONS_PER_TURN:
+            break
+    return relations
+
+
+def _clean_name(value: Any) -> str:
+    name = unicodedata.normalize("NFKC", str(value or ""))
+    name = _SAFE_NAME.sub(" ", name).strip(" \t\r\n,，。；;：:")
+    if len(name) < 2 or len(name) > _MAX_ENTITY_CHARS:
+        return ""
+    return name
+
+
+def _normalise_name(value: str) -> str:
+    return _SAFE_NAME.sub(" ", unicodedata.normalize("NFKC", value).lower()).strip()
+
+
+def _entity_key(name: str, entity_type: str) -> str:
+    raw = f"{entity_type}|{_normalise_name(name)}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+
+
+def relation_id_for(relation: GraphRelation, *, scope_user_id: str, workspace_id: str) -> str:
+    raw = "|".join(
+        (
+            scope_user_id,
+            workspace_id or "default",
+            _entity_key(relation.source, relation.source_type),
+            relation.predicate,
+            _entity_key(relation.target, relation.target_type),
+        )
+    )
+    return "grel_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:28]
+
+
+_driver = None
+_driver_lock = threading.Lock()
+_schema_ready = False
+
+
+def _get_driver():
+    """Lazily create the thread-safe Neo4j driver; failures are retryable."""
+    global _driver, _schema_ready
+    if not (settings.memory.enabled and settings.memory.graph_enabled):
+        return None
+    if _driver is not None:
+        return _driver
+    with _driver_lock:
+        if _driver is not None:
+            return _driver
+        try:
+            from neo4j import GraphDatabase
+
+            driver = GraphDatabase.driver(
+                settings.memory.neo4j_url,
+                auth=(settings.memory.neo4j_username, settings.memory.neo4j_password),
+                connection_timeout=3.0,
+            )
+            driver.verify_connectivity()
+            _driver = driver
+            if not _schema_ready:
+                _ensure_schema(driver)
+                _schema_ready = True
+            logger.info("[GraphMemory] Neo4j L3 initialized")
+            return _driver
+        except Exception as exc:  # noqa: BLE001 - optional memory layer
+            logger.warning(
+                "[GraphMemory] initialization failed; L3 disabled for this attempt: %s", exc
+            )
+            _driver = None
+            return None
+
+
+def _reset_driver() -> None:
+    global _driver, _schema_ready
+    with _driver_lock:
+        current, _driver = _driver, None
+        _schema_ready = False
+    if current is not None:
+        try:
+            current.close()
+        except Exception:
+            pass
+
+
+def _ensure_schema(driver) -> None:
+    statements = (
+        "CREATE CONSTRAINT memory_entity_scope_key IF NOT EXISTS "
+        "FOR (n:MemoryEntity) REQUIRE (n.scope_user_id, n.workspace_id, n.key) IS UNIQUE",
+        "CREATE INDEX memory_relation_id IF NOT EXISTS "
+        "FOR ()-[r:MEMORY_RELATION]-() ON (r.relation_id)",
+    )
+    try:
+        with driver.session() as session:
+            for statement in statements:
+                session.run(statement).consume()
+    except Exception as exc:  # Schema acceleration must not make L3 unavailable.
+        logger.warning("[GraphMemory] schema setup skipped: %s", exc)
+
+
+_UPSERT_CYPHER = """
+MERGE (s:MemoryEntity {
+  scope_user_id: $scope_user_id, workspace_id: $workspace_id, key: $source_key
+})
+ON CREATE SET s.created_at = datetime()
+SET s.name = $source, s.entity_type = $source_type, s.last_seen_at = datetime()
+MERGE (t:MemoryEntity {
+  scope_user_id: $scope_user_id, workspace_id: $workspace_id, key: $target_key
+})
+ON CREATE SET t.created_at = datetime()
+SET t.name = $target, t.entity_type = $target_type, t.last_seen_at = datetime()
+MERGE (s)-[r:MEMORY_RELATION {relation_id: $relation_id}]->(t)
+ON CREATE SET r.created_at = datetime(), r.seen_count = 0, r.weight = 1.0, r.active = true
+SET r.predicate = $predicate,
+    r.relationship = $relationship,
+    r.last_seen_at = datetime(),
+    r.seen_count = coalesce(r.seen_count, 0) + 1,
+    r.confidence = CASE
+      WHEN coalesce(r.confidence, 0.0) > $confidence THEN r.confidence
+      ELSE $confidence
+    END,
+    r.author_user_id = $author_user_id,
+    r.chat_id = $chat_id,
+    r.evidence_hash = $evidence_hash
+RETURN r.relation_id AS relation_id, r.seen_count AS seen_count
+"""
+
+
+def _write_sync(ctx: MemoryContext, relations: Sequence[GraphRelation]) -> list[Dict[str, Any]]:
+    driver = _get_driver()
+    if driver is None:
+        return []
+    evidence_hash = hashlib.sha256(
+        f"{ctx.chat_id or ''}|{ctx.message_id or ''}".encode("utf-8")
+    ).hexdigest()
+    rows: list[Dict[str, Any]] = []
+    try:
+        with driver.session() as session:
+            for relation in relations:
+                relation_id = relation_id_for(
+                    relation,
+                    scope_user_id=ctx.effective_scope_user_id,
+                    workspace_id=ctx.workspace_id,
+                )
+                record = session.run(
+                    _UPSERT_CYPHER,
+                    scope_user_id=ctx.effective_scope_user_id,
+                    workspace_id=ctx.workspace_id or "default",
+                    source_key=_entity_key(relation.source, relation.source_type),
+                    source=relation.source,
+                    source_type=relation.source_type,
+                    target_key=_entity_key(relation.target, relation.target_type),
+                    target=relation.target,
+                    target_type=relation.target_type,
+                    relation_id=relation_id,
+                    predicate=relation.predicate,
+                    relationship=relation.relationship,
+                    confidence=relation.confidence,
+                    author_user_id=ctx.user_id,
+                    chat_id=ctx.chat_id or "",
+                    evidence_hash=evidence_hash,
+                ).single()
+                if record is None:
+                    continue
+                row = relation.to_dict()
+                row.update(
+                    {
+                        "relation_id": str(record["relation_id"]),
+                        "seen_count": int(record["seen_count"] or 1),
+                    }
+                )
+                rows.append(row)
+        return rows
+    except Exception as exc:  # noqa: BLE001 - L3 is optional and post-response
+        logger.warning("[GraphMemory] write failed: %s", exc)
+        _reset_driver()
+        return []
+
+
+async def write_graph_relations(
+    ctx: MemoryContext, relations: Sequence[GraphRelation]
+) -> list[Dict[str, Any]]:
+    """Persist validated relations without blocking the event loop."""
+    if not relations:
+        return []
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _write_sync, ctx, list(relations))
+
+
+_LIST_CYPHER = """
+MATCH (s:MemoryEntity)-[r:MEMORY_RELATION]->(t:MemoryEntity)
+WHERE s.scope_user_id = $scope_user_id
+  AND s.workspace_id = $workspace_id
+  AND coalesce(r.active, true) = true
+RETURN r.relation_id AS relation_id,
+       s.name AS source, s.entity_type AS source_type,
+       r.predicate AS predicate, r.relationship AS relationship,
+       t.name AS target, t.entity_type AS target_type,
+       coalesce(r.confidence, 0.0) AS confidence,
+       coalesce(r.seen_count, 1) AS seen_count,
+       coalesce(r.weight, 1.0) AS weight,
+       toString(r.last_seen_at) AS last_seen_at
+ORDER BY coalesce(r.weight, 1.0) DESC, coalesce(r.seen_count, 1) DESC, r.last_seen_at DESC
+LIMIT $limit
+"""
+
+
+_SEARCH_CYPHER = """
+MATCH (s:MemoryEntity)-[r:MEMORY_RELATION]->(t:MemoryEntity)
+WHERE s.scope_user_id = $scope_user_id
+  AND s.workspace_id = $workspace_id
+  AND coalesce(r.active, true) = true
+  AND (
+    toLower($search_text) CONTAINS toLower(s.name)
+    OR toLower($search_text) CONTAINS toLower(t.name)
+  )
+RETURN r.relation_id AS relation_id,
+       s.name AS source, s.entity_type AS source_type,
+       r.predicate AS predicate, r.relationship AS relationship,
+       t.name AS target, t.entity_type AS target_type,
+       coalesce(r.confidence, 0.0) AS confidence,
+       coalesce(r.seen_count, 1) AS seen_count,
+       coalesce(r.weight, 1.0) AS weight,
+       toString(r.last_seen_at) AS last_seen_at
+ORDER BY coalesce(r.weight, 1.0) DESC, coalesce(r.seen_count, 1) DESC, r.last_seen_at DESC
+LIMIT $limit
+"""
+
+
+def _read_sync(
+    *, scope_user_id: str, workspace_id: str, limit: int, query: str = ""
+) -> list[Dict[str, Any]]:
+    driver = _get_driver()
+    if driver is None:
+        return []
+    statement = _SEARCH_CYPHER if query.strip() else _LIST_CYPHER
+    try:
+        with driver.session() as session:
+            result = session.run(
+                statement,
+                scope_user_id=scope_user_id,
+                workspace_id=workspace_id or "default",
+                search_text=query.strip(),
+                limit=max(1, min(int(limit), 200)),
+            )
+            return [dict(record) for record in result]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[GraphMemory] read failed: %s", exc)
+        _reset_driver()
+        return []
+
+
+async def list_graph_relations(
+    scope_user_id: str, *, workspace_id: str = "default", limit: int = 30
+) -> list[Dict[str, Any]]:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: _read_sync(
+            scope_user_id=scope_user_id,
+            workspace_id=workspace_id,
+            limit=limit,
+        ),
+    )
+
+
+async def search_graph_relations(
+    scope_user_id: str,
+    query: str,
+    *,
+    workspace_id: str = "default",
+    limit: int = 5,
+) -> list[Dict[str, Any]]:
+    if not query.strip():
+        return []
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: _read_sync(
+            scope_user_id=scope_user_id,
+            workspace_id=workspace_id,
+            limit=limit,
+            query=query,
+        ),
+    )
+
+
+def relation_is_active(relation_id: str, *, scope_user_id: str) -> Optional[bool]:
+    """Whether a relation still exists and is active. ``None`` = could not tell.
+
+    Used by the evolution runtime to decide whether a skill whose manifest
+    depends on this relation is still applicable. Tri-state on purpose: an
+    unreachable graph store must not disable every dependent skill.
+    """
+    driver = _get_driver()
+    if driver is None or not relation_id:
+        return None
+    try:
+        with driver.session() as session:
+            record = session.run(
+                """
+                MATCH (s:MemoryEntity)-[r:MEMORY_RELATION {relation_id: $relation_id}]->()
+                WHERE s.scope_user_id = $scope_user_id
+                RETURN coalesce(r.active, true) AS active
+                """,
+                relation_id=relation_id,
+                scope_user_id=scope_user_id,
+            ).single()
+            if record is None:
+                return False
+            return bool(record["active"])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[GraphMemory] relation_is_active failed: %s", exc)
+        _reset_driver()
+        return None
+
+
+def update_relation_state(
+    relation_id: str,
+    *,
+    scope_user_id: str,
+    weight: Optional[float] = None,
+    active: Optional[bool] = None,
+) -> bool:
+    """Adjust one relation's weight and/or active flag — never delete.
+
+    This is the write surface graph evolution is allowed: down-weighting and
+    deactivating are reversible; deletion is not, and a wrongly deleted edge is
+    indistinguishable from knowledge the system never had.
+    """
+    driver = _get_driver()
+    if driver is None or not relation_id:
+        return False
+    sets = []
+    parameters: Dict[str, Any] = {
+        "relation_id": relation_id,
+        "scope_user_id": scope_user_id,
+    }
+    if weight is not None:
+        sets.append("r.weight = $weight")
+        parameters["weight"] = max(0.0, min(1.0, float(weight)))
+    if active is not None:
+        sets.append("r.active = $active")
+        parameters["active"] = bool(active)
+    if not sets:
+        return False
+    try:
+        with driver.session() as session:
+            record = session.run(
+                "MATCH (s:MemoryEntity)-[r:MEMORY_RELATION {relation_id: $relation_id}]->() "
+                "WHERE s.scope_user_id = $scope_user_id "
+                f"SET {', '.join(sets)} "
+                "RETURN count(r) AS touched",
+                **parameters,
+            ).single()
+            return bool(record and int(record["touched"] or 0) > 0)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[GraphMemory] update_relation_state failed: %s", exc)
+        _reset_driver()
+        return False
+
+
+def _delete_sync(relation_id: str, *, scope_user_id: str) -> bool:
+    driver = _get_driver()
+    if driver is None:
+        return False
+    try:
+        with driver.session() as session:
+            record = session.run(
+                """
+                MATCH (s:MemoryEntity)-[r:MEMORY_RELATION {relation_id: $relation_id}]->(t)
+                WHERE s.scope_user_id = $scope_user_id
+                DELETE r
+                WITH s, t, count(*) AS deleted
+                OPTIONAL MATCH (s)-[sr]-()
+                WITH s, t, deleted, count(sr) AS s_degree
+                FOREACH (_ IN CASE WHEN s_degree = 0 THEN [1] ELSE [] END | DELETE s)
+                WITH t, deleted
+                OPTIONAL MATCH (t)-[tr]-()
+                WITH t, deleted, count(tr) AS t_degree
+                FOREACH (_ IN CASE WHEN t_degree = 0 THEN [1] ELSE [] END | DELETE t)
+                RETURN deleted
+                """,
+                relation_id=relation_id,
+                scope_user_id=scope_user_id,
+            ).single()
+            return bool(record and int(record["deleted"] or 0) > 0)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[GraphMemory] delete failed: %s", exc)
+        _reset_driver()
+        return False
+
+
+async def delete_graph_relation(relation_id: str, *, scope_user_id: str) -> bool:
+    if not relation_id:
+        return False
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None, lambda: _delete_sync(relation_id, scope_user_id=scope_user_id)
+    )

--- a/src/backend/core/memory/ref_shadow.py
+++ b/src/backend/core/memory/ref_shadow.py
@@ -98,7 +98,10 @@ def record_retrieved_refs(
                     user_id=user_id,
                     workspace_id=workspace_id,
                     content_hash=relation.content_hash,
-                    external_id=None,
+                    # The graph store's stable relation id (grel_*). Without it
+                    # an L3 evidence ref cannot be resolved back to the Neo4j
+                    # edge it came from, which makes graph evidence unauditable.
+                    external_id=relation.relation_id or None,
                     preview=_preview(
                         f"{relation.source} → {relation.relationship} → {relation.target}"
                     ),

--- a/src/backend/core/memory/retrieval_types.py
+++ b/src/backend/core/memory/retrieval_types.py
@@ -81,12 +81,23 @@ class RetrievedMemory:
 
 @dataclass(frozen=True)
 class RetrievedRelation:
-    """One graph-memory relation triple (L3)."""
+    """One graph-memory relation triple (L3).
+
+    ``relation_id`` is the stable id the graph store assigned at write time
+    (``grel_*``). It is what lets an Episode's L3 evidence be resolved back to
+    the exact Neo4j edge weeks later — content alone cannot do that once the
+    entities have been renamed or merged. Old traces without it degrade to the
+    content hash, so the field is optional rather than required.
+    """
 
     source: str
     relationship: str
     target: str
     rank: int
+    workspace_id: str = "default"
+    relation_id: str = ""
+    predicate: str = ""
+    confidence: float = 0.0
 
     @property
     def is_complete(self) -> bool:
@@ -99,8 +110,12 @@ class RetrievedRelation:
     def to_event_payload(self) -> Dict[str, Any]:
         return {
             "layer": LAYER_GRAPH,
+            "relation_id": self.relation_id,
+            "predicate": self.predicate,
+            "confidence": round(self.confidence, 4),
             "content_hash": self.content_hash,
             "rank": self.rank,
+            "workspace_id": self.workspace_id,
         }
 
 

--- a/src/backend/core/memory/service.py
+++ b/src/backend/core/memory/service.py
@@ -2,9 +2,12 @@
 
 Directly reuses mem0 framework capabilities:
 - vector retrieval (Milvus)
-- graph retrieval (Neo4j, enable_graph=True)
 - native expiration (add/update ``expiration_date``; expired entries are hidden
   from search and get_all)
+
+L3 graph memory is implemented locally in :mod:`core.memory.graph`. mem0ai 2.x
+removed graph-store support from its open-source ``Memory`` class, so passing a
+``graph_store`` config block there would be silently ignored.
 
 What it deliberately does NOT delegate to mem0: extraction and dedup. Writes go
 in with ``infer=False`` after our own extractors have judged the turn, and
@@ -26,11 +29,7 @@ from typing import List, Optional
 
 from core.config.settings import settings
 from core.memory.context import Confidentiality
-from core.memory.retrieval_types import (
-    MemoryRetrievalResult,
-    RetrievedRelation,
-    build_memory_item,
-)
+from core.memory.retrieval_types import MemoryRetrievalResult, RetrievedRelation, build_memory_item
 
 logger = logging.getLogger(__name__)
 
@@ -87,11 +86,12 @@ def _build_mem0_config() -> dict:
     - LLM: from DB (memory role) or env fallback
     - Embedder: from DB (embedding role) or env fallback
     - Vector Store: Milvus
-    - Graph Store: Neo4j (optional, controlled by settings.memory.graph_enabled)
+    L3 Neo4j configuration is owned by ``core.memory.graph`` rather than mem0.
     """
     # Resolve LLM config from DB
     try:
         from core.services.model_config import ModelConfigService
+
         svc = ModelConfigService.get_instance()
         mem_cfg = svc.resolve("memory")
         embed_cfg = svc.resolve("embedding")
@@ -106,7 +106,9 @@ def _build_mem0_config() -> dict:
     embed_model = embed_cfg.model_name if embed_cfg else settings.memory.embed_model
     embed_url = embed_cfg.base_url if embed_cfg else settings.memory.embed_url
     embed_key = embed_cfg.api_key if embed_cfg else settings.memory.embed_api_key
-    embed_dims = int((embed_cfg.extra.get("dimensions") if embed_cfg else None) or settings.memory.embed_dims)
+    embed_dims = int(
+        (embed_cfg.extra.get("dimensions") if embed_cfg else None) or settings.memory.embed_dims
+    )
 
     config: dict = {
         "llm": {
@@ -151,17 +153,6 @@ def _build_mem0_config() -> dict:
         # exists.
     }
 
-    # Graph memory (optional)
-    if settings.memory.graph_enabled:
-        config["graph_store"] = {
-            "provider": "neo4j",
-            "config": {
-                "url": settings.memory.neo4j_url,
-                "username": settings.memory.neo4j_username,
-                "password": settings.memory.neo4j_password,
-            },
-        }
-
     return config
 
 
@@ -184,8 +175,11 @@ def _get_memory() -> Optional[object]:
         try:
             _patch_mem0_embedding()
             from mem0 import Memory
+
             cfg = _build_mem0_config()
-            logger.info("[MemoryService] 初始化 mem0.Memory (graph=%s)", settings.memory.graph_enabled)
+            logger.info(
+                "[MemoryService] 初始化 mem0.Memory (graph=%s)", settings.memory.graph_enabled
+            )
             _memory_instance = Memory.from_config(cfg)
             _memory_init_failed = False
             return _memory_instance
@@ -270,23 +264,39 @@ async def retrieve_memories_structured(
     if not settings.memory.enabled or not user_id:
         return MemoryRetrievalResult.degraded_result("disabled")
 
-    # Breaker short-circuit: skip the attempt if Milvus has failed consecutively recently
+    # The Milvus breaker and the Neo4j path are independent: an open vector
+    # breaker must not hide graph relations that are still available.
     try:
         from core.memory.pipeline import milvus_breaker
-        if milvus_breaker.is_open():
-            logger.info("[MemoryService] milvus breaker open, skipping retrieval")
-            return MemoryRetrievalResult.degraded_result("breaker_open")
     except Exception:
         milvus_breaker = None  # type: ignore[assignment]
 
     async def _do_search() -> MemoryRetrievalResult:
+        typed_relations = await _retrieve_graph_relations(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            query=query,
+            limit=5,
+        )
+        if milvus_breaker is not None and milvus_breaker.is_open():
+            logger.info("[MemoryService] milvus breaker open, serving L3 only")
+            return MemoryRetrievalResult(
+                relations=typed_relations,
+                degraded=True,
+                degrade_reason="breaker_open",
+            )
+
         for attempt in range(2):
             loop = asyncio.get_running_loop()
             # A cold _get_memory() start does mem0.Memory.from_config (~700ms);
             # it must run in the executor, otherwise it blocks the event loop and bypasses the wait_for budget.
             memory = await loop.run_in_executor(None, _get_memory)
             if memory is None:
-                return MemoryRetrievalResult.degraded_result("store_unavailable")
+                return MemoryRetrievalResult(
+                    relations=typed_relations,
+                    degraded=True,
+                    degrade_reason="store_unavailable",
+                )
             try:
                 # mem0 2.0+: user_id must go into filters; limit was renamed top_k;
                 # workspace_id also goes into filters so Milvus filters at the recall stage,
@@ -300,15 +310,15 @@ async def retrieve_memories_structured(
                         query,
                         filters=search_filters,
                         top_k=limit,
-                    )
+                    ),
                 )
-                # mem0 v1.1 returns {"results": [...], "relations": [...]}
+                # mem0ai 2.x returns vector results only. L3 relations are read
+                # independently from our Neo4j layer above.
                 items = result.get("results", []) if isinstance(result, dict) else result
-                relations = result.get("relations", []) if isinstance(result, dict) else []
 
                 # ── Scope + confidentiality filtering (new) ──
                 filtered_items = []
-                for m in (items if isinstance(items, list) else []):
+                for m in items if isinstance(items, list) else []:
                     if not isinstance(m, dict):
                         continue
                     meta = m.get("metadata") or {}
@@ -345,35 +355,23 @@ async def retrieve_memories_structured(
                 # actually injected, not the store's raw recall order.
                 typed_items = []
                 for index, raw in enumerate(filtered_items, start=1):
-                    typed = build_memory_item(
-                        raw, rank=index, default_workspace=workspace_id
-                    )
+                    typed = build_memory_item(raw, rank=index, default_workspace=workspace_id)
                     if typed is not None:
                         typed_items.append(typed)
 
-                typed_relations = []
-                for index, r in enumerate(relations[:5], start=1):
-                    if not isinstance(r, dict):
-                        continue
-                    typed_relations.append(
-                        RetrievedRelation(
-                            source=r.get("source", ""),
-                            relationship=r.get("relationship", ""),
-                            target=r.get("target", ""),
-                            rank=index,
-                        )
-                    )
-
                 result = MemoryRetrievalResult(
                     items=tuple(typed_items),
-                    relations=tuple(typed_relations),
+                    relations=typed_relations,
                     recalled_count=recalled_count,
                     filtered_count=filtered_count,
                 )
 
                 logger.info(
                     "[MemoryService] 检索: user=%s ws=%s 召回 %d → 过滤后 %d",
-                    user_id, workspace_id, recalled_count, filtered_count,
+                    user_id,
+                    workspace_id,
+                    recalled_count,
+                    filtered_count,
                 )
                 if milvus_breaker is not None:
                     milvus_breaker.record_success()
@@ -390,8 +388,16 @@ async def retrieve_memories_structured(
                 logger.warning("[MemoryService] 检索失败，降级为空: %s", exc)
                 if milvus_breaker is not None:
                     milvus_breaker.record_failure()
-                return MemoryRetrievalResult.degraded_result("search_failed")
-        return MemoryRetrievalResult.degraded_result("retry_exhausted")
+                return MemoryRetrievalResult(
+                    relations=typed_relations,
+                    degraded=True,
+                    degrade_reason="search_failed",
+                )
+        return MemoryRetrievalResult(
+            relations=typed_relations,
+            degraded=True,
+            degrade_reason="retry_exhausted",
+        )
 
     if timeout_s is None:
         return await _do_search()
@@ -419,6 +425,47 @@ def _record_retrieval_refs(
         logger.debug("[MemoryService] ref shadow upsert skipped: %s", exc)
 
 
+async def _retrieve_graph_relations(
+    *, user_id: str, workspace_id: str, query: str, limit: int
+) -> tuple[RetrievedRelation, ...]:
+    """Best-effort L3 lookup, independent from the Milvus health state."""
+    if not settings.memory.graph_enabled:
+        return ()
+    try:
+        from core.memory.graph import search_graph_relations
+
+        rows = await search_graph_relations(
+            user_id,
+            query,
+            workspace_id=workspace_id,
+            limit=limit,
+        )
+    except Exception as exc:  # noqa: BLE001 - optional layer
+        logger.warning("[MemoryService] graph retrieval failed: %s", exc)
+        return ()
+    return tuple(
+        RetrievedRelation(
+            source=str(row.get("source") or ""),
+            relationship=str(row.get("relationship") or row.get("predicate") or ""),
+            target=str(row.get("target") or ""),
+            rank=index,
+            workspace_id=workspace_id,
+            relation_id=str(row.get("relation_id") or ""),
+            predicate=str(row.get("predicate") or ""),
+            confidence=_safe_float(row.get("confidence")),
+        )
+        for index, row in enumerate(rows, start=1)
+        if isinstance(row, dict) and row.get("source") and row.get("target")
+    )
+
+
+def _safe_float(value) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _expiration_from_ttl(ttl_days: int) -> Optional[str]:
     """YYYY-MM-DD expiry for mem0's native expiration, or None for no expiry."""
     if not ttl_days or ttl_days <= 0:
@@ -441,10 +488,7 @@ async def find_similar_procedure(
     """
     if not settings.memory.enabled or not content or not ctx or not ctx.user_id:
         return None
-    threshold = (
-        min_score if min_score is not None
-        else settings.memory.procedure_dedup_min_score
-    )
+    threshold = min_score if min_score is not None else settings.memory.procedure_dedup_min_score
 
     loop = asyncio.get_running_loop()
     memory = await loop.run_in_executor(None, _get_memory)
@@ -520,8 +564,12 @@ async def reinforce_procedure_entry(similar: dict, *, strength: str = "weak") ->
                 expiration_date=_expiration_from_ttl(ttl),
             ),
         )
-        logger.info("[MemoryService] procedure reinforced id=%s seen=%d (stated as %s)",
-                    memory_id, seen, strength)
+        logger.info(
+            "[MemoryService] procedure reinforced id=%s seen=%d (stated as %s)",
+            memory_id,
+            seen,
+            strength,
+        )
         return True
     except Exception as exc:
         logger.warning("[MemoryService] reinforce failed id=%s: %s", memory_id, exc)
@@ -634,8 +682,12 @@ async def save_procedure_entry(
         if milvus_breaker is not None:
             milvus_breaker.record_success()
         memory_id = _added_memory_id(result)
-        logger.debug("[MemoryService] procedure saved user=%s ws=%s id=%s",
-                     ctx.user_id, ctx.workspace_id, memory_id)
+        logger.debug(
+            "[MemoryService] procedure saved user=%s ws=%s id=%s",
+            ctx.user_id,
+            ctx.workspace_id,
+            memory_id,
+        )
         return memory_id
     except Exception as exc:
         logger.warning("[MemoryService] save_procedure_entry failed: %s", exc)
@@ -707,11 +759,10 @@ async def save_conversation(user_id: str, user_message: str, assistant_message: 
             return
         try:
             loop = asyncio.get_running_loop()
-            logger.info("[MemoryService] 开始保存记忆, user_id=%s, msg_len=%d", user_id, len(user_message))
-            result = await loop.run_in_executor(
-                None,
-                lambda: memory.add(messages, user_id=user_id)
+            logger.info(
+                "[MemoryService] 开始保存记忆, user_id=%s, msg_len=%d", user_id, len(user_message)
             )
+            result = await loop.run_in_executor(None, lambda: memory.add(messages, user_id=user_id))
             logger.info("[MemoryService] 用户 %s 的记忆已保存, result=%s", user_id, result)
             return
         except Exception as exc:
@@ -750,8 +801,7 @@ async def get_all_memories(
             loop = asyncio.get_running_loop()
             # mem0 2.0+: user_id must go into filters; workspace_id filters as metadata
             result = await loop.run_in_executor(
-                None,
-                lambda: memory.get_all(filters=filters, top_k=top_k)
+                None, lambda: memory.get_all(filters=filters, top_k=top_k)
             )
             if isinstance(result, dict):
                 return result.get("results", [])
@@ -784,9 +834,7 @@ async def update_memory(memory_id: str, content: str) -> bool:
             return False
         try:
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(
-                None, lambda: memory.update(memory_id, content.strip())
-            )
+            await loop.run_in_executor(None, lambda: memory.update(memory_id, content.strip()))
             return True
         except Exception as exc:
             if attempt == 0 and _is_connection_error(exc):

--- a/src/backend/orchestration/autonomous_loop.py
+++ b/src/backend/orchestration/autonomous_loop.py
@@ -372,6 +372,15 @@ async def _run_worker_iteration(
             elif et == "tool_pending":
                 if emit:
                     await emit({"type": "tool_pending", **(payload or {})})
+            elif et == "model_progress":
+                # Liveness during long tool-call-arg generation: written to the
+                # Redis stream so the stale-run reaper sees a live run (its
+                # "quiet" check reads the last stream entry), but never
+                # forwarded to clients — follow_run_as_sse skips this type.
+                # Deliberately NOT forwarding "heartbeat" here: those fire even
+                # when the model is truly silent and would defeat the reaper.
+                if emit:
+                    await emit({"type": "model_progress"})
             elif et == "error":
                 logger.warning("[loop] worker stream error: %s", payload)
     finally:

--- a/src/backend/orchestration/chat_run_executor.py
+++ b/src/backend/orchestration/chat_run_executor.py
@@ -481,6 +481,13 @@ async def _run_workflow(
                 # Not written to the stream — the SSE layer's own keep-alive cadence is handled by Nginx/StreamingResponse
                 continue
 
+            elif chunk_type == "model_progress":
+                # The model is still streaming (e.g. long tool-call-argument
+                # generation) even though nothing maps to an SSE event. Not
+                # written to the wire; merely receiving it resets the
+                # inactivity watchdog (is_activity excludes only "heartbeat").
+                continue
+
             elif chunk_type == "tool_pending":
                 pending_event = {
                     "type": "tool_pending",
@@ -907,16 +914,26 @@ async def follow_run(run_id: str, *, from_offset: int = 0) -> AsyncIterator[Dict
 
 
 def _decode_entry(fields: Any) -> Optional[Dict[str, Any]]:
-    """Decode the fields of a single Redis Stream entry into an SSE event dict."""
+    """Decode the fields of a single Redis Stream entry into an SSE event dict.
+
+    Returns None for undecodable entries and for internal liveness markers
+    (``model_progress``): those exist only so the stale-run reaper sees a live
+    stream (it reads entry timestamps, not payloads) and must never reach
+    clients — the frontend treats unknown event types as "pending ended".
+    Only used by follow_run_as_sse's replay/tail paths.
+    """
     if not fields:
         return None
     raw = fields.get("data") if isinstance(fields, dict) else None
     if raw is None:
         return None
     try:
-        return json.loads(raw)
+        event = json.loads(raw)
     except Exception:
         return None
+    if isinstance(event, dict) and event.get("type") == "model_progress":
+        return None
+    return event
 
 
 def _next_id(last_id: str) -> str:

--- a/src/backend/orchestration/streaming.py
+++ b/src/backend/orchestration/streaming.py
@@ -8,7 +8,10 @@ fine-grained EventType into our 8 SSE events:
 - ("tool_call", dict)      - tool invocation complete
 - ("tool_result", dict)    - tool invocation result
 - ("file_confirm", dict)   - myspace write confirmation (in-house ContextVar gate, distinct from native HITL)
-- ("heartbeat", None)      - silence heartbeat
+- ("heartbeat", None)      - silence heartbeat (queue empty ≥3s: the model produced nothing at all)
+- ("model_progress", None) - throttled liveness signal: upstream events keep arriving but none maps
+                             to an SSE event (tool-call args / suppressed thinking streaming). Unlike
+                             "heartbeat" it counts as activity for the run inactivity watchdog.
 - ("error", Exception|dict)- agent error (dict shaped like ExceedMaxIters' {kind,name})
 
 No standalone end event: ``stream()`` ends the generator directly upon the internal done
@@ -48,6 +51,13 @@ logger = logging.getLogger(__name__)
 
 
 _HTTP_ERR_RE = re.compile(r"HTTP\s*[45]\d\d")
+
+# Minimum spacing of ("model_progress", None) liveness signals. During long
+# tool-call-argument generation the model streams ToolCallDeltaEvent for
+# minutes while _map_event yields nothing downstream — without this signal the
+# run inactivity watchdog (CHAT_RUN_INACTIVITY_TIMEOUT_SEC) sees pure silence
+# and kills a healthy run mid-generation.
+_MODEL_PROGRESS_MIN_INTERVAL_S = 5.0
 
 
 def _looks_like_tool_error(content: str) -> bool:
@@ -230,6 +240,9 @@ class StreamingAgent:
         _stream_start = time.monotonic()
         _first_event_logged = False
         _poll_interval = 3.0
+        # Last time anything was yielded downstream — basis for the throttled
+        # model_progress liveness signal when upstream events map to nothing.
+        _last_out_ts = time.monotonic()
 
         try:
             while True:
@@ -262,12 +275,26 @@ class StreamingAgent:
                 reasoning_protocol = self._take_reasoning_protocol()
                 if reasoning_protocol is not None:
                     yield ("reasoning_protocol", reasoning_protocol)
+                _mapped_any = False
                 async for out in self._map_event(payload):
                     if not _first_event_logged:
                         _ttfe = (time.monotonic() - _stream_start) * 1000
                         logger.info("[stream] TTFE: %.0fms, type=%s", _ttfe, out[0])
                         _first_event_logged = True
+                    _mapped_any = True
                     yield out
+                if _mapped_any:
+                    _last_out_ts = time.monotonic()
+                else:
+                    # The model is alive (an upstream event just arrived) but
+                    # nothing was forwarded — typical of long tool-call-arg /
+                    # suppressed-thinking streaming. Emit a throttled liveness
+                    # signal so the inactivity watchdog doesn't misjudge a
+                    # healthy run as hung.
+                    _now = time.monotonic()
+                    if _now - _last_out_ts >= _MODEL_PROGRESS_MIN_INTERVAL_S:
+                        _last_out_ts = _now
+                        yield ("model_progress", None)
         except Exception as e:  # noqa: BLE001
             yield ("error", e)
         finally:

--- a/src/backend/orchestration/workflow.py
+++ b/src/backend/orchestration/workflow.py
@@ -1650,6 +1650,12 @@ async def _astream_subagent_direct(
                 elif event_type == "heartbeat":
                     yield {"type": "heartbeat"}
 
+                elif event_type == "model_progress":
+                    # Liveness signal from StreamingAgent: the model is still
+                    # streaming (tool-call args etc.) though nothing maps to an
+                    # SSE event. Forwarded so the run watchdog counts activity.
+                    yield {"type": "model_progress"}
+
                 elif event_type == "tool_pending":
                     yield {"type": "tool_pending", **(payload or {})}
 
@@ -2610,6 +2616,12 @@ async def astream_chat_workflow(
 
                 elif event_type == "heartbeat":
                     yield {"type": "heartbeat"}
+
+                elif event_type == "model_progress":
+                    # Liveness signal from StreamingAgent: the model is still
+                    # streaming (tool-call args etc.) though nothing maps to an
+                    # SSE event. Forwarded so the run watchdog counts activity.
+                    yield {"type": "model_progress"}
 
                 elif event_type == "tool_pending":
                     yield {"type": "tool_pending", **(payload or {})}

--- a/src/backend/tests/evolution/test_compiler_v2.py
+++ b/src/backend/tests/evolution/test_compiler_v2.py
@@ -1,0 +1,660 @@
+"""分层证据融合技能编译器 V2 — 端到端与边界测试.
+
+验收标准逐条落在测试上：pack 内容寻址且可重放；L3 只影响边界、不生成步骤；
+共享技能不含 L1 原文；新技能拿不到证据外的工具授权；L3 冲突不能自动激活；
+激活技能可沿血缘反查 L2/L3/Episode；回放集覆盖不足不得晋级。
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.db.engine import Base
+from core.db.models import AdminSkill
+from core.db.models.evolution import (
+    EvolutionAgentProfile,
+    EvolutionCandidate,
+    EvolutionCreditDecision,
+    EvolutionEpisode,
+    EvolutionEvidencePack,
+    EvolutionMemoryOp,
+    EvolutionPromotionLink,
+    EvolutionRelease,
+    EvolutionTraceEvent,
+)
+from core.evolution import evidence_contract as EC
+from core.evolution import graph_scan as GS
+from core.evolution import lineage as LN
+from core.evolution.applicability import (
+    assess_replay_coverage,
+    load_manifest,
+    manifest_permits,
+)
+from core.evolution.evidence_resolver import resolve_capability_pack
+from core.evolution.skill_candidate_engine import (
+    STATUS_CREATED,
+    STATUS_REJECTED,
+    SkillCandidateSpec,
+    create_skill_candidate,
+)
+
+_TABLES = [
+    EvolutionEpisode.__table__,
+    EvolutionTraceEvent.__table__,
+    EvolutionCandidate.__table__,
+    EvolutionRelease.__table__,
+    EvolutionAgentProfile.__table__,
+    EvolutionMemoryOp.__table__,
+    EvolutionEvidencePack.__table__,
+    EvolutionCreditDecision.__table__,
+    EvolutionPromotionLink.__table__,
+    AdminSkill.__table__,
+]
+
+
+@pytest.fixture
+def db(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine, tables=_TABLES)
+    factory = sessionmaker(bind=engine)
+    import core.db.engine as engine_mod
+    import core.evolution.activation as A
+    import core.evolution.loop as L
+    import core.memory.weights as weights_mod
+
+    monkeypatch.setattr(engine_mod, "SessionLocal", factory)
+    monkeypatch.setattr(A, "SessionLocal", factory)
+    monkeypatch.setattr(L, "SessionLocal", factory)
+    monkeypatch.setattr(weights_mod, "_cache", {})
+    session = factory()
+    yield session
+    session.close()
+
+
+def _view(episode_id, *, verdict="success", tools=("tool_a", "tool_b"), user="u1",
+          chat=None, tenant="default", task_type="finance", relations=()):
+    return {
+        "episode_id": episode_id,
+        "chat_id": chat or f"c-{episode_id}",
+        "user_id": user,
+        "tenant_id": tenant,
+        "verdict": verdict,
+        "task_type": task_type,
+        "tool_sequence": list(tools),
+        "objective": "查一下项目A的进展",
+        "graph_relations": list(relations),
+        "graph_refs": [r.get("content_hash", "") for r in relations],
+    }
+
+
+_REL = {
+    "relation_id": "grel_dep1",
+    "content_hash": "hash-dep1",
+    "predicate": "depends_on",
+    "confidence": 0.9,
+    "workspace_id": "default",
+}
+
+
+# ── Pack：内容寻址、分层边界 ──────────────────────────────────────────────────
+
+
+def test_same_evidence_resolves_to_the_same_pack_id():
+    views = [_view(f"e{i}") for i in range(3)]
+    pack_a = resolve_capability_pack(views=views, scope={"level": "workspace"})
+    pack_b = resolve_capability_pack(views=views, scope={"level": "workspace"})
+    assert pack_a.pack_id == pack_b.pack_id
+    assert pack_a.content_hash() == pack_b.content_hash()
+
+    changed = resolve_capability_pack(
+        views=views + [_view("e9")], scope={"level": "workspace"}
+    )
+    assert changed.pack_id != pack_a.pack_id
+
+
+def test_cross_tenant_episodes_are_dropped_by_the_resolver():
+    views = [_view("mine"), _view("theirs", tenant="other-tenant")]
+    pack = resolve_capability_pack(views=views, scope={"level": "workspace"})
+    assert [e["episode_id"] for e in pack.episodes] == ["mine"]
+
+
+def test_graph_evidence_carries_relation_id_and_a_bounded_role():
+    pack = resolve_capability_pack(
+        views=[_view("e1", relations=[_REL])], scope={"level": "workspace"}
+    )
+    relation = pack.graph_context[0]
+    assert relation["relation_id"] == "grel_dep1"
+    assert relation["role"] == EC.ROLE_DEPENDENCY
+    assert pack.validate() == []
+
+
+def test_a_step_role_is_structurally_impossible():
+    """图谱事实永远不能变成执行步骤——role 白名单没有 step。"""
+    pack = EC.CapabilityEvidencePackV2(
+        graph_context=[{"relation_id": "grel_x", "role": "step"}]
+    )
+    assert any(v.startswith("graph_role_not_allowed") for v in pack.validate())
+
+
+def test_raw_l1_content_in_a_pack_is_a_violation():
+    pack = EC.CapabilityEvidencePackV2(
+        profile_policy_refs=[{"policy": "p", "content": "用户喜欢深色模式"}]
+    )
+    assert "profile_raw_content_in_pack" in pack.validate()
+
+
+def test_functional_predicate_with_two_targets_is_a_conflict():
+    pack = EC.CapabilityEvidencePackV2(
+        graph_context=[
+            {"relation_id": "r1", "role": "dependency", "source": "项目A",
+             "predicate": "depends_on", "target": "系统B"},
+            {"relation_id": "r2", "role": "dependency", "source": "项目A",
+             "predicate": "depends_on", "target": "系统C"},
+        ]
+    )
+    conflicts = pack.graph_conflicts()
+    assert conflicts and conflicts[0]["source"] == "项目A"
+    manifest = EC.build_manifest(pack, scope_level="workspace", risk_tier="high")
+    assert manifest["graph_conflict"] is True
+
+
+# ── Manifest：L3 只进边界 ────────────────────────────────────────────────────
+
+
+def test_manifest_routes_each_graph_role_to_its_boundary_only():
+    pack = EC.CapabilityEvidencePackV2(
+        graph_context=[
+            {"relation_id": "r1", "role": "dependency", "source": "项目A",
+             "predicate": "depends_on", "target": "系统B"},
+            {"relation_id": "r2", "role": "exclusion", "source": "规则R",
+             "predicate": "related_to", "target": "场景S"},
+            {"relation_id": "r3", "role": "applicability", "source": "项目A",
+             "predicate": "related_to", "target": "周报"},
+        ],
+        required_tools=["tool_a"],
+    )
+    manifest = EC.build_manifest(pack, scope_level="workspace", risk_tier="high")
+    assert [d["relation_id"] for d in manifest["dependencies"]] == ["r1"]
+    assert [e["relation_id"] for e in manifest["excludes_when"]] == ["r2"]
+    assert [a["relation_id"] for a in manifest["applies_when"]] == ["r3"]
+    assert set(manifest["required_graph_relations"]) == {"r1", "r2", "r3"}
+    # manifest 里没有任何「步骤」字段可以让 L3 溜进去。
+    assert "steps" not in manifest
+
+
+# ── 强制校验 ─────────────────────────────────────────────────────────────────
+
+
+def _pack_and_manifest(**overrides):
+    pack = resolve_capability_pack(
+        views=[_view(f"e{i}", relations=[_REL]) for i in range(3)],
+        scope={"level": "workspace"},
+        **overrides,
+    )
+    manifest = EC.build_manifest(pack, scope_level="workspace", risk_tier="high")
+    return pack, manifest
+
+
+def test_a_tool_outside_the_evidence_is_refused():
+    """新技能不能获得证据中未使用的工具权限。"""
+    pack, manifest = _pack_and_manifest()
+    violations = EC.validate_candidate_structure(
+        pack=pack,
+        manifest=manifest,
+        document_tools=["tool_a", "delete_everything"],
+        body="## 不适用范围\n无\n",
+        scope_level="workspace",
+    )
+    assert any(v.startswith("tool_not_in_evidence") for v in violations)
+
+
+def test_secret_material_in_the_body_is_refused():
+    pack, manifest = _pack_and_manifest()
+    violations = EC.validate_candidate_structure(
+        pack=pack,
+        manifest=manifest,
+        document_tools=["tool_a"],
+        body="## 步骤\n1. 使用 api_key: sk-abcdefghijklmnop1234 调用\n",
+        scope_level="workspace",
+    )
+    assert "secret_material_in_body" in violations
+
+
+def test_a_graph_fact_written_into_the_steps_section_is_refused():
+    pack, manifest = _pack_and_manifest()
+    pack.graph_context[0].update(
+        {"source": "项目A", "relationship": "依赖", "target": "系统B"}
+    )
+    manifest = EC.build_manifest(pack, scope_level="workspace", risk_tier="high")
+    violations = EC.validate_candidate_structure(
+        pack=pack,
+        manifest=manifest,
+        document_tools=["tool_a"],
+        body="## 步骤\n1. 执行 项目A 依赖 系统B\n",
+        scope_level="workspace",
+    )
+    assert any(v.startswith("graph_relation_written_as_step") for v in violations)
+
+
+def test_l2_l3_contradiction_refuses_generation():
+    pack, _ = _pack_and_manifest()
+    pack.graph_context.append(
+        {"relation_id": "r-ex", "role": "exclusion", "source": "规则R",
+         "predicate": "related_to", "target": "场景S"}
+    )
+    pack.procedures.append(
+        {"ref": {"external_id": "mref-1"}, "rule": "按旧口径处理", "applies_to": "场景S"}
+    )
+    manifest = EC.build_manifest(pack, scope_level="workspace", risk_tier="high")
+    violations = EC.validate_candidate_structure(
+        pack=pack,
+        manifest=manifest,
+        document_tools=[],
+        body="",
+        scope_level="workspace",
+    )
+    assert any(v.startswith("l2_l3_contradiction") for v in violations)
+
+
+# ── 统一引擎（入库） ─────────────────────────────────────────────────────────
+
+
+_FAKE_BODY = (
+    "## 不适用范围\n"
+    "不适用于与项目A无关的查询，也不适用于需要修改数据的任务。\n\n"
+    "## 适用条件\n"
+    "当用户询问项目A的当前进展、里程碑或阻塞项时使用本技能。\n\n"
+    "## 步骤\n"
+    "1. 使用 `tool_a` 查询项目A的最新状态，确认返回里包含项目名称与更新时间。\n"
+    "2. 核对返回的更新时间在最近一周内，超期则提示用户数据可能滞后。\n\n"
+    "## 常见失败与处理\n"
+    "查询为空时先确认项目名称拼写，再重试一次；仍为空则如实告知用户没有记录。\n"
+)
+
+
+async def _fake_generate(**kwargs):
+    from core.evolution.skill_gen import DraftResult
+
+    return (
+        {
+            "skill_id": kwargs["skill_id"],
+            "display_name": "项目进展核查",
+            "description": "查询项目A进展时使用",
+            "content": f"---\nname: x\n---\n\n{_FAKE_BODY}",
+            "allowed_tools": ["tool_a"],
+        },
+        DraftResult(ok=True, attempts=1),
+    )
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _spec(**overrides):
+    defaults = dict(
+        asset_id="auto-intent-abc",
+        proposer="intent_engine",
+        hypothesis="同一意图反复出现",
+        views=[_view(f"e{i}", relations=[_REL]) for i in range(3)],
+        procedures=[
+            {"ref": "mref-1", "user_id": "u1", "rule": "先核验主体", "why": "口径要求"}
+        ],
+        write_document=True,
+    )
+    defaults.update(overrides)
+    return SkillCandidateSpec(**defaults)
+
+
+def test_engine_persists_candidate_pack_credit_and_manifest(db, monkeypatch):
+    import core.evolution.skill_gen as skill_gen
+
+    monkeypatch.setattr(skill_gen, "generate_skill_document", _fake_generate)
+
+    outcome = create_skill_candidate(
+        _spec(), credit={"selected": "skill", "confidence": 0.8,
+                         "may_produce_candidate": True}, run_async=_run
+    )
+    assert outcome["status"] == STATUS_CREATED, outcome
+
+    candidate = db.query(EvolutionCandidate).one()
+    assert candidate.evidence_pack_id == outcome["pack_id"]
+    change = candidate.ir["changes"][0]
+    assert change["manifest"]["evidence_pack_id"] == outcome["pack_id"]
+    assert change["document"]["display_name"] == "项目进展核查"
+    # 血缘可反查：pack 行存在且哈希一致；归因决策已持久化并被候选引用。
+    pack_row = db.query(EvolutionEvidencePack).one()
+    assert pack_row.pack_hash == outcome["pack_hash"]
+    decision = db.query(EvolutionCreditDecision).one()
+    assert candidate.credit_decision["decision_id"] == decision.decision_id
+
+
+def test_engine_is_idempotent_for_identical_evidence(db, monkeypatch):
+    import core.evolution.skill_gen as skill_gen
+
+    monkeypatch.setattr(skill_gen, "generate_skill_document", _fake_generate)
+    credit = {"selected": "skill", "confidence": 0.8, "may_produce_candidate": True}
+
+    first = create_skill_candidate(_spec(), credit=credit, run_async=_run)
+    second = create_skill_candidate(_spec(), credit=credit, run_async=_run)
+    assert first["candidate_id"] == second["candidate_id"]
+    assert db.query(EvolutionCandidate).count() == 1
+    assert db.query(EvolutionEvidencePack).count() == 1
+
+
+def test_engine_refuses_a_document_that_widens_tool_authority(db, monkeypatch):
+    async def widened(**kwargs):
+        from core.evolution.skill_gen import DraftResult
+
+        return (
+            {
+                "skill_id": kwargs["skill_id"],
+                "display_name": "x",
+                "description": "y",
+                "content": "## 不适用范围\n无\n",
+                "allowed_tools": ["tool_a", "rm_rf"],
+            },
+            DraftResult(ok=True, attempts=1),
+        )
+
+    import core.evolution.skill_gen as skill_gen
+
+    monkeypatch.setattr(skill_gen, "generate_skill_document", widened)
+    outcome = create_skill_candidate(
+        _spec(), credit={"selected": "skill", "confidence": 0.8,
+                         "may_produce_candidate": True}, run_async=_run
+    )
+    assert outcome["status"] == STATUS_REJECTED
+    assert outcome["code"] == "structure_violation"
+    assert db.query(EvolutionCandidate).count() == 0
+
+
+# ── 激活：manifest 落盘、血缘落账、冲突闸门 ───────────────────────────────────
+
+
+def _materialisable_candidate(db, monkeypatch, *, graph_conflict=False, risk="medium",
+                              status="replay_passed"):
+    import core.evolution.skill_gen as skill_gen
+
+    monkeypatch.setattr(skill_gen, "generate_skill_document", _fake_generate)
+    views = [_view(f"e{i}", relations=[_REL]) for i in range(3)]
+    if graph_conflict:
+        conflicting = dict(_REL, relation_id="grel_dep2", content_hash="hash-dep2")
+        views.append(_view("e-conflict", relations=[conflicting]))
+
+    spec = _spec(views=views, risk_tier=risk)
+    outcome = create_skill_candidate(
+        spec, credit={"selected": "skill", "confidence": 0.8,
+                      "may_produce_candidate": True}, run_async=_run
+    )
+    assert outcome["status"] == STATUS_CREATED, outcome
+    candidate = db.query(EvolutionCandidate).one()
+    if graph_conflict:
+        # 人为把 manifest 标记为冲突（resolver 只有拿到实体文本才能发现冲突，
+        # 这里直接测试激活闸门本身）。deepcopy：原地改嵌套 JSON 不会被 flush。
+        import copy
+
+        ir = copy.deepcopy(candidate.ir)
+        ir["changes"][0]["manifest"]["graph_conflict"] = True
+        candidate.ir = ir
+    candidate.status = status
+    candidate.risk_tier = risk
+    db.commit()
+    return candidate.candidate_id
+
+
+def test_materialisation_writes_the_manifest_and_the_lineage(db, monkeypatch):
+    from core.evolution import activation as A
+
+    candidate_id = _materialisable_candidate(db, monkeypatch)
+    result = A.materialise_skill_candidate(candidate_id, approver="admin")
+
+    row = db.query(AdminSkill).one()
+    manifest = load_manifest(row.extra_files)
+    assert manifest is not None
+    assert manifest["evidence_pack_id"].startswith("pack_")
+    assert [d["relation_id"] for d in manifest["dependencies"]] == ["grel_dep1"]
+
+    links = db.query(EvolutionPromotionLink).all()
+    relations = {link.relation for link in links}
+    assert LN.REL_CONSTRAINED_BY in relations   # L3 → skill
+    assert LN.REL_VALIDATED_BY in relations     # episode → skill
+    assert LN.REL_COMPILED_FROM in relations    # L2 → skill
+    assert result["lineage_links"] == len(links)
+    # 图谱证据可以通过 relation_id 反查。
+    graph_links = [l for l in links if l.relation == LN.REL_CONSTRAINED_BY]
+    assert graph_links[0].source_id == "grel_dep1"
+
+
+def test_a_graph_conflicted_candidate_cannot_activate_directly(db, monkeypatch):
+    from core.evolution import activation as A
+
+    candidate_id = _materialisable_candidate(
+        db, monkeypatch, graph_conflict=True, risk="low"
+    )
+    with pytest.raises(A.ActivationError) as excinfo:
+        A.materialise_skill_candidate(candidate_id, approver="admin")
+    assert excinfo.value.code == "graph_conflict_requires_review"
+
+
+def test_a_graph_conflicted_candidate_may_still_enter_shadow(db, monkeypatch):
+    from core.evolution import activation as A
+
+    candidate_id = _materialisable_candidate(
+        db, monkeypatch, graph_conflict=True, risk="medium"
+    )
+    result = A.materialise_skill_candidate(candidate_id, approver="admin")
+    assert result["stage"] == "shadow"
+    assert result["exposed_to"] == "nobody (shadow)"
+
+
+# ── Replay 覆盖 ──────────────────────────────────────────────────────────────
+
+
+def _coverage_pack():
+    views = [
+        _view("ok1", relations=[_REL]),
+        _view("ok2"),
+        _view("bad1", verdict="failed"),
+    ]
+    return resolve_capability_pack(views=views, scope={"level": "workspace"})
+
+
+def test_replay_set_without_failure_cases_is_not_covered():
+    pack = _coverage_pack()
+    assessment = assess_replay_coverage(pack, ["ok1", "ok2"])
+    assert assessment["covered"] is False
+    assert "failure_recovery_episode" in assessment["missing"]
+    assert "negative_example_episode" in assessment["missing"]
+
+
+def test_replay_set_covering_both_graph_classes_passes():
+    pack = _coverage_pack()
+    assessment = assess_replay_coverage(pack, ["ok1", "ok2", "bad1"])
+    assert assessment["covered"] is True, assessment
+
+
+def test_replay_set_missing_the_no_graph_class_is_not_covered():
+    views = [
+        _view("ok1", relations=[_REL]),
+        _view("ok2"),  # 唯一「不带图谱依赖」的场景
+        _view("bad1", verdict="failed", relations=[_REL]),
+    ]
+    pack = resolve_capability_pack(views=views, scope={"level": "workspace"})
+    assessment = assess_replay_coverage(pack, ["ok1", "bad1"])
+    assert "no_graph_dependency_episode" in assessment["missing"]
+
+
+# ── 运行时适用性 ─────────────────────────────────────────────────────────────
+
+
+def test_manifest_excludes_and_declared_task_types_are_enforced():
+    manifest = {
+        "applies_when": [{"task_type": "finance"}],
+        "excludes_when": [{"task_type": "legal"}],
+    }
+    assert manifest_permits(manifest, task_type="finance")[0] is True
+    assert manifest_permits(manifest, task_type="legal")[0] is False
+    assert manifest_permits(manifest, task_type="hr")[0] is False
+    # 没有上下文 → 不拦（fail-open）。
+    assert manifest_permits(manifest)[0] is True
+    # 没有 manifest（人写的技能）→ 永远放行。
+    assert manifest_permits(None, task_type="legal")[0] is True
+
+
+def test_an_inactive_graph_dependency_withholds_the_skill():
+    manifest = {"dependencies": [{"relation_id": "grel_dep1"}]}
+    ok, reason = manifest_permits(
+        manifest, relation_active=lambda rid: False
+    )
+    assert ok is False and "dependency_inactive" in reason
+    # 图谱不可达（None）不拦：误拦是能力损失。
+    assert manifest_permits(manifest, relation_active=lambda rid: None)[0] is True
+
+
+def test_exposure_withholds_an_evolved_skill_outside_its_manifest(db):
+    from core.evolution.exposure import filter_skill_ids
+
+    db.add(
+        AdminSkill(
+            skill_id="evo-fin",
+            skill_content="x",
+            display_name="x",
+            description="x",
+            extra_files={
+                "evolution_manifest.json": '{"excludes_when": [{"task_type": "legal"}]}'
+            },
+        )
+    )
+    db.add(
+        EvolutionRelease(
+            release_id="rel-1",
+            candidate_id="cand-1",
+            target_kind="skill",
+            target_asset_id="evo-fin",
+            stage="active",
+            traffic_percent=100,
+            scope_filter={},
+            guardrails={},
+        )
+    )
+    db.commit()
+
+    assert filter_skill_ids(["evo-fin"], user_id="u1", db=db) == ["evo-fin"]
+    assert filter_skill_ids(["evo-fin"], user_id="u1", task_type="legal", db=db) == []
+    assert filter_skill_ids(
+        ["evo-fin"], user_id="u1", task_type="finance", db=db
+    ) == ["evo-fin"]
+
+
+# ── graph_scan ───────────────────────────────────────────────────────────────
+
+
+def _relation_row(relation_id, *, source="项目A", predicate="depends_on",
+                  target="系统B", weight=1.0, seen=3, last_seen=None):
+    return {
+        "relation_id": relation_id,
+        "source": source,
+        "predicate": predicate,
+        "relationship": "依赖",
+        "target": target,
+        "confidence": 0.9,
+        "seen_count": seen,
+        "weight": weight,
+        "last_seen_at": (last_seen or datetime.now(timezone.utc)).isoformat(),
+    }
+
+
+def test_an_observed_relation_is_reinforced_automatically():
+    ops = GS.scan_graph_relations(
+        [_relation_row("r1")], observed_relation_ids={"r1": 2}
+    )
+    reinforce = [op for op in ops if op.operation == GS.OP_REINFORCE]
+    assert reinforce and reinforce[0].auto is True
+    assert reinforce[0].payload["weight"] == pytest.approx(1.0)
+
+
+def test_a_stale_relation_is_down_weighted_never_deleted():
+    old = datetime.now(timezone.utc) - timedelta(days=120)
+    ops = GS.scan_graph_relations([_relation_row("r1", last_seen=old)])
+    assert [op.operation for op in ops] == [GS.OP_REWEIGHT]
+    assert ops[0].auto is True
+    assert ops[0].payload["weight"] == pytest.approx(0.5)
+
+
+def test_a_floored_stale_relation_becomes_a_manual_deactivation_proposal():
+    old = datetime.now(timezone.utc) - timedelta(days=120)
+    ops = GS.scan_graph_relations([_relation_row("r1", weight=0.2, last_seen=old)])
+    assert [op.operation for op in ops] == [GS.OP_DEACTIVATE]
+    assert ops[0].auto is False
+
+
+def test_contradictions_are_flagged_for_humans_not_resolved_by_majority():
+    ops = GS.scan_graph_relations(
+        [_relation_row("r1", target="系统B"), _relation_row("r2", target="系统C")]
+    )
+    flags = [op for op in ops if op.operation == GS.OP_FLAG_CONTRADICTION]
+    assert flags and flags[0].auto is False
+    assert sorted(flags[0].payload["targets"]) == ["系统B", "系统C"]
+
+
+def test_a_clearly_superseded_relation_is_proposed_not_applied():
+    old = datetime.now(timezone.utc) - timedelta(days=200)
+    ops = GS.scan_graph_relations(
+        [
+            _relation_row("r-old", target="旧系统", seen=2, last_seen=old),
+            _relation_row("r-new", target="新系统", seen=5),
+        ]
+    )
+    supersedes = [op for op in ops if op.operation == GS.OP_SUPERSEDE]
+    assert supersedes and supersedes[0].auto is False
+    assert supersedes[0].payload["superseded_by"] == "r-new"
+
+
+def test_repeatedly_mentioned_missing_entities_are_suggested():
+    ops = GS.scan_graph_relations(
+        [_relation_row("r1")], entity_mentions={"新中台": 4, "系统B": 9}
+    )
+    suggestions = [op for op in ops if op.operation == GS.OP_SUGGEST_MISSING]
+    # 系统B 已在图谱里，不建议；新中台不在，建议。
+    assert [op.payload["entity"] for op in suggestions] == ["新中台"]
+
+
+def test_apply_never_writes_manual_operations(monkeypatch):
+    calls = []
+
+    def fake_update(relation_id, *, scope_user_id, weight=None, active=None):
+        calls.append((relation_id, weight, active))
+        return True
+
+    import core.memory.graph as G
+
+    monkeypatch.setattr(G, "update_relation_state", fake_update)
+    ops = [
+        GS.GraphOp(operation=GS.OP_REINFORCE, relation_id="r1", payload={"weight": 0.9}),
+        GS.GraphOp(operation=GS.OP_FLAG_CONTRADICTION, relation_id="r2"),
+        GS.GraphOp(operation=GS.OP_SUPERSEDE, relation_id="r3"),
+    ]
+    outcome = GS.apply_graph_ops(ops, scope_user_id="u1")
+    assert [c[0] for c in calls] == ["r1"]
+    assert len(outcome["manual"]) == 2
+
+
+# ── 血缘账本 ─────────────────────────────────────────────────────────────────
+
+
+def test_lineage_edges_are_idempotent(db):
+    edge = ("memory", "mref-1", LN.REL_COMPILED_FROM, "skill", "evo-x@1.0.0")
+    assert len(LN.record_links([edge])) == 1
+    assert len(LN.record_links([edge])) == 1
+    assert db.query(EvolutionPromotionLink).count() == 1
+
+
+def test_unknown_link_relations_are_refused(db):
+    edges = [("memory", "mref-1", "made_up_edge", "skill", "evo-x@1.0.0")]
+    assert LN.record_links(edges) == []
+    assert db.query(EvolutionPromotionLink).count() == 0

--- a/src/backend/tests/evolution/test_engines_end_to_end.py
+++ b/src/backend/tests/evolution/test_engines_end_to_end.py
@@ -315,6 +315,126 @@ def test_rolling_the_skill_back_restores_the_memories(db):
     assert weights == {}
 
 
+def _rollback_fixture(db, monkeypatch, *, guardrails):
+    """A materialised skill, its demoted source memory, and a dependent profile."""
+    from sqlalchemy.orm import sessionmaker
+
+    from core.db.models import AdminSkill
+    from core.evolution import activation as A
+
+    AdminSkill.__table__.create(db.get_bind(), checkfirst=True)
+    factory = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr(A, "SessionLocal", factory)
+
+    db.add(
+        EvolutionCandidate(
+            candidate_id="cand-9",
+            target_kind="skill",
+            target_asset_id="evo-fin",
+            operation="new",
+            ir={"changes": []},
+            change_checksum="cand-9",
+            evidence_refs=[],
+            status="active",
+        )
+    )
+    db.add(
+        AdminSkill(
+            skill_id="evo-fin",
+            skill_content="new",
+            display_name="新版",
+            description="新版",
+            is_enabled=True,
+            version="1.0.1",
+        )
+    )
+    db.add(
+        EvolutionRelease(
+            release_id="rel-9",
+            candidate_id="cand-9",
+            target_kind="skill",
+            target_asset_id="evo-fin",
+            stage="canary",
+            traffic_percent=5,
+            scope_filter={},
+            guardrails=guardrails,
+            rollback_version_id="",
+            approved_by="admin",
+        )
+    )
+    db.add(
+        EvolutionAgentProfile(
+            profile_id="prof-1",
+            payload={"skill_ids": ["evo-fin"]},
+            is_active=True,
+        )
+    )
+    db.commit()
+    MA.demote_promoted_memories(
+        candidate_id="cand-9", user_id="u1", memory_refs=["mref-a"], skill_id="evo-fin"
+    )
+    return A
+
+
+def test_release_rollback_restores_demoted_memories_in_the_same_motion(db, monkeypatch):
+    """The gap this closes: rollback restored the skill but not the knowledge.
+
+    Materialisation down-weights the memories a skill was compiled from. Rolling
+    the release back without reverting those ops left the knowledge half-priced
+    with no carrier — retrieval skipped it because a skill supposedly covered
+    it, and the skill was gone.
+    """
+    from core.db.models import AdminSkill
+    from core.memory.weights import invalidate, load_overlay
+
+    A = _rollback_fixture(db, monkeypatch, guardrails={})
+    weights, _ = load_overlay("u1", "default")
+    assert weights == {"mref-a": MA.PROMOTION_WEIGHT}
+
+    outcome = A.rollback_skill_activation("rel-9", actor="admin", reason="canary 指标崩了")
+
+    invalidate()
+    weights, _ = load_overlay("u1", "default")
+    assert weights == {}
+    assert outcome["restored_memory_ops"], outcome
+    # No prior version: the skill stops being loadable, so the profile built on
+    # top of it must stop being applied — same cross-layer rule as retirement.
+    assert outcome["invalidated_profiles"] == ["prof-1"]
+    db.expire_all()
+    assert db.query(AdminSkill).one().is_enabled is False
+    assert db.query(EvolutionAgentProfile).one().is_active is False
+
+
+def test_release_rollback_to_a_prior_version_keeps_dependent_profiles(db, monkeypatch):
+    """With a restored prior version the skill stays loadable — profiles hold."""
+    from core.db.models import AdminSkill
+    from core.memory.weights import invalidate, load_overlay
+
+    previous = {
+        "skill_content": "old",
+        "display_name": "旧版",
+        "description": "旧版",
+        "version": "1.0.0",
+        "tags": ["evolved"],
+        "allowed_tools": ["a"],
+        "extra_files": {},
+        "is_enabled": True,
+    }
+    A = _rollback_fixture(db, monkeypatch, guardrails={"previous": previous})
+
+    outcome = A.rollback_skill_activation("rel-9", actor="admin", reason="人工回滚")
+
+    invalidate()
+    weights, _ = load_overlay("u1", "default")
+    assert weights == {}
+    assert outcome["restored_previous"] is True
+    assert outcome["invalidated_profiles"] == []
+    db.expire_all()
+    row = db.query(AdminSkill).one()
+    assert row.is_enabled is True and row.skill_content == "old"
+    assert db.query(EvolutionAgentProfile).one().is_active is True
+
+
 # ── Orchestration governs the next run ───────────────────────────────────────
 
 

--- a/src/backend/tests/evolution/test_personal_approval.py
+++ b/src/backend/tests/evolution/test_personal_approval.py
@@ -12,7 +12,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.db.engine import Base
-from core.db.models.evolution import EvolutionCandidate, EvolutionEpisode
+from core.db.models.evolution import (
+    EvolutionCandidate,
+    EvolutionEpisode,
+    EvolutionRelease,
+)
 from core.evolution import user_settings as US
 
 
@@ -20,7 +24,12 @@ from core.evolution import user_settings as US
 def db(monkeypatch):
     engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
     Base.metadata.create_all(
-        engine, tables=[EvolutionEpisode.__table__, EvolutionCandidate.__table__]
+        engine,
+        tables=[
+            EvolutionEpisode.__table__,
+            EvolutionCandidate.__table__,
+            EvolutionRelease.__table__,
+        ],
     )
     factory = sessionmaker(bind=engine)
     monkeypatch.setattr(US, "SessionLocal", factory)
@@ -297,3 +306,77 @@ def test_the_skill_body_is_shown_so_approval_is_a_decision(db):
     assert change["type"] == "skill_document"
     assert "## 步骤" in change["content"]
     assert change["allowed_tools"] == ["internet_search"]
+
+
+# ── An accepted candidate leaves the queue ───────────────────────────────────
+#
+# A personal activation deliberately keeps the candidate's status at
+# draft/replay_passed so others can still accept it and an administrator can
+# still consider it globally. That must not mean the *acceptor* keeps seeing it:
+# a row that survives its own approval reads as "the button did nothing", and a
+# second press mints a duplicate release.
+
+
+def _personal_release(db, release_id, candidate_id, owner, stage="active"):
+    db.add(
+        EvolutionRelease(
+            release_id=release_id,
+            candidate_id=candidate_id,
+            target_kind="skill",
+            target_asset_id=f"evo-{candidate_id}-u{owner}",
+            stage=stage,
+            traffic_percent=0,
+            scope_filter={"level": "workspace", "owner_user_id": owner},
+            approved_by=f"user:{owner}",
+        )
+    )
+
+
+def test_a_candidate_i_accepted_no_longer_appears_in_my_queue(db):
+    for i in range(5):
+        _episode(db, f"e{i}", "alice")
+    _candidate(db, "c1", [f"e{i}" for i in range(5)])
+    _personal_release(db, "r1", "c1", "alice")
+    db.commit()
+
+    assert US.pending_for_user("alice") == []
+
+
+def test_my_acceptance_does_not_hide_the_candidate_from_others(db):
+    for i in range(3):
+        _episode(db, f"a{i}", "alice")
+    for i in range(3):
+        _episode(db, f"b{i}", "bob")
+    # Same candidate qualifies for both users (own_share threshold met per user
+    # is impossible with shared evidence, so use two separate candidates).
+    _candidate(db, "ca", [f"a{i}" for i in range(3)])
+    _candidate(db, "cb", [f"b{i}" for i in range(3)])
+    _personal_release(db, "r1", "ca", "alice")
+    db.commit()
+
+    assert US.pending_for_user("alice") == []
+    assert [c["candidate_id"] for c in US.pending_for_user("bob")] == ["cb"]
+
+
+def test_a_rolled_back_personal_release_reoffers_the_candidate(db):
+    for i in range(5):
+        _episode(db, f"e{i}", "alice")
+    _candidate(db, "c1", [f"e{i}" for i in range(5)])
+    _personal_release(db, "r1", "c1", "alice", stage="rolled_back")
+    db.commit()
+
+    assert [c["candidate_id"] for c in US.pending_for_user("alice")] == ["c1"]
+
+
+def test_re_approving_an_accepted_candidate_is_refused_with_the_reason(db):
+    for i in range(5):
+        _episode(db, f"e{i}", "alice")
+    _candidate(db, "c1", [f"e{i}" for i in range(5)])
+    _personal_release(db, "r1", "c1", "alice")
+    db.commit()
+
+    with pytest.raises(PermissionError) as exc:
+        US.approve_for_user("c1", "alice")
+    # Not the scope refusal: telling a user they lack permission over a skill
+    # they just installed misreports success as failure.
+    assert "已启用" in str(exc.value)

--- a/src/backend/tests/evolution/test_runtime_binding.py
+++ b/src/backend/tests/evolution/test_runtime_binding.py
@@ -98,6 +98,24 @@ def test_substitution_does_not_mutate_the_original():
     assert bundle.first_of_kind(C.ASSET_SKILL).version == "v1"
 
 
+def test_memory_policy_ref_names_each_layer():
+    """Attribution must distinguish "L3 offered nothing" from "L3 was off".
+
+    A single opaque ``v1`` policy could not answer which layered configuration
+    a given Episode actually ran under.
+    """
+    refs = rb._memory_refs(True, "ws-1")
+    layers = refs[0].detail["layers"]
+    assert set(layers) == {"profile", "fact", "graph"}
+    assert "enabled" in layers["graph"]
+    assert "dedup_min_score" in layers["fact"]
+
+    # With the user switch off, every layer reads disabled regardless of env.
+    off = rb._memory_refs(False, "ws-1")
+    assert off[0].detail["enabled"] is False
+    assert off[0].detail["layers"]["graph"]["enabled"] is False
+
+
 # ── binding behaviour ────────────────────────────────────────────────────────
 
 

--- a/src/backend/tests/memory/test_extractor_routing.py
+++ b/src/backend/tests/memory/test_extractor_routing.py
@@ -14,7 +14,6 @@ Two rules this file exists to hold:
 
 from core.memory.extractors.router import ExtractorType, classify_conversation
 
-
 LONG_ANSWER = "好的，我按你说的口径重新算了一遍，" * 3
 
 
@@ -25,6 +24,7 @@ def test_there_is_no_fact_extractor():
         "preference",
         "task",
         "procedural",
+        "graph",
     }
 
 
@@ -55,9 +55,7 @@ def test_a_throwaway_turn_is_not_worth_an_llm_call():
 
 def test_an_unanswered_turn_is_not_examined():
     # A question the assistant never answered has no outcome to learn from.
-    assert ExtractorType.PROCEDURAL not in classify_conversation(
-        "这个财务口径应该怎么算比较好", ""
-    )
+    assert ExtractorType.PROCEDURAL not in classify_conversation("这个财务口径应该怎么算比较好", "")
 
 
 def test_identity_and_preference_stay_keyword_gated():
@@ -66,3 +64,20 @@ def test_identity_and_preference_stay_keyword_gated():
     assert ExtractorType.IDENTITY in classify_conversation("我是研发中心的负责人", LONG_ANSWER)
     assert ExtractorType.IDENTITY not in classify_conversation("帮我算下这个季度的数", LONG_ANSWER)
     assert ExtractorType.PREFERENCE in classify_conversation("以后回答简洁点", LONG_ANSWER)
+
+
+def test_graph_extraction_is_deployment_gated(monkeypatch):
+    from types import SimpleNamespace
+
+    from core.memory.extractors import router
+
+    monkeypatch.setattr(
+        router,
+        "settings",
+        SimpleNamespace(memory=SimpleNamespace(graph_enabled=True)),
+    )
+    classes = router.classify_conversation(
+        "项目北斗依赖统一身份认证平台才能登录",
+        LONG_ANSWER,
+    )
+    assert ExtractorType.GRAPH in classes

--- a/src/backend/tests/memory/test_graph_memory.py
+++ b/src/backend/tests/memory/test_graph_memory.py
@@ -1,0 +1,190 @@
+"""L3 graph memory keeps declarative relations separate and actionable."""
+
+from types import SimpleNamespace
+
+import pytest
+from core.memory import graph as G
+from core.memory import service as S
+from core.memory.context import MemoryContext
+from core.memory.extractors import writers as W
+from core.memory.extractors.router import ExtractorType
+from core.memory.retrieval_types import RetrievedRelation
+
+
+def test_relation_parser_accepts_only_the_bounded_graph_vocabulary():
+    relation = G.parse_relation(
+        {
+            "source": "项目北斗",
+            "source_type": "project",
+            "predicate": "depends_on",
+            "target": "统一身份认证平台",
+            "target_type": "system",
+            "confidence": 1.7,
+        }
+    )
+    assert relation is not None
+    assert relation.relationship == "依赖"
+    assert relation.confidence == 1.0
+    assert G.parse_relation({"source": "A", "predicate": "invented", "target": "B"}) is None
+    assert (
+        G.parse_relation(
+            {
+                "source": "项目北斗",
+                "predicate": "depends_on",
+                "target": "统一身份认证平台",
+                "confidence": 0.4,
+            }
+        )
+        is None
+    )
+
+
+def test_relation_parser_deduplicates_one_turn():
+    raw = {
+        "source": "项目北斗",
+        "source_type": "project",
+        "predicate": "uses",
+        "target": "数据中台",
+        "target_type": "system",
+    }
+    assert len(G.parse_relations([raw, dict(raw)])) == 1
+
+
+def test_graph_read_uses_a_non_reserved_cypher_parameter(monkeypatch):
+    class Session:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def run(self, statement, **parameters):
+            assert "$search_text" in statement
+            assert parameters["search_text"] == "Project Polaris"
+            return []
+
+    class Driver:
+        @staticmethod
+        def session():
+            return Session()
+
+    monkeypatch.setattr(G, "_get_driver", lambda: Driver())
+    assert (
+        G._read_sync(
+            scope_user_id="u1",
+            workspace_id="default",
+            limit=5,
+            query="Project Polaris",
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_graph_writer_reports_an_addressable_l3_relation(monkeypatch):
+    monkeypatch.setattr(
+        W,
+        "settings",
+        SimpleNamespace(memory=SimpleNamespace(graph_enabled=True)),
+    )
+
+    async def fake_write(_ctx, relations):
+        assert relations[0].predicate == "belongs_to"
+        return [
+            {
+                **relations[0].to_dict(),
+                "relation_id": "grel-42",
+                "seen_count": 1,
+            }
+        ]
+
+    async def fake_audit(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(W, "write_graph_relations", fake_write)
+    monkeypatch.setattr(W, "audit_record_batch", fake_audit)
+    ctx = MemoryContext(user_id="u1", write_enabled=True, message_id="m1")
+
+    written = await W.write_layered(
+        {
+            ExtractorType.GRAPH: {
+                "relations": [
+                    {
+                        "source": "研发一组",
+                        "source_type": "team",
+                        "predicate": "belongs_to",
+                        "target": "研发中心",
+                        "target_type": "organization",
+                    }
+                ]
+            }
+        },
+        ctx,
+    )
+
+    assert written == [
+        {
+            "layer": "L3",
+            "kind": "graph_relation",
+            "handle": "grel-42",
+            "text": "研发一组 → 隶属于 → 研发中心",
+            "action": "write",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retrieved_relations_carry_identity_from_the_graph_store(monkeypatch):
+    """Retrieval must not discard the id/confidence the store already returns."""
+    monkeypatch.setattr(
+        S,
+        "settings",
+        SimpleNamespace(memory=SimpleNamespace(enabled=True, graph_enabled=True)),
+    )
+
+    async def fake_search(_scope_user_id, _query, *, workspace_id, limit):
+        return [
+            {
+                "source": "项目北斗",
+                "relationship": "依赖",
+                "target": "统一身份认证平台",
+                "relation_id": "grel_x1",
+                "predicate": "depends_on",
+                "confidence": 0.87,
+            }
+        ]
+
+    monkeypatch.setattr("core.memory.graph.search_graph_relations", fake_search)
+    relations = await S._retrieve_graph_relations(
+        user_id="u1", workspace_id="default", query="项目北斗", limit=5
+    )
+    relation = relations[0]
+    assert relation.relation_id == "grel_x1"
+    assert relation.predicate == "depends_on"
+    assert relation.confidence == pytest.approx(0.87)
+
+
+@pytest.mark.asyncio
+async def test_graph_relations_survive_a_vector_store_outage(monkeypatch):
+    monkeypatch.setattr(
+        S,
+        "settings",
+        SimpleNamespace(memory=SimpleNamespace(enabled=True, graph_enabled=True)),
+    )
+    monkeypatch.setattr(S, "_get_memory", lambda: None)
+
+    async def fake_graph(**_kwargs):
+        return (
+            RetrievedRelation(
+                source="项目北斗",
+                relationship="依赖",
+                target="统一身份认证平台",
+                rank=1,
+            ),
+        )
+
+    monkeypatch.setattr(S, "_retrieve_graph_relations", fake_graph)
+    result = await S.retrieve_memories_structured("u1", "项目北斗依赖什么？")
+    assert result.degraded is True
+    assert result.degrade_reason == "store_unavailable"
+    assert result.relations[0].target == "统一身份认证平台"

--- a/src/backend/tests/memory/test_retrieval_structured.py
+++ b/src/backend/tests/memory/test_retrieval_structured.py
@@ -171,6 +171,71 @@ def test_graph_relations_reported_as_graph_layer():
     assert result.relations[0].to_event_payload()["layer"] == LAYER_GRAPH
 
 
+def test_relation_event_payload_carries_the_stable_graph_id():
+    """L3 evidence must be resolvable back to the Neo4j edge it came from.
+
+    Without ``relation_id`` in the trace event, an Episode's graph evidence can
+    only be matched by content — which breaks as soon as an entity is renamed
+    or merged. Old traces without the id still degrade to the content hash.
+    """
+    relation = RetrievedRelation(
+        source="项目北斗",
+        relationship="依赖",
+        target="统一身份认证平台",
+        rank=1,
+        relation_id="grel_abc123",
+        predicate="depends_on",
+        confidence=0.87,
+    )
+    payload = relation.to_event_payload()
+    assert payload["relation_id"] == "grel_abc123"
+    assert payload["predicate"] == "depends_on"
+    assert payload["confidence"] == pytest.approx(0.87)
+    # Legacy construction (no id) stays valid and keys on content alone.
+    legacy = RetrievedRelation(source="A", relationship="属于", target="B", rank=1)
+    assert legacy.to_event_payload()["relation_id"] == ""
+
+
+def test_relation_ref_shadow_records_the_graph_relation_id(monkeypatch):
+    """The shadow row for an L3 relation must keep the store's own id.
+
+    ``external_id=None`` made graph evidence unauditable: the ref existed but
+    pointed at nothing that could be looked up in Neo4j.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    import core.memory.ref_shadow as RS
+    from core.db.engine import Base
+    from core.db.models import MemoryRefShadow
+
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine, tables=[MemoryRefShadow.__table__])
+    factory = sessionmaker(bind=engine)
+    monkeypatch.setattr(RS, "SessionLocal", factory)
+
+    result = MemoryRetrievalResult(
+        relations=(
+            RetrievedRelation(
+                source="项目北斗",
+                relationship="依赖",
+                target="统一身份认证平台",
+                rank=1,
+                relation_id="grel_abc123",
+            ),
+        )
+    )
+    refs = RS.record_retrieved_refs(result, user_id="u1")
+    assert len(refs) == 1
+    with factory() as db:
+        row = db.query(MemoryRefShadow).one()
+        assert row.layer == LAYER_GRAPH
+        assert row.external_id == "grel_abc123"
+        assert row.ref_id == refs[0]
+
+
 # ── Content hash / ref stability ─────────────────────────────────────────────
 
 

--- a/src/backend/tests/orchestration/test_model_progress_signal.py
+++ b/src/backend/tests/orchestration/test_model_progress_signal.py
@@ -1,0 +1,69 @@
+"""model_progress liveness signal tests.
+
+During long tool-call-argument generation the model streams ToolCallDeltaEvent
+for minutes while StreamingAgent._map_event yields nothing downstream; the run
+inactivity watchdog then saw pure silence and killed a healthy run. stream()
+now emits a throttled ("model_progress", None) when upstream events keep
+arriving but none maps to an SSE event.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import orchestration.streaming as streaming_mod
+from orchestration.streaming import StreamingAgent
+
+
+class ToolCallStartEvent:  # noqa: D101 - name-dispatched by _map_event
+    def __init__(self, tid="t1", name="bash"):
+        self.tool_call_id = tid
+        self.tool_call_name = name
+
+
+class ToolCallDeltaEvent:  # noqa: D101
+    def __init__(self, tid="t1", delta="x"):
+        self.tool_call_id = tid
+        self.delta = delta
+
+
+def _fake_agent(events):
+    async def reply_stream(inputs=None):
+        for ev in events:
+            yield ev
+
+    state = SimpleNamespace(
+        user_id="u1",
+        chat_id="c1",
+        apply_request_context=lambda ctx, text: None,
+        context=SimpleNamespace(extend=lambda msgs: None),
+    )
+    return SimpleNamespace(state=state, model=None, reply_stream=reply_stream)
+
+
+async def _collect(agent):
+    sa = StreamingAgent(agent, mcp_clients=[])
+    out = []
+    async for item in sa.stream(session_messages=[], context={"enable_thinking": True}):
+        out.append(item)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_swallowed_deltas_emit_model_progress(monkeypatch):
+    monkeypatch.setattr(streaming_mod, "_MODEL_PROGRESS_MIN_INTERVAL_S", 0.0)
+    events = [ToolCallStartEvent()] + [ToolCallDeltaEvent(delta="chunk") for _ in range(5)]
+    out = await _collect(_fake_agent(events))
+    types = [t for t, _ in out]
+    assert "tool_pending" in types
+    assert types.count("model_progress") == 5
+
+
+@pytest.mark.asyncio
+async def test_throttle_suppresses_model_progress():
+    # Default 5s throttle: a fast burst of swallowed deltas must not spam signals.
+    events = [ToolCallStartEvent()] + [ToolCallDeltaEvent(delta="chunk") for _ in range(5)]
+    out = await _collect(_fake_agent(events))
+    types = [t for t, _ in out]
+    assert types.count("model_progress") == 0

--- a/src/backend/tests/sandbox/test_user_bound_sandbox.py
+++ b/src/backend/tests/sandbox/test_user_bound_sandbox.py
@@ -1,0 +1,77 @@
+"""Regression tests for OpenSandbox per-user volume routing."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from core.sandbox import _opensandbox_internals as internals
+from core.sandbox._opensandbox_session import _OpenSandboxSessionMixin
+
+_FLAGS = (
+    "opensandbox_myspace_bind_mount_enabled",
+    "dws_creds_bind_mount_enabled",
+    "lark_creds_bind_mount_enabled",
+    "email_creds_bind_mount_enabled",
+    "yida_creds_bind_mount_enabled",
+)
+
+
+def _settings(**overrides):
+    values = {name: False for name in _FLAGS}
+    values.update(overrides)
+    return SimpleNamespace(sandbox=SimpleNamespace(**values))
+
+
+@pytest.mark.parametrize("enabled_flag", _FLAGS)
+def test_each_private_mount_requires_user_bound_sandbox(monkeypatch, enabled_flag):
+    monkeypatch.setattr(internals, "settings", _settings(**{enabled_flag: True}))
+
+    assert internals._user_bound_sandbox_required() is True
+
+
+def test_all_private_mounts_disabled_allow_general_pool(monkeypatch):
+    monkeypatch.setattr(internals, "settings", _settings())
+
+    assert internals._user_bound_sandbox_required() is False
+
+
+def test_dingtalk_mount_uses_user_pool_when_myspace_mount_is_disabled(monkeypatch):
+    """HugAgentOS regression: dws=true + myspace=false must still mount user credentials."""
+    monkeypatch.setattr(
+        internals,
+        "settings",
+        _settings(dws_creds_bind_mount_enabled=True),
+    )
+    provider = _OpenSandboxSessionMixin()
+    user_sandbox = SimpleNamespace(id="user-sandbox")
+    provider._jupyter_user_pool = SimpleNamespace(acquire=AsyncMock(return_value=user_sandbox))
+    provider._pool = SimpleNamespace(acquire=AsyncMock())
+
+    session = asyncio.run(provider._create_session(user_id="user-1"))
+
+    assert session.sandbox is user_sandbox
+    assert session.pool_source == "user"
+    provider._jupyter_user_pool.acquire.assert_awaited_once_with("user-1")
+    provider._pool.acquire.assert_not_awaited()
+
+
+def test_missing_user_id_still_uses_general_pool(monkeypatch):
+    monkeypatch.setattr(
+        internals,
+        "settings",
+        _settings(dws_creds_bind_mount_enabled=True),
+    )
+    provider = _OpenSandboxSessionMixin()
+    general_sandbox = SimpleNamespace(id="general-sandbox")
+    provider._jupyter_user_pool = SimpleNamespace(acquire=AsyncMock())
+    provider._pool = SimpleNamespace(acquire=AsyncMock(return_value=general_sandbox))
+
+    session = asyncio.run(provider._create_session(user_id=None))
+
+    assert session.sandbox is general_sandbox
+    assert session.pool_source == "general"
+    provider._pool.acquire.assert_awaited_once_with("jupyter")
+    provider._jupyter_user_pool.acquire.assert_not_awaited()

--- a/src/backend/tests/test_iter_budget_middleware.py
+++ b/src/backend/tests/test_iter_budget_middleware.py
@@ -92,3 +92,45 @@ def test_tiny_budget_never_reminds(max_iters):
     agent = _fake_agent(max_iters=max_iters, cur_iter=max(0, max_iters - 1))
     mw._maybe_remind(agent)
     assert agent.state.context == []
+
+
+# ── _maybe_force_text ──────────────────────────────────────────────────────
+
+
+def test_force_text_on_final_round():
+    mw = IterBudgetReminderMiddleware()
+    agent = _fake_agent(max_iters=10, cur_iter=9)  # final round
+    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    tc = out.get("tool_choice")
+    assert tc is not None and tc.mode == "none"
+
+
+def test_no_force_text_before_final_round():
+    mw = IterBudgetReminderMiddleware()
+    agent = _fake_agent(max_iters=10, cur_iter=8)  # 2 left
+    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    assert out.get("tool_choice") is None
+
+
+def test_force_text_respects_explicit_tool_choice():
+    sentinel = object()
+    mw = IterBudgetReminderMiddleware()
+    agent = _fake_agent(max_iters=10, cur_iter=9)
+    out = mw._maybe_force_text(agent, {"tool_choice": sentinel})
+    assert out["tool_choice"] is sentinel
+
+
+@pytest.mark.parametrize("max_iters", [1, 2, 3])
+def test_force_text_skips_tiny_budget(max_iters):
+    mw = IterBudgetReminderMiddleware()
+    agent = _fake_agent(max_iters=max_iters, cur_iter=max(0, max_iters - 1))
+    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    assert out.get("tool_choice") is None
+
+
+def test_force_text_kill_switch(monkeypatch):
+    monkeypatch.setenv("CHAT_FINAL_ITER_FORCE_TEXT", "false")
+    mw = IterBudgetReminderMiddleware()
+    agent = _fake_agent(max_iters=10, cur_iter=9)
+    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    assert out.get("tool_choice") is None

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -1091,6 +1091,11 @@ export async function deleteMemory(memoryId: string, messageId?: string): Promis
   await apiRequest(`/v1/memories/${memoryId}${qs}`, { method: 'DELETE' });
 }
 
+export async function deleteGraphRelation(relationId: string, messageId?: string): Promise<void> {
+  const qs = messageId ? `?message_id=${encodeURIComponent(messageId)}` : '';
+  await apiRequest(`/v1/memories/graph/${relationId}${qs}`, { method: 'DELETE' });
+}
+
 export async function updateMemory(
   memoryId: string,
   text: string,
@@ -2284,6 +2289,7 @@ export const api = {
   healthCheck,
   getMemories,
   deleteMemory,
+  deleteGraphRelation,
   updateMemory,
   updateProfileField,
   deleteProfileField,

--- a/src/frontend/src/components/chat/EvolutionCard.tsx
+++ b/src/frontend/src/components/chat/EvolutionCard.tsx
@@ -8,6 +8,7 @@ import { motion } from 'motion/react';
 import { useState } from 'react';
 
 import {
+  deleteGraphRelation,
   deleteMemory,
   deleteProfileField,
   updateMemory,
@@ -40,6 +41,7 @@ interface EvolutionCardProps {
 const LAYER_LABEL: Record<string, string> = {
   L1: '用户画像',
   L2: '做法沉淀',
+  L3: '图谱关系',
 };
 
 function MemoryRow({
@@ -59,6 +61,7 @@ function MemoryRow({
   const [error, setError] = useState('');
 
   const isProfile = entry.layer === 'L1';
+  const isGraph = entry.layer === 'L3';
 
   const save = async () => {
     const text = draft.trim();
@@ -72,6 +75,10 @@ function MemoryRow({
     try {
       if (isProfile) {
         await updateProfileField(entry.handle, text, messageId);
+      } else if (isGraph) {
+        // Graph relations are triples. They can be removed and re-learned, but
+        // free-text editing would make the relation shape ambiguous.
+        return;
       } else {
         await updateMemory(entry.handle, text, messageId);
       }
@@ -90,6 +97,8 @@ function MemoryRow({
     try {
       if (isProfile) {
         await deleteProfileField(entry.handle, messageId);
+      } else if (isGraph) {
+        await deleteGraphRelation(entry.handle, messageId);
       } else {
         await deleteMemory(entry.handle, messageId);
       }
@@ -161,14 +170,16 @@ function MemoryRow({
           </>
         ) : (
           <>
-            <button
-              type="button"
-              aria-label={t('编辑这条记忆')}
-              onClick={() => setEditing(true)}
-              disabled={busy}
-            >
-              <EditOutlined />
-            </button>
+            {!isGraph && (
+              <button
+                type="button"
+                aria-label={t('编辑这条记忆')}
+                onClick={() => setEditing(true)}
+                disabled={busy}
+              >
+                <EditOutlined />
+              </button>
+            )}
             <button
               type="button"
               aria-label={t('删除这条记忆')}

--- a/src/frontend/src/components/chat/InputArea.tsx
+++ b/src/frontend/src/components/chat/InputArea.tsx
@@ -864,6 +864,7 @@ export function InputArea({
               aria-label={t('计划模式')}
               title={planMode ? t('关闭计划模式：切换为普通对话') : t('开启计划模式：AI 将自动分解任务为多步骤并逐步执行')}
             >
+              <OrderedListOutlined className="jx-planModeIcon" />
               <span>{t('计划模式')}</span>
             </motion.button>
           )}
@@ -875,6 +876,7 @@ export function InputArea({
               aria-label={t('批量执行模式')}
               title={t('批量执行模式：描述要批量处理的对象与任务，AI 会自动生成可确认的执行计划')}
             >
+              <ThunderboltOutlined className="jx-planModeIcon" />
               <span>{t('批量执行')}</span>
             </div>
           )}
@@ -888,6 +890,7 @@ export function InputArea({
               aria-label={t('自主循环')}
               title={t('关闭自主循环：切换为普通对话')}
             >
+              <SyncOutlined className="jx-planModeIcon" />
               <span>{t('自主循环')}</span>
             </motion.button>
           )}
@@ -901,6 +904,9 @@ export function InputArea({
               aria-label={activeMode === 'plan' ? t('计划模式') : t('批量执行')}
               title={t('发送后将以该模式在本项目内开始对话；点击取消')}
             >
+              {activeMode === 'plan'
+                ? <OrderedListOutlined className="jx-planModeIcon" />
+                : <ThunderboltOutlined className="jx-planModeIcon" />}
               <span>{activeMode === 'plan' ? t('计划模式') : t('批量执行')}</span>
             </motion.button>
           )}

--- a/src/frontend/src/components/settings/EvolutionApprovalList.tsx
+++ b/src/frontend/src/components/settings/EvolutionApprovalList.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { approveMyEvolutionCandidate, getMyEvolutionCandidates } from '../../api';
 import type { MyEvolutionCandidate } from '../../api';
 import { t } from '../../i18n';
+import { useCatalogStore } from '../../stores/catalogStore';
 
 /**
  * Capability changes the signed-in user can decide on for themselves.
@@ -107,13 +108,24 @@ export function EvolutionApprovalList() {
         message.success(
           candidate.action === 'apply_memory'
             ? t('已应用该记忆调整')
-            : t('已为你启用该能力'),
+            : t('已为你启用该能力，可在「能力中心 → 技能」查看'),
         );
         // Drop it locally rather than refetching: the row is gone either way,
         // and a spinner over a list the user just acted on reads as uncertainty.
         setItems((prev) => prev.filter((c) => c.candidate_id !== candidate.candidate_id));
+        if (candidate.action !== 'apply_memory') {
+          // The new private skill lives in the capability catalog; without a
+          // refetch the cached store keeps showing the pre-approval list until
+          // the next full page load.
+          void useCatalogStore.getState().fetchCatalog();
+        }
       })
-      .catch(() => message.error(t('操作失败，请稍后重试')))
+      .catch((err: unknown) => {
+        // The backend explains refusals ("你已启用过…" / "需管理员审批") — a
+        // generic retry toast would hide the one line that resolves them.
+        const detail = err instanceof Error ? err.message : '';
+        message.error(detail && !detail.startsWith('API Error') ? detail : t('操作失败，请稍后重试'));
+      })
       .finally(() => setApproving(''));
   };
 

--- a/src/frontend/src/hooks/useChatInit.ts
+++ b/src/frontend/src/hooks/useChatInit.ts
@@ -9,7 +9,7 @@ import { stripMcpToolPrefix } from '../utils/constants';
 import { parseContextCompactionState } from '../utils/contextUsage';
 import { shouldRestorePlanModeFromHistory } from '../utils/chatMode';
 import { LOGIN_LANDING_KEY, useAuthStore, useSettingsStore, useUIStore, useChatStore, useCatalogStore, useAutomationChatStore, useBatchStore } from '../stores';
-import type { Catalog, ChatItem, ChatMessage, CitationItem, ContextCompactionState, OntologyGovernanceSummary, ToolCall, UpdateEntry, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
+import type { Catalog, ChatItem, ChatMessage, CitationItem, ContextCompactionState, EvolutionSummary, OntologyGovernanceSummary, ToolCall, UpdateEntry, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
 
 const effectiveApiUrl = (import.meta.env.VITE_API_BASE_URL as string || '').trim() || '/api';
 
@@ -139,6 +139,15 @@ function parseHistoryMessage(m: any): ChatMessage {
     ? (m.metadata.workspace_files as unknown[])
         .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
     : undefined;
+  const rawEvolution = m.role === 'assistant'
+    && m.metadata?.evolution
+    && typeof m.metadata.evolution === 'object'
+    ? m.metadata.evolution as Partial<EvolutionSummary>
+    : undefined;
+  const histEvolution: EvolutionSummary | undefined = rawEvolution
+    && ['pending', 'settled', 'failed', 'empty'].includes(String(rawEvolution.state))
+    ? rawEvolution as EvolutionSummary
+    : undefined;
   const rawOntologyGovernance = m.role === 'assistant'
     && m.metadata?.ontology_governance
     && typeof m.metadata.ontology_governance === 'object'
@@ -199,6 +208,7 @@ function parseHistoryMessage(m: any): ChatMessage {
     ...(histAttachments && histAttachments.length > 0 && { attachments: histAttachments }),
     ...(histQuotedFollowUp?.text && { quotedFollowUp: histQuotedFollowUp }),
     ...(histWorkspaceFiles !== undefined && { workspaceFiles: histWorkspaceFiles }),
+    ...(histEvolution && { evolution: histEvolution }),
     ...(histOntologyGovernance && { ontologyGovernance: histOntologyGovernance }),
     ...(histSkillId && { skillId: histSkillId }),
     ...(histSkillName && { skillName: histSkillName }),

--- a/src/frontend/src/i18n/en/settings.ts
+++ b/src/frontend/src/i18n/en/settings.ts
@@ -571,6 +571,8 @@ export const SETTINGS_DICT: Record<string, string> = {
   '调权': 'Reweight',
   '合并': 'Merge',
   '已为你启用该能力': 'Capability enabled for you',
+  '已为你启用该能力，可在「能力中心 → 技能」查看':
+    'Capability enabled for you — find it under Capability Centre → Skills',
   '启用失败，请稍后重试': 'Could not enable it — please try again',
   '启用后仅对你生效，不影响其他成员；随时可在能力中心停用。':
     'Enabling applies to you only and does not affect other members; you can disable it anytime in the capability centre.',

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -2166,6 +2166,9 @@ textarea.jx-composer{
   transition:color .18s ease, border-color .18s ease;
   pointer-events:auto;
 }
+.jx-planModeIcon{
+  display:none;
+}
 .jx-planModeBtn:hover{
   color:rgba(15,23,42,.88);
   border-color:rgba(15,23,42,.22);

--- a/src/frontend/src/styles/mobile.css
+++ b/src/frontend/src/styles/mobile.css
@@ -521,8 +521,11 @@
   .jx-appShell.ant-layout{
     width:100%;
     max-width:100vw;
+    /* 100vh is the compatibility fallback; 100dvh follows the actually visible
+     * browser viewport while the mobile address/tool bars expand and collapse. */
+    height:100vh !important;
     height:100dvh !important;
-    min-height:100vh;
+    min-height:0;
     flex-direction:row !important;
     overflow:hidden;
   }
@@ -645,7 +648,9 @@
   }
 }
 
-@media (max-width: 768px){
+/* Portrait phones use the width breakpoint; landscape phones can exceed 768px,
+ * so a short-height clause keeps the same compact chat composition there. */
+@media (max-width: 768px), (max-width: 960px) and (max-height: 600px){
   .jx-mainRow,
   .jx-content{
     min-width:0;
@@ -668,7 +673,7 @@
     width:100%;
     height:100%;
     min-height:100%;
-    padding:0 18px max(52px, env(safe-area-inset-bottom));
+    padding:0 18px max(16px, env(safe-area-inset-bottom));
     overflow:hidden;
   }
 
@@ -685,7 +690,7 @@
     order:1;
     flex:none;
     padding:0;
-    margin-top:88px;
+    margin-top:clamp(24px, 8dvh, 68px);
     overflow:visible;
   }
 
@@ -707,14 +712,14 @@
   .jx-mobileHeroText h1{
     margin:0;
     color:#090d15;
-    font-size:54px;
+    font-size:clamp(42px, 14vw, 54px);
     font-weight:800;
     line-height:1.02;
-    letter-spacing:-2.7px;
+    letter-spacing:-.05em;
   }
 
   .jx-mobileHeroText p{
-    margin:18px 0 0;
+    margin:12px 0 0;
     color:#5f6672;
     font-size:16px;
     font-weight:400;
@@ -785,14 +790,10 @@
     order:3;
     flex:none;
     width:100%;
-    margin-top:16px;
+    margin-top:clamp(10px, 2dvh, 16px);
   }
 
-  .jx-emptyPage--main .jx-homeInput .jx-runTargetRow,
-  .jx-emptyPage--main .jx-homeInput .jx-promptHubBtn,
-  .jx-emptyPage--main .jx-homeInput .jx-planModeBtn,
-  .jx-emptyPage--main .jx-homeInput .jx-modelDropBtn,
-  .jx-emptyPage--main .jx-homeInput .jx-ctxGauge{
+  .jx-emptyPage--main .jx-homeInput .jx-runTargetRow{
     display:none !important;
   }
 
@@ -823,8 +824,8 @@
 
   .jx-emptyPage--main .jx-homeInput .jx-composerBar{
     height:44px;
-    gap:6px;
-    padding:6px 12px 8px;
+    gap:4px;
+    padding:6px 10px 8px;
     border-bottom-left-radius:18px;
     border-bottom-right-radius:18px;
   }
@@ -847,20 +848,61 @@
 
   .jx-emptyPage--main .jx-homeInput .jx-modeDropBtn{
     order:2;
-    height:28px;
-    min-height:28px;
-    margin-left:2px;
-    padding:0 3px 0 13px;
-    border:0;
-    border-left:1px solid #d8dee8;
-    border-radius:0;
+    width:30px;
+    min-width:30px;
+    height:30px;
+    min-height:30px;
+    flex:0 0 30px;
+    justify-content:center;
+    margin:0;
+    padding:0;
+    border-color:transparent;
+    border-radius:8px;
     color:#141923;
-    font-size:13px;
   }
 
   .jx-emptyPage--main .jx-homeInput .jx-modeIcon{
     width:15px;
     height:15px;
+  }
+
+  /* Mobile composer controls keep every capability available, but collapse
+   * their visible labels so narrow screens never push actions outside the box. */
+  .jx-composerBar{
+    gap:4px;
+    padding-right:10px;
+    padding-left:10px;
+  }
+
+  .jx-modeDropBtn,
+  .jx-promptHubBtn,
+  .jx-modelDropBtn,
+  .jx-planModeBtn{
+    width:30px;
+    min-width:30px;
+    height:30px;
+    min-height:30px;
+    flex:0 0 30px;
+    justify-content:center;
+    gap:0;
+    padding:0;
+  }
+
+  .jx-modeDropBtn > span,
+  .jx-modeDropBtn .jx-modeArrow,
+  .jx-promptHubBtn > span,
+  .jx-modelDropText,
+  .jx-planModeBtn > span{
+    display:none;
+  }
+
+  .jx-planModeIcon{
+    display:inline-flex;
+    font-size:16px;
+  }
+
+  .jx-modelDropBtn{
+    border-color:transparent;
   }
 
   .jx-projectDropBtn,
@@ -946,6 +988,13 @@
 @media (max-width: 360px){
   .jx-emptyPage--main{
     padding-inline:14px;
+  }
+
+  .jx-composerBar,
+  .jx-emptyPage--main .jx-homeInput .jx-composerBar{
+    gap:3px;
+    padding-right:8px;
+    padding-left:8px;
   }
 
   .jx-mobileQuickTasksRow{
@@ -1599,5 +1648,43 @@
 
   .jx-abilityCenter .jx-sk-detailName{
     max-width:none;
+  }
+}
+
+/* Short phones and landscape browser windows need a denser vertical rhythm.
+ * Width-only breakpoints cannot account for their much smaller visible height. */
+@media (max-width:960px) and (max-height:700px){
+  .jx-mobileHeader{
+    flex-basis:54px;
+    height:54px;
+    padding:6px 16px;
+  }
+
+  .jx-emptyPage--main .jx-heroBg{
+    margin-top:clamp(12px, 4dvh, 28px);
+  }
+
+  .jx-mobileHeroText h1{
+    font-size:40px;
+  }
+
+  .jx-mobileHeroText p{
+    margin-top:8px;
+    font-size:14px;
+  }
+
+  .jx-mobileQuickTasksLabel{
+    margin-bottom:8px;
+  }
+
+  .jx-mobileQuickTask{
+    height:32px;
+  }
+
+  .jx-emptyPage--main .jx-homeInput .jx-composerWrap,
+  .jx-emptyPage--main .jx-homeInput .jx-composer,
+  .jx-emptyPage--main .jx-homeInput .jx-composerEditor{
+    height:82px !important;
+    min-height:82px !important;
   }
 }

--- a/src/frontend/src/types.ts
+++ b/src/frontend/src/types.ts
@@ -280,13 +280,13 @@ export interface OntologyRevisionSummary {
 /**
  * One memory a turn wrote.
  *
- * `handle` is what makes the row actionable — a mem0 id for an L2 procedure, a
- * profile field key for an L1 entry — and decides which API the edit and delete
- * buttons call. An entry without one is never emitted by the backend.
+ * `handle` is what makes the row actionable — a profile field key for L1, a
+ * mem0 id for L2, or a Neo4j relation id for L3 — and decides which API the
+ * actions call. An entry without one is never emitted by the backend.
  */
 export interface EvolutionMemoryEntry {
-  /** `L1` = user profile field, `L2` = procedural memory. */
-  layer: 'L1' | 'L2';
+  /** `L1` = user profile, `L2` = procedure, `L3` = entity relation. */
+  layer: 'L1' | 'L2' | 'L3';
   handle: string;
   text: string;
   kind?: string;


### PR DESCRIPTION
## What

Evolved skills used to be distilled from procedural (L2) memory alone: they could state steps, but nothing decided when they applied, what they depended on, or how trustworthy they were. This PR turns skill compilation into a layered-evidence pipeline where each memory layer decides only its own part — steps come from L2, boundaries from the L3 graph, validity from episodes, and personalization stays a runtime binding of L1.

## Highlights

**L3 graph memory (Neo4j)**
- Entity relations with stable `grel_*` ids, a bounded predicate vocabulary, per-scope isolation, and confidence/seen-count tracking
- Retrieval carries `relation_id` end to end, so an episode's graph evidence can always be resolved back to the exact edge

**Evidence contract & resolver**
- Immutable, content-addressed evidence packs: the same evidence always resolves to the same `pack_id`, so repeated cycles never mint duplicate candidates
- Graph roles are a closed set (`applicability` / `dependency` / `constraint` / `exclusion` / `alias`) — a graph fact can bound a skill, never become an executable step
- Tenant isolation is enforced in the resolver, and shared packs may carry L1 policy references only, never raw profile content

**Unified candidate engine**
- The intent-cluster path and the tool-sequence path now share one compile chain: resolver → deterministic manifest (tools, boundaries, dependencies, risk decided by code) → LLM writes only the document body → cross-layer validation
- Validation refuses: tools outside the evidence, graph facts written into the steps section, secret material, raw profile content in shared skills, L2/L3 contradictions, and unresolvable pack hashes

**Lineage & governance**
- New tables for evidence packs, persisted credit decisions, and promotion links (`compiled_from` / `constrained_by` / `validated_by` / `assembled_into` / `rolled_back_to`)
- Activation writes a machine-readable `evolution_manifest.json` next to `SKILL.md`; runtime applicability (task types, live graph dependencies) reads the manifest
- Replay sets must cover failure recoveries, negative examples, and both graph-dependency classes before a candidate advances; conflicting graph evidence may enter shadow but can never auto-activate
- Rollback now restores down-weighted source memories and deactivates dependent agent profiles

**Graph evolution**
- Reinforcement and stale down-weighting apply automatically; contradictions, supersessions, alias merges, and missing-edge suggestions become human-review proposals; relations are never deleted

**UX**
- Personal approvals no longer re-list capabilities the user already enabled; approval failures surface the backend's actual reason

## Schema

Three new tables (`evolution_evidence_packs`, `evolution_credit_decisions`, `evolution_promotion_links`) and one new column (`evolution_candidates.evidence_pack_id`) — created automatically by the CE schema reconciliation on startup, no manual migration needed.

## Tests

41 new tests (evidence contract, resolver determinism, engine idempotency, activation lineage, replay coverage, runtime applicability, graph scan automation boundary); full evolution + memory suites pass.