### PR TITLE
fix(evolution): gate tool-sequence skill promotion behind SOP commonality

### DIFF
--- a/src/backend/core/evolution/activation.py
+++ b/src/backend/core/evolution/activation.py
@@ -54,9 +54,10 @@ def _skill_label(tools: Sequence[str], *, rules_only: bool = False) -> str:
 
     The name and description are the *only* things the model sees before it
     decides whether to open a skill, so they have to describe the job. The
-    candidate's ``hypothesis`` reads "5 个 Episode 出现相同工具子序列且成功率
-    100%" — true, and useless for that decision, since it says nothing about
-    when the skill applies. It belongs in the provenance section, not the title.
+    candidate's ``hypothesis`` describes the evidence ("「…」类请求在 N 次独立
+    会话中以同一序列成功完成") — true, and useless for that decision, since it
+    says nothing about when the skill applies. It belongs in the provenance
+    section, not the title.
     """
     head = " → ".join(tools[:4]) + ("…" if len(tools) > 4 else "")
     return ("工具顺序规则：" if rules_only else "固定调用顺序：") + head

--- a/src/backend/core/evolution/credit.py
+++ b/src/backend/core/evolution/credit.py
@@ -228,7 +228,7 @@ def _score_targets(f: CreditFeatures) -> Dict[str, float]:
 def _explain(selected: str, f: CreditFeatures) -> str:
     reasons = {
         T_MEMORY: "当前请求与注入记忆存在显式冲突",
-        T_SKILL: "出现稳定重复的工具子序列，但每次都在重新规划",
+        T_SKILL: "出现稳定重复的工具子序列，存在可沉淀的过程知识",
         # Names the *assembly* — tools, skills, prompt fragments, routes — not a
         # DAG. The product's main axis is a ReAct loop, which executes no DAG,
         # so "workflow" pointed reviewers at a thing that does not exist here.

--- a/src/backend/core/evolution/loop.py
+++ b/src/backend/core/evolution/loop.py
@@ -229,15 +229,13 @@ def load_episode_views(*, limit: int = 500, since_days: int = 30) -> List[Dict[s
 
 
 def _features_for(pattern: P.Pattern) -> CreditFeatures:
-    """Translate a discovered pattern into attribution features."""
-    if pattern.kind == P.PATTERN_SUCCESS_SUBSEQUENCE and pattern.tool_sequence:
-        return CreditFeatures(
-            outcome_verdict="failed",  # "works, but is re-planned every time"
-            outcome_confidence=0.85,
-            repeated_tool_subsequence=True,
-            skill_selected_count=0,
-            skill_rejected_count=len(pattern.tool_sequence),
-        )
+    """Translate a discovered pattern into attribution features.
+
+    Success-subsequence tool patterns no longer come through here: they are an
+    aggregate observation over successful runs, and inventing a ``failed``
+    verdict to route them through the failure attributor is the exact move
+    :func:`core.evolution.credit.aggregate_finding` exists to replace.
+    """
     if pattern.kind == P.PATTERN_REPEATED_FAILURE:
         return CreditFeatures(
             outcome_verdict="failed",
@@ -1218,7 +1216,21 @@ def run_evolution_cycle(*, limit: int = 500, dry_run: bool = False) -> Dict[str,
     by_episode_id = {str(v.get("episode_id") or ""): v for v in views}
 
     for pattern in patterns:
-        decision = assign_credit(_features_for(pattern))
+        if pattern.kind == P.PATTERN_SUCCESS_SUBSEQUENCE and pattern.tool_sequence:
+            # An observation across many *successful* runs — aggregate decision,
+            # not failure attribution with invented features.
+            decision = aggregate_finding(
+                target=T_SKILL,
+                explanation=(
+                    f"{pattern.support} 个成功 Episode 复现同一 "
+                    f"{len(pattern.tool_sequence)} 步工具序列"
+                    f"（成功率 {pattern.success_rate:.0%}）"
+                ),
+                confidence=confidence_from_evidence(pattern.support, saturates_at=10),
+                evidence_count=pattern.support,
+            )
+        else:
+            decision = assign_credit(_features_for(pattern))
         if not decision.may_produce_candidate:
             # No-update / unidentifiable / a non-asset cause. Refusing here is
             # the mechanism that stops a KB gap being "fixed" by editing a skill.
@@ -1227,6 +1239,7 @@ def run_evolution_cycle(*, limit: int = 500, dry_run: bool = False) -> Dict[str,
 
         proposal = P.promote_tool_sequence_to_skill(
             pattern,
+            episodes=views,
             skill_credit=decision.scores.get("skill", 0.0),
             workflow_credit=decision.scores.get("workflow", 0.0),
             existing_skill_signatures=existing_signatures,
@@ -1247,6 +1260,34 @@ def run_evolution_cycle(*, limit: int = 500, dry_run: bool = False) -> Dict[str,
             for e in (proposal.payload.get("episode_ids") or [])
             if e in by_episode_id
         ]
+
+        # 规则门测统计，测不了语义——意图簇可能是巧合归并，序列可能是对任何
+        # 任务都成立的通用组合。规则幸存者再过一道 LLM 裁决，拒绝即不产候选。
+        from core.evolution.sop_judge import adjudicate_sequence_sop
+
+        verdict = _run_async(
+            adjudicate_sequence_sop(
+                representative=str(proposal.payload.get("intent") or ""),
+                objectives=[str(v.get("objective") or "") for v in supporting],
+                tool_sequence=sequence,
+                occasions=int(proposal.payload.get("occasions") or 0),
+                support=proposal.support,
+                success_rate=pattern.success_rate,
+            )
+        )
+        if not verdict.worthy:
+            report["rejected"].append(
+                {
+                    "signature": proposal.signature,
+                    "code": (
+                        "sop_judge_unavailable"
+                        if verdict.judge_unavailable
+                        else "sop_judge_refused"
+                    ),
+                    "reason": verdict.reason,
+                }
+            )
+            continue
         spec = SkillCandidateSpec(
             asset_id=asset_id,
             proposer="promotion_chain",
@@ -1274,7 +1315,12 @@ def run_evolution_cycle(*, limit: int = 500, dry_run: bool = False) -> Dict[str,
             ),
             write_document=False,
         )
-        outcome = create_skill_candidate(spec, credit=decision.to_dict(), dry_run=dry_run)
+        # 裁决结论随候选进 credit_decision 落库，评审员能看到机器放行的理由。
+        outcome = create_skill_candidate(
+            spec,
+            credit={**decision.to_dict(), "sop_judge": verdict.to_dict()},
+            dry_run=dry_run,
+        )
         status = outcome.get("status")
         if status == STATUS_REJECTED:
             report["rejected"].append(

--- a/src/backend/core/evolution/personal.py
+++ b/src/backend/core/evolution/personal.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, List, Optional
 
 from core.db.engine import SessionLocal
 from core.evolution import promotion as P
-from core.evolution.credit import CreditFeatures, assign_credit
+from core.evolution.credit import T_SKILL, aggregate_finding, confidence_from_evidence
 from core.evolution.ir import (
     RISK_LOW,
     RISK_MEDIUM,
@@ -161,25 +161,71 @@ def run_personal_cycle(
     known_concepts = _known_concepts(prefs)
 
     for pattern in patterns:
-        decision = assign_credit(
-            CreditFeatures(
-                outcome_verdict="failed",
-                outcome_confidence=0.85,
-                repeated_tool_subsequence=True,
-                skill_selected_count=0,
-                skill_rejected_count=len(pattern.tool_sequence),
-            )
+        if pattern.kind != P.PATTERN_SUCCESS_SUBSEQUENCE or not pattern.tool_sequence:
+            continue
+        # 这是"多次成功里观察到的共性"，不是某次失败的归因，所以走聚合决策。
+        # 旧实现在这里伪造 outcome_verdict="failed" 逼归因器选中技能引擎——
+        # 正是 credit.aggregate_finding 的 docstring 点名批判的做法：评审台
+        # 因此展示了一句没人测量过的失败解释。
+        decision = aggregate_finding(
+            target=T_SKILL,
+            explanation=(
+                f"{pattern.support} 个成功 Episode 复现同一 "
+                f"{len(pattern.tool_sequence)} 步工具序列"
+                f"（成功率 {pattern.success_rate:.0%}），观察自本人历史会话"
+            ),
+            confidence=confidence_from_evidence(pattern.support, saturates_at=10),
+            evidence_count=pattern.support,
         )
         if not decision.may_produce_candidate:
             report["no_update"] += 1
             continue
 
+        # min_support 必须显式传入：发现阶段用的个人门槛（3）在 _discover 返回
+        # 后已恢复为全局值（5），不传的话支持度 3–4 的个人模式会在这里被静默拒绝。
         proposal = P.promote_tool_sequence_to_skill(
             pattern,
+            episodes=views,
+            min_support=PERSONAL_MIN_SUPPORT,
             skill_credit=decision.scores.get("skill", 0.0),
             workflow_credit=decision.scores.get("workflow", 0.0),
         )
         if proposal is None:
+            continue
+
+        # 规则门之后的 LLM 语义裁决：意图簇是否巧合归并、序列是否只是对任何
+        # 任务都成立的通用组合。拒绝即不产候选；模型不可用同样拒绝，但在
+        # 报告里可区分。
+        from core.evolution.loop import _run_async
+        from core.evolution.sop_judge import adjudicate_sequence_sop
+
+        covered = {str(e) for e in (proposal.payload.get("episode_ids") or [])}
+        verdict = _run_async(
+            adjudicate_sequence_sop(
+                representative=str(proposal.payload.get("intent") or ""),
+                objectives=[
+                    str(v.get("objective") or "")
+                    for v in views
+                    if str(v.get("episode_id") or "") in covered
+                ],
+                tool_sequence=[str(t) for t in proposal.payload.get("tool_sequence", [])],
+                occasions=int(proposal.payload.get("occasions") or 0),
+                support=proposal.support,
+                success_rate=pattern.success_rate,
+            )
+        )
+        if not verdict.worthy:
+            report["rejected"].append(
+                {
+                    "signature": proposal.signature,
+                    "code": (
+                        "sop_judge_unavailable"
+                        if verdict.judge_unavailable
+                        else "sop_judge_refused"
+                    ),
+                    "reason": verdict.reason,
+                }
+            )
             continue
 
         asset_id = "u" + hashlib.sha256(
@@ -213,10 +259,11 @@ def run_personal_cycle(
             evaluation_plan={"replay_set": "personal", "primary_metric": "task_success"},
         )
 
+        stored_credit = {**decision.to_dict(), "sop_judge": verdict.to_dict()}
         try:
             validate_ir(
                 ir,
-                credit_decision=decision.to_dict(),
+                credit_decision=stored_credit,
                 allowed_scopes=["user", "workspace"],
                 known_concepts=known_concepts,
             )
@@ -232,7 +279,7 @@ def run_personal_cycle(
 
         candidate_id = _persist_candidate(
             ir,
-            credit=decision.to_dict(),
+            credit=stored_credit,
             proposer=f"personal:{user_id}",
             evidence_refs=proposal.payload.get("episode_ids", []),
         )

--- a/src/backend/core/evolution/promotion.py
+++ b/src/backend/core/evolution/promotion.py
@@ -57,6 +57,14 @@ WORKFLOW_MIN_COMBO_FREQUENCY = 5
 # common sequence becomes a workflow whether or not the grouping helps.
 WORKFLOW_MIN_UPLIFT = 0.05
 
+# 一段 SOP 至少要有的步骤数。长度 1–2 的"序列"几乎总是通用工具的巧合复现——
+# 整轮对话只调一次 view_text_file 也会形成"相同序列"——包装它们不携带任何
+# 过程知识，只往评审队列里添噪声。
+MIN_TOOL_SEQUENCE_LEN = 3
+# 支撑 Episode 中归入同一意图簇的最低占比。序列相同只说明工具巧合，
+# 意图相同才说明存在可复用的做事方法——这是把一段序列当 SOP 的前提。
+INTENT_COHESION_RATIO = 0.6
+
 
 @dataclass
 class Pattern:
@@ -197,21 +205,84 @@ class PromotionProposal:
         }
 
 
+def _dominant_shared_intent(
+    pattern: Pattern,
+    episodes: Optional[Sequence[Dict[str, Any]]],
+    *,
+    support_floor: int,
+):
+    """The one intent behind a sequence's supporting episodes, or ``None``.
+
+    ``None`` is a refusal, and deliberately covers the honest-uncertainty cases
+    too: no views supplied, request text too short to cluster, no clustering
+    method available. "We cannot tell whether these conversations had anything
+    in common" and "they had nothing in common" both mean no SOP claim can be
+    made — treating the first as a pass is how single-tool coincidences used to
+    become skills.
+    """
+    if not episodes:
+        return None
+    wanted = {str(e) for e in pattern.episode_ids}
+    supporting = [e for e in episodes if str(e.get("episode_id") or "") in wanted]
+    if len(supporting) < support_floor:
+        return None
+
+    from core.evolution.similarity import METHOD_NONE, cluster_intents
+
+    clusters, method = cluster_intents(supporting, min_support=2)
+    if method == METHOD_NONE or not clusters:
+        return None
+    top = clusters[0]
+    if len(top.episode_ids) < support_floor:
+        return None
+    if len(top.episode_ids) / len(supporting) < INTENT_COHESION_RATIO:
+        return None
+    # 复现必须跨会话：occasions 按 chat_id 去重，同一会话里反复跑同一套
+    # 流程只算一次场合，不构成"这件事总在发生"。
+    if top.occasions < support_floor:
+        return None
+    return top
+
+
 def promote_tool_sequence_to_skill(
     pattern: Pattern,
     *,
+    episodes: Optional[Sequence[Dict[str, Any]]] = None,
+    min_support: Optional[int] = None,
     skill_credit: float = 0.0,
     workflow_credit: float = 0.0,
     existing_skill_signatures: Optional[Dict[str, str]] = None,
 ) -> Optional[PromotionProposal]:
     """Compile a recurring successful tool sequence into a skill proposal.
 
+    A recurring sequence alone is *not* evidence of a reusable capability.
+    Generic tools recur across unrelated conversations by construction, and the
+    limiting case — a whole conversation whose "sequence" is one call to
+    ``view_text_file`` — says only that the task was trivial. What justifies an
+    SOP is commonality of *purpose*: the same kind of request, on separate
+    occasions, repeatedly completed by the same non-trivial procedure. So the
+    gates hold together, and each excludes a specific way of being wrong:
+
+    * the sequence is **non-trivial** (≥ :data:`MIN_TOOL_SEQUENCE_LEN` steps) —
+      wrapping one generic tool adds an asset and no knowledge;
+    * the supporting episodes **share an intent** — a dominant cluster over
+      their request text (via :mod:`core.evolution.similarity`) covers
+      ≥ :data:`INTENT_COHESION_RATIO` of them; without that the recurrence is a
+      coincidence of tooling, and no commonality means no promotion;
+    * the recurrence spans **separate conversations** — one chat re-running the
+      same procedure is one occasion, not evidence it keeps coming back;
+    * the recurrences **succeed** at ≥ :data:`SKILL_MIN_SUCCESS_RATE`.
+
+    ``episodes`` are the flattened views the pattern was discovered from; the
+    intent gate reads their request text. A caller that cannot supply them gets
+    a refusal, not the benefit of the doubt.
+
     Named for what it reads. This was called ``promote_memory_to_skill`` and
-    carried ``from_layer="memory"``, but all three of its thresholds are about
-    tool sequences and no memory content ever enters the result —
-    ``pattern.memory_refs`` are hashes of whatever happened to be retrieved
-    during the supporting episodes. The name promised a memory→skill chain the
-    code did not have; :func:`promote_procedural_memory_to_skill` is that chain.
+    carried ``from_layer="memory"``, but no memory content ever enters the
+    result — ``pattern.memory_refs`` are hashes of whatever happened to be
+    retrieved during the supporting episodes. The name promised a memory→skill
+    chain the code did not have; :func:`promote_procedural_memory_to_skill` is
+    that chain.
 
     Refuses when orchestration is the better explanation: a stable tool ordering
     can equally mean "the workflow is fixed" rather than "there is a reusable
@@ -220,7 +291,15 @@ def promote_tool_sequence_to_skill(
     """
     if pattern.kind != PATTERN_SUCCESS_SUBSEQUENCE or not pattern.tool_sequence:
         return None
-    if pattern.support < MIN_SUPPORT:
+    support_floor = MIN_SUPPORT if min_support is None else int(min_support)
+    if len(pattern.tool_sequence) < MIN_TOOL_SEQUENCE_LEN:
+        logger.info(
+            "[promotion] skipping %s: %d-step sequence is below the SOP floor",
+            pattern.signature,
+            len(pattern.tool_sequence),
+        )
+        return None
+    if pattern.support < support_floor:
         return None
     if pattern.success_rate < SKILL_MIN_SUCCESS_RATE:
         return None
@@ -231,15 +310,27 @@ def promote_tool_sequence_to_skill(
         )
         return None
 
+    intent = _dominant_shared_intent(pattern, episodes, support_floor=support_floor)
+    if intent is None:
+        logger.info(
+            "[promotion] skipping %s: supporting episodes share no intent — a "
+            "recurring sequence without a recurring request is not an SOP",
+            pattern.signature,
+        )
+        return None
+    covered = [e for e in pattern.episode_ids if e in set(intent.episode_ids)]
+
     existing = (existing_skill_signatures or {}).get(pattern.signature)
     return PromotionProposal(
         from_layer="episode",
         to_layer="skill",
         signature=pattern.signature,
-        support=pattern.support,
+        support=len(covered),
         rationale=(
-            f"{pattern.support} 个 Episode 出现相同工具子序列且成功率 "
-            f"{pattern.success_rate:.0%}，每次仍在重新规划"
+            f"「{intent.representative[:40]}」类请求在 {intent.occasions} 次独立会话中"
+            f"反复出现，每次都以同一 {len(pattern.tool_sequence)} 步工具序列成功完成"
+            f"（{len(covered)} 个 Episode，成功率 {pattern.success_rate:.0%}）——"
+            "同类意图 + 稳定做法，具备沉淀为 SOP 的共性"
         ),
         # Co-retrieved memories are *context*, not sources. They are carried so
         # a reviewer can see what was in view, and deliberately not demoted —
@@ -248,7 +339,9 @@ def promote_tool_sequence_to_skill(
         source_refs=[],
         payload={
             "tool_sequence": pattern.tool_sequence,
-            "episode_ids": pattern.episode_ids[:20],
+            "episode_ids": covered[:20],
+            "intent": intent.representative,
+            "occasions": intent.occasions,
             "co_retrieved_memory_refs": list(pattern.memory_refs),
         },
         # An equivalent skill already exists → patch it instead of adding a twin.

--- a/src/backend/core/evolution/sop_judge.py
+++ b/src/backend/core/evolution/sop_judge.py
@@ -1,0 +1,134 @@
+"""LLM adjudication of sequence→skill proposals — the semantic gate after the rules.
+
+规则门（`promotion.promote_tool_sequence_to_skill` 的四道门）能测出**统计**层面
+的问题：复现不足、单会话刷量、意图不聚、成功率低。但有一类问题规则写不出来，
+只有读懂请求文本和工具语义才能判断：
+
+* 意图簇可能是**巧合归并**——嵌入相似不等于同一类任务；
+* 一个满足全部统计条件的序列可能**不携带区分性知识**——"搜索→整理→写文件"
+  对几乎任何任务都成立，沉淀成 SOP 后对下一次执行没有任何指导价值；
+* 把这套做法固化下来照做，可能有规则看不见的**明显风险**。
+
+所以在规则幸存者上加一道 LLM 裁决。边界与技能编译的「两段式生成」一致
+（见 :mod:`core.evolution.skill_gen`）：模型只回答「这值不值得沉淀为 SOP」
+并给出理由和触发条件，它不能扩权、不能改工具序列、不能凭空造资产——那些
+仍由代码与 IR 不变量把守。裁决结论随候选落库，评审员能看到机器放行的理由。
+
+失败语义与全链路一致：**不确定不等于通过**。模型不可用、输出解析不了，
+都按拒绝处理——但两种状态在结果里可区分（``judge_unavailable``），运维
+才能把"模型挂了"和"提案被否了"分开看。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Sequence
+
+logger = logging.getLogger(__name__)
+
+JUDGE_TIMEOUT_S = 45
+MAX_OBJECTIVE_SAMPLES = 8
+
+_JUDGE_PROMPT = """你在评审一个自动生成的提案：把一段在历史会话中反复出现的工具调用序列，沉淀为一条可复用的技能（SOP）。统计门槛（跨会话复现、意图聚类、成功率）已经通过，不需要你复核数字。你要做的是统计规则做不了的**语义判断**。
+
+# 证据
+
+## 意图簇代表句
+{representative}
+
+## 用户实际提出过的请求（去重抽样，共 {objective_count} 条）
+{objectives}
+
+## 每次都复现的工具调用序列
+{tool_sequence}
+
+## 统计
+出现于 {occasions} 次独立会话、{support} 个执行片段，成功率 {success_rate}。
+
+# 你要判断的三件事
+
+1. **这些请求真的属于同一类任务吗？** 意图聚类可能把措辞相近但目的不同的请求归并到一起。
+2. **这个序列对这类任务携带有区分度的过程知识吗？** 像"先搜索再写文件"这种对任何任务都成立的通用组合，沉淀成 SOP 不提供任何指导价值，不值得占用一个技能位。
+3. **固化后照做是否合理？** 下次遇到同类请求直接按这个序列执行，有没有明显不妥（比如中间步骤依赖当次会话的特殊上下文）。
+
+# 输出
+
+严格输出一个 JSON 对象，不要代码块、不要额外说明：
+
+{{"worthy": true 或 false, "reason": "一句话结论，评审员可读，说明为什么值得/不值得沉淀", "trigger": "worthy 为 true 时：什么样的请求应当触发这条 SOP，一句话；否则留空字符串"}}
+"""
+
+
+@dataclass
+class SopVerdict:
+    """One adjudication, refusal-by-default."""
+
+    worthy: bool
+    reason: str
+    trigger: str = ""
+    # ``True`` when no judgement could be made because the model was
+    # unreachable — an operational state, not a rejection, and the two must
+    # not look alike in the report.
+    judge_unavailable: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "worthy": self.worthy,
+            "reason": self.reason,
+            "trigger": self.trigger,
+            "judge_unavailable": self.judge_unavailable,
+        }
+
+
+async def adjudicate_sequence_sop(
+    *,
+    representative: str,
+    objectives: Sequence[str],
+    tool_sequence: Sequence[str],
+    occasions: int,
+    support: int,
+    success_rate: float,
+) -> SopVerdict:
+    """Ask the model whether a rule-surviving sequence is worth compiling.
+
+    Returns a refusal on every uncertain path: unreachable model, unparseable
+    output, missing fields. Passing on uncertainty is how single-tool noise
+    became skills before the rule gates existed, and the same principle holds
+    at this layer.
+    """
+    from core.memory.extractors._base import parse_json, run_llm_with_prompt
+
+    sampled = [str(o).strip() for o in objectives if str(o).strip()]
+    deduped: list = []
+    for objective in sampled:
+        if objective not in deduped:
+            deduped.append(objective)
+        if len(deduped) >= MAX_OBJECTIVE_SAMPLES:
+            break
+
+    prompt = _JUDGE_PROMPT.format(
+        representative=str(representative).strip() or "（无）",
+        objective_count=len(deduped),
+        objectives="\n".join(f"- {o[:160]}" for o in deduped) or "（无）",
+        tool_sequence=" → ".join(str(t) for t in tool_sequence),
+        occasions=occasions,
+        support=support,
+        success_rate=f"{success_rate:.0%}",
+    )
+    raw = await run_llm_with_prompt(prompt, timeout_s=JUDGE_TIMEOUT_S, max_tokens=400)
+    if raw is None:
+        return SopVerdict(
+            worthy=False, reason="判定模型不可用，按拒绝处理", judge_unavailable=True
+        )
+
+    data = parse_json(raw, require_key="worthy")
+    if not isinstance(data, dict):
+        logger.info("[sop-judge] unparseable verdict: %r", raw[:200])
+        return SopVerdict(worthy=False, reason="判定输出无法解析，按拒绝处理")
+
+    return SopVerdict(
+        worthy=bool(data.get("worthy")),
+        reason=str(data.get("reason") or "").strip()[:200],
+        trigger=str(data.get("trigger") or "").strip()[:200],
+    )

--- a/src/backend/tests/evolution/test_promotion_chain.py
+++ b/src/backend/tests/evolution/test_promotion_chain.py
@@ -48,25 +48,44 @@ def test_patterns_carry_the_memories_they_came_from():
     assert len(success.memory_refs) == 6
 
 
-# ── Memory → Skill ───────────────────────────────────────────────────────────
+# ── Episode → Skill：SOP 门 ───────────────────────────────────────────────────
 
 
-def _success_pattern(support=27, rate=0.9):
+def _success_pattern(support=27, rate=0.9, tools=("search", "verify", "chart", "export")):
     return P.Pattern(
         kind=P.PATTERN_SUCCESS_SUBSEQUENCE,
-        signature="search→verify→chart→export",
+        signature="→".join(tools),
         support=support,
         success_rate=rate,
-        tool_sequence=["search", "verify", "chart", "export"],
+        tool_sequence=list(tools),
         memory_refs=[f"mref-{i}" for i in range(support)],
         episode_ids=[f"ep-{i}" for i in range(support)],
     )
 
 
+def _supporting_episodes(
+    support=27, *, objective="帮我生成一份本周的销售数据周报", chats=None
+):
+    """The views behind the pattern: same kind of request, separate conversations."""
+    return [
+        {
+            "episode_id": f"ep-{i}",
+            "chat_id": chats[i] if chats else f"chat-{i}",
+            "verdict": "success",
+            "tool_sequence": ["search", "verify", "chart", "export"],
+            "objective": objective,
+        }
+        for i in range(support)
+    ]
+
+
 def test_recurring_pattern_is_compiled_into_a_skill_proposal():
-    """The 27-weekly-reports case: same tools every time, re-planned every time."""
+    """The 27-weekly-reports case: same request, same tools, separate chats."""
     proposal = P.promote_tool_sequence_to_skill(
-        _success_pattern(), skill_credit=0.81, workflow_credit=0.46
+        _success_pattern(),
+        episodes=_supporting_episodes(27),
+        skill_credit=0.81,
+        workflow_credit=0.46,
     )
     assert proposal is not None
     # Named for what it reads. Co-retrieved memories are context, not sources:
@@ -76,11 +95,18 @@ def test_recurring_pattern_is_compiled_into_a_skill_proposal():
     assert proposal.support == 27
     assert proposal.source_refs == []
     assert len(proposal.payload["co_retrieved_memory_refs"]) == 27
+    # The rationale states the shared intent — the thing that makes it an SOP —
+    # not an unmeasured claim about re-planning.
+    assert proposal.payload["intent"]
+    assert "重新规划" not in proposal.rationale
 
 
 def test_promotion_is_refused_when_orchestration_explains_it_better():
     proposal = P.promote_tool_sequence_to_skill(
-        _success_pattern(), skill_credit=0.3, workflow_credit=0.8
+        _success_pattern(),
+        episodes=_supporting_episodes(27),
+        skill_credit=0.3,
+        workflow_credit=0.8,
     )
     # A stable ordering can mean "the workflow is fixed", not "a skill exists".
     # Promoting anyway creates a skill with no independent content.
@@ -89,23 +115,110 @@ def test_promotion_is_refused_when_orchestration_explains_it_better():
 
 def test_low_success_rate_is_not_promoted():
     assert (
-        P.promote_tool_sequence_to_skill(_success_pattern(rate=0.4), skill_credit=0.9) is None
+        P.promote_tool_sequence_to_skill(
+            _success_pattern(rate=0.4), episodes=_supporting_episodes(27), skill_credit=0.9
+        )
+        is None
     )
 
 
 def test_insufficient_support_is_not_promoted():
     assert (
-        P.promote_tool_sequence_to_skill(_success_pattern(support=2), skill_credit=0.9) is None
+        P.promote_tool_sequence_to_skill(
+            _success_pattern(support=2), episodes=_supporting_episodes(2), skill_credit=0.9
+        )
+        is None
     )
 
 
 def test_existing_equivalent_skill_becomes_a_patch_not_a_twin():
     proposal = P.promote_tool_sequence_to_skill(
         _success_pattern(),
+        episodes=_supporting_episodes(27),
         skill_credit=0.9,
         existing_skill_signatures={"search→verify→chart→export": "skill-weekly-report"},
     )
     assert proposal.patch_target == "skill-weekly-report"
+
+
+def test_a_trivial_sequence_is_never_promoted():
+    """整轮对话只调一次 view_text_file 也构成"相同序列"——但那说明任务简单，
+    不说明存在可复用的过程知识。包装单个通用工具是纯噪声。"""
+    for tools in (("view_text_file",), ("call_subagent", "view_text_file")):
+        pattern = _success_pattern(support=9, rate=1.0, tools=tools)
+        assert (
+            P.promote_tool_sequence_to_skill(
+                pattern, episodes=_supporting_episodes(9), skill_credit=0.9
+            )
+            is None
+        )
+
+
+def test_unrelated_conversations_are_not_an_sop():
+    """Same tool sequence across unrelated requests is a coincidence of tooling."""
+    objectives = [
+        "帮我生成一份本周的销售数据周报",
+        "把这份英文合同翻译成中文",
+        "查一下明天上海到北京的航班",
+        "写一首关于秋天的短诗",
+        "统计仓库里还剩多少台服务器",
+        "给新同事拟一封入职欢迎邮件",
+    ]
+    episodes = [
+        {
+            "episode_id": f"ep-{i}",
+            "chat_id": f"chat-{i}",
+            "verdict": "success",
+            "tool_sequence": ["search", "verify", "chart", "export"],
+            "objective": objectives[i],
+        }
+        for i in range(6)
+    ]
+    assert (
+        P.promote_tool_sequence_to_skill(
+            _success_pattern(support=6), episodes=episodes, skill_credit=0.9
+        )
+        is None
+    )
+
+
+def test_recurrence_within_one_conversation_is_one_occasion():
+    """一场会话里反复跑同一套流程只算一次场合，不构成"这件事总在发生"。"""
+    episodes = _supporting_episodes(6, chats=["chat-same"] * 6)
+    assert (
+        P.promote_tool_sequence_to_skill(
+            _success_pattern(support=6), episodes=episodes, skill_credit=0.9
+        )
+        is None
+    )
+
+
+def test_no_request_text_means_no_commonality_and_no_promotion():
+    """Commonality that cannot be established is not commonality."""
+    episodes = _supporting_episodes(6, objective="")
+    assert (
+        P.promote_tool_sequence_to_skill(
+            _success_pattern(support=6), episodes=episodes, skill_credit=0.9
+        )
+        is None
+    )
+
+
+def test_promotion_without_supporting_views_is_refused():
+    """A caller that cannot show the episodes gets a refusal, not the benefit
+    of the doubt."""
+    assert P.promote_tool_sequence_to_skill(_success_pattern(), skill_credit=0.9) is None
+
+
+def test_personal_support_floor_is_honoured_when_passed():
+    """个人路径发现阶段用门槛 3；晋升阶段必须沿用同一门槛，而不是全局的 5。"""
+    proposal = P.promote_tool_sequence_to_skill(
+        _success_pattern(support=3),
+        episodes=_supporting_episodes(3),
+        min_support=3,
+        skill_credit=0.9,
+    )
+    assert proposal is not None and proposal.support == 3
 
 
 def test_procedural_memories_are_what_becomes_a_skill():

--- a/src/backend/tests/evolution/test_sop_judge.py
+++ b/src/backend/tests/evolution/test_sop_judge.py
@@ -1,0 +1,83 @@
+"""The semantic gate after the rule gates: LLM adjudication of SOP proposals.
+
+The rules can measure recurrence, cohesion and success; they cannot tell a
+distinctive procedure from a generic tool combination, or a real intent cluster
+from a coincidental merge. These tests pin the adjudicator's contract — and,
+more importantly, its refusal semantics: every uncertain path refuses.
+"""
+
+import asyncio
+
+import core.memory.extractors._base as base
+from core.evolution.sop_judge import SopVerdict, adjudicate_sequence_sop
+
+
+def _judge(monkeypatch, reply):
+    async def fake_llm(prompt, timeout_s, *, max_tokens=800):
+        return reply
+
+    monkeypatch.setattr(base, "run_llm_with_prompt", fake_llm)
+    return asyncio.run(
+        adjudicate_sequence_sop(
+            representative="帮我生成本周销售周报",
+            objectives=["帮我生成本周销售周报", "出一版这周的销售周报"],
+            tool_sequence=["search", "verify", "chart", "export"],
+            occasions=6,
+            support=6,
+            success_rate=0.9,
+        )
+    )
+
+
+def test_a_worthy_verdict_passes_with_reason_and_trigger(monkeypatch):
+    verdict = _judge(
+        monkeypatch,
+        '{"worthy": true, "reason": "同类周报请求，序列步骤有区分度", '
+        '"trigger": "用户要求生成周期性销售报告时"}',
+    )
+    assert verdict.worthy is True
+    assert verdict.reason and verdict.trigger
+    assert verdict.judge_unavailable is False
+
+
+def test_a_generic_combination_is_refused(monkeypatch):
+    verdict = _judge(
+        monkeypatch,
+        '{"worthy": false, "reason": "搜索后写文件对任何任务都成立，不携带过程知识", '
+        '"trigger": ""}',
+    )
+    assert verdict.worthy is False
+    assert "不携带过程知识" in verdict.reason
+
+
+def test_an_unreachable_model_refuses_but_is_distinguishable(monkeypatch):
+    """"The model was down" and "the proposal was rejected" are different
+    operational states and must not look alike in the report."""
+    verdict = _judge(monkeypatch, None)
+    assert verdict.worthy is False
+    assert verdict.judge_unavailable is True
+
+
+def test_unparseable_output_refuses_rather_than_passes(monkeypatch):
+    verdict = _judge(monkeypatch, "我觉得这个提案还不错，可以通过。")
+    assert verdict.worthy is False
+    assert verdict.judge_unavailable is False
+
+
+def test_reasoning_noise_before_the_answer_is_tolerated(monkeypatch):
+    """A reasoning model narrates before it answers; the last valid object wins."""
+    verdict = _judge(
+        monkeypatch,
+        '先看第一个问题……这些请求都是周报。{"worthy": true, "reason": "ok", "trigger": "周报请求"}',
+    )
+    assert verdict.worthy is True
+
+
+def test_verdict_serialises_for_the_credit_record():
+    verdict = SopVerdict(worthy=True, reason="r", trigger="t")
+    assert verdict.to_dict() == {
+        "worthy": True,
+        "reason": "r",
+        "trigger": "t",
+        "judge_unavailable": False,
+    }


### PR DESCRIPTION
## Problem

Personal evolution promoted any recurring tool sequence into a skill candidate. Because episodes are grouped by exact sequence equality with no further evidence, the most common outcome was noise: a whole conversation whose "sequence" is a single `view_text_file` or `call_subagent` call qualified, and unrelated conversations that merely happened to call the same tools were counted as recurrence. The candidate hypothesis also asserted "re-planned every time", which nothing ever measured.

## Change

Recurrence alone no longer justifies promotion — the pattern must show **SOP commonality**:

1. **Non-trivial sequence** — fewer than 3 steps is refused (`MIN_TOOL_SEQUENCE_LEN`); wrapping one generic tool adds an asset and no knowledge.
2. **Shared intent** — supporting episodes are clustered on request text (`similarity.cluster_intents`); the dominant cluster must cover >=60% of them. Missing request text refuses: uncertainty is not a pass.
3. **Cross-conversation recurrence** — occasions are deduped by `chat_id`; one chat re-running a procedure is one occasion.
4. **LLM semantic adjudication** (new `sop_judge`) on rule survivors: is the intent cluster a coincidental merge, does the sequence carry distinctive procedural knowledge, is it safe to follow verbatim. Strict JSON validated by code; unreachable model or unparseable output refuses, with `sop_judge_unavailable` kept distinguishable from `sop_judge_refused`. The verdict is stored with the candidate's credit decision so reviewers can see why the machine let it through.

Success patterns now go through `aggregate_finding` instead of fabricating `failed` verdicts to steer the failure attributor, and the candidate hypothesis states measured evidence (intent representative, distinct conversations, sequence length, success rate). Also fixes a latent bug where the personal path discovered patterns at support 3 but promotion silently rejected below the global floor of 5.

## Tests

- `test_promotion_chain.py` rewritten for the new contract, plus regression cases: single-tool sequences, unrelated conversations, single-conversation recurrence, missing request text, missing evidence views are all refused.
- New `test_sop_judge.py` covering verdict parsing, refusal-by-default on unavailable/unparseable output, and reasoning-noise tolerance.
- Full evolution suite passes (569 tests).