### PR TITLE
fix(evolution): mount personal evolution routes; desktop 0.2.13

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugagent-desktop",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS/Linux 离线本机服务）",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1687,7 +1687,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hugagent-desktop"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "axum",
  "bytes",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugagent-desktop"
-version = "0.2.12"
+version = "0.2.13"
 description = "HugAgentOS桌面客户端"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HugAgentOS",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "identifier": "com.hugagent.desktop",
   "build": {
     "frontendDist": "../../src/frontend/dist",

--- a/src/backend/api/routes/v1/__init__.py
+++ b/src/backend/api/routes/v1/__init__.py
@@ -43,6 +43,11 @@ CE_ROUTERS: tuple[tuple[str, str], ...] = (
     ("integrations", "router"),
     ("channels", "router"),
     ("meta", "router"),
+    # 个人进化的证据面与偏好开关（结算查询 / prefs / 个人候选审批）。CE 完整
+    # 可用；控制面（管理员审批/发布）在 EE。此前 CE 漏挂本路由，首启向导的
+    # PATCH /v1/evolution/prefs 落到桌面本机 server 的 GET catch-all 上，
+    # 「启动进化」直接 405。
+    ("evolution", "router"),
     ("sites", "router"),
     ("desktop", "router"),
     ("local", "router"),

--- a/src/backend/tests/ce_release/test_ce_release_regressions.py
+++ b/src/backend/tests/ce_release/test_ce_release_regressions.py
@@ -134,6 +134,34 @@ def test_ce_registers_all_local_auth_routes():
     } <= actual
 
 
+def test_ce_registers_personal_evolution_routes():
+    """The evolution evidence plane is a CE capability, and it must be mounted.
+
+    When this router is missing, the first-run wizard's
+    ``PATCH /v1/evolution/prefs`` falls through to the desktop local server's
+    GET-only SPA catch-all and surfaces as a bare 405 — the whole「启动进化」
+    step becomes a dead end.
+    """
+    from api.app import app
+
+    operations = {"get", "post", "put", "patch", "delete"}
+    actual = {
+        (method.upper(), path)
+        for path, path_item in app.openapi()["paths"].items()
+        for method in path_item
+        if method in operations
+    }
+
+    assert {
+        ("GET", "/v1/evolution/prefs"),
+        ("PATCH", "/v1/evolution/prefs"),
+        ("GET", "/v1/evolution/settings"),
+        ("PATCH", "/v1/evolution/settings"),
+        ("GET", "/v1/evolution/my-candidates"),
+        ("POST", "/v1/evolution/my-cycle"),
+    } <= actual
+
+
 def test_ce_self_service_skill_and_mcp_do_not_import_admin_routes(
     initialized_ce_database,
     monkeypatch,


### PR DESCRIPTION
Fixes the first-run wizard dead end on the desktop local server: "Enable evolution" failed with **405 Method Not Allowed** because the personal evolution router was never mounted in `CE_ROUTERS` — `PATCH /v1/evolution/prefs` fell through to the GET-only SPA catch-all.

- Mount the `evolution` router (evidence plane: settlement queries, prefs, personal candidate approvals — all community capabilities)
- Add a release regression test pinning every evidence-plane endpoint
- Bump desktop to 0.2.13 so local-mode installers ship the fixed server payload