### PR TITLE
fix(orchestration): harden long-running task guardrails

### DIFF
--- a/src/backend/core/llm/agent_factory.py
+++ b/src/backend/core/llm/agent_factory.py
@@ -1691,14 +1691,13 @@ async def create_agent_executor(
     else:
         # Main-agent env override for long-running tasks. Wins over the profile
         # value: the profile validation range tops out at 80 turns, far below
-        # what e.g. a multi-hour report-generation run needs. Read per-call so
-        # ops can adjust without code changes (container restart still needed).
-        _env_iters = (os.getenv("CHAT_MAIN_MAX_ITERS") or "").strip()
-        if _env_iters:
-            try:
-                _max_iters = max(3, int(_env_iters))
-            except ValueError:
-                _log.warning("[factory] 非法 CHAT_MAIN_MAX_ITERS=%r，忽略", _env_iters)
+        # what e.g. a multi-hour report-generation run needs (container restart
+        # required to change, like all env config).
+        from core.config.settings import _env, _int
+
+        _env_iters = _int(_env("CHAT_MAIN_MAX_ITERS"), 0)
+        if _env_iters > 0:
+            _max_iters = max(3, _env_iters)
 
     # ── Create the Agent (AgentScope 2.0) ──
     # Note: long_term_memory is not passed — mem0 is fully stripped from the SSE

--- a/src/backend/core/llm/middlewares.py
+++ b/src/backend/core/llm/middlewares.py
@@ -19,7 +19,6 @@ import asyncio
 import base64
 import json
 import logging
-import os
 import time
 from contextvars import ContextVar
 from pathlib import Path
@@ -635,26 +634,33 @@ class IterBudgetReminderMiddleware(MiddlewareBase):
     def __init__(self, *, threshold: int = 2) -> None:
         self._threshold = threshold
         self._last_key: tuple | None = None
+        # Env is immutable for the process lifetime — parse the kill-switch once
+        # per middleware (one per agent build), not on every reasoning round.
+        from core.config.settings import _bool, _env
+
+        self._force_text = _bool(_env("CHAT_FINAL_ITER_FORCE_TEXT", "true"))
 
     async def on_reasoning(self, agent: Agent, input_kwargs: dict, next_handler):
+        max_iters, cur_iter, remaining = self._budget(agent)
         try:
-            self._maybe_remind(agent)
+            self._maybe_remind(agent, max_iters, cur_iter, remaining)
         except Exception as exc:  # noqa: BLE001
             logger.warning("[iter_budget] failed: %s", exc)
         try:
-            input_kwargs = self._maybe_force_text(agent, input_kwargs)
+            input_kwargs = self._maybe_force_text(input_kwargs, max_iters, remaining)
         except Exception as exc:  # noqa: BLE001
             logger.warning("[iter_budget] force-text failed: %s", exc)
         async for evt in next_handler(**input_kwargs):
             yield evt
 
-    def _remaining(self, agent: Agent) -> tuple[int, int]:
-        """Return (max_iters, remaining-including-current-round)."""
+    @staticmethod
+    def _budget(agent: Agent) -> tuple[int, int, int]:
+        """Return (max_iters, cur_iter, remaining-including-current-round)."""
         max_iters = int(getattr(agent.react_config, "max_iters", 0) or 0)
         cur_iter = int(getattr(agent.state, "cur_iter", 0) or 0)
-        return max_iters, max_iters - cur_iter
+        return max_iters, cur_iter, max_iters - cur_iter
 
-    def _maybe_force_text(self, agent: Agent, input_kwargs: dict) -> dict:
+    def _maybe_force_text(self, input_kwargs: dict, max_iters: int, remaining: int) -> dict:
         """Final round: force tool_choice="none" so the model can only produce text.
 
         The reminder alone is advisory — a model that still emits a tool call in
@@ -664,12 +670,7 @@ class IterBudgetReminderMiddleware(MiddlewareBase):
         micro budgets (same guard as the reminder) and when a caller already
         pinned an explicit tool_choice. Kill-switch: CHAT_FINAL_ITER_FORCE_TEXT=false.
         """
-        if (os.getenv("CHAT_FINAL_ITER_FORCE_TEXT") or "true").strip().lower() in (
-            "0", "false", "off", "no",
-        ):
-            return input_kwargs
-        max_iters, remaining = self._remaining(agent)
-        if max_iters <= self._threshold + 1 or remaining > 1:
+        if remaining > 1 or max_iters <= self._threshold + 1 or not self._force_text:
             return input_kwargs
         if input_kwargs.get("tool_choice") is not None:
             return input_kwargs
@@ -681,11 +682,9 @@ class IterBudgetReminderMiddleware(MiddlewareBase):
         )
         return {**input_kwargs, "tool_choice": ToolChoice(mode="none")}
 
-    def _maybe_remind(self, agent: Agent) -> None:
-        max_iters, remaining = self._remaining(agent)
+    def _maybe_remind(self, agent: Agent, max_iters: int, cur_iter: int, remaining: int) -> None:
         if max_iters <= self._threshold + 1:
             return
-        cur_iter = int(getattr(agent.state, "cur_iter", 0) or 0)
         if remaining > self._threshold:
             return
         key = (getattr(agent.state, "reply_id", "") or "", cur_iter)

--- a/src/backend/core/sandbox/keepalive.py
+++ b/src/backend/core/sandbox/keepalive.py
@@ -1,0 +1,44 @@
+"""Sandbox session keepalive for long-running workflows.
+
+A worker/reviewer agent can stream model output (thinking, huge tool-call
+arguments) for well past the idle-reap threshold without issuing a single
+sandbox call; the idle reaper then destroys the session mid-run and the
+workspace is wiped (observed live: "reaped idle session=loop-... idle
+643s > 600s" — no snapshot either, since idle < snapshot threshold). Callers
+start a keepalive task for the phase during which the session must stay
+alive and cancel it in their ``finally``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Well under both the idle-reap threshold (600s) and the server-side TTL
+# renew window (1800s), with margin for a delayed tick.
+_KEEPALIVE_INTERVAL_S = 240.0
+
+
+def start_session_keepalive(session_id: str) -> asyncio.Task:
+    """Spawn a task that periodically marks ``session_id`` as active.
+
+    The provider and its ``touch_session`` are resolved once; providers whose
+    ``touch_session`` is a no-op (no such session yet) are touched again on the
+    next tick — the session may be created later in the phase.
+    Cancel the returned task when the phase ends.
+    """
+
+    async def _run() -> None:
+        from core.sandbox import get_sandbox_provider
+
+        touch = get_sandbox_provider().touch_session
+        while True:
+            await asyncio.sleep(_KEEPALIVE_INTERVAL_S)
+            try:
+                await touch(session_id)
+            except Exception as exc:  # noqa: BLE001 - keepalive must never kill the caller
+                logger.debug("session keepalive touch(%s) failed: %s", session_id, exc)
+
+    return asyncio.create_task(_run())

--- a/src/backend/core/sandbox/protocol.py
+++ b/src/backend/core/sandbox/protocol.py
@@ -232,6 +232,18 @@ class SandboxProvider(Protocol):
         """
         ...
 
+    async def touch_session(self, session_id: str) -> bool:
+        """Mark a live session as active without executing anything in it.
+
+        Long-running workflows call this on a timer (see
+        ``core/sandbox/keepalive.py``) so the idle reaper does not destroy
+        their session during long model-streaming phases with no sandbox
+        calls. Returns False when the session does not exist (yet); providers
+        with no session lifecycle implement it as a no-op returning False.
+        Never raises.
+        """
+        ...
+
     async def health(self) -> bool: ...
 
     # ── Read-only admin interface (for the security admin console; all pure

--- a/src/backend/core/sandbox/script_runner_provider.py
+++ b/src/backend/core/sandbox/script_runner_provider.py
@@ -175,6 +175,11 @@ class ScriptRunnerProvider:
         """No-op: the sidecar's ``/workspace`` is globally shared; there is no per-session sandbox to destroy."""
         del session_id
 
+    async def touch_session(self, session_id: str) -> bool:
+        """No-op: no per-session lifecycle, nothing to keep alive."""
+        del session_id
+        return False
+
     async def current_sandbox_id(self, session_id: Optional[str]) -> Optional[str]:
         """The script_runner sidecar's ``/workspace`` is global to the container
         and persists for the container's lifetime. There is no "per-session

--- a/src/backend/orchestration/autonomous_loop.py
+++ b/src/backend/orchestration/autonomous_loop.py
@@ -181,15 +181,39 @@ def _new_ledger(objective: str, requirements: List[Dict[str, Any]]) -> Dict[str,
     return {"objective": objective, "iteration": 0, "requirements": requirements}
 
 
-async def _read_ledger(*, session_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+async def _read_ledger(
+    *, session_id: str, user_id: str, loop_id: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Read the sandbox ledger; reject one stamped by a different loop.
+
+    Sandboxes are pool-recycled across sessions of the same user (idle
+    sessions park their sandbox for reuse), so a brand-new loop can inherit
+    the previous loop's /workspace — including its feature_list.json.
+    Observed live: a fresh loop "resumed" from a dead loop's checkpoint with
+    a requirement already attempt-blocked. The loop_id stamp (written by
+    _write_ledger) makes foreign ledgers invisible; unstamped legacy ledgers
+    are still accepted.
+    """
     raw = await _read_file(_LEDGER_PATH, session_id=session_id, user_id=user_id)
     if not raw:
         return None
     try:
         obj = json.loads(raw)
-        return obj if isinstance(obj, dict) and obj.get("requirements") else None
     except (json.JSONDecodeError, ValueError):
         return None
+    if not (isinstance(obj, dict) and obj.get("requirements")):
+        return None
+    stamp = obj.get("loop_id")
+    if loop_id and stamp != loop_id:
+        # Unstamped counts as foreign too: a recycled sandbox carrying a
+        # pre-stamp ledger is exactly the contamination case. The DB mirror
+        # (keyed by loop_id) is the compatibility path for legacy resumes.
+        logger.info(
+            "[loop %s] ignoring foreign sandbox ledger (stamped %s — recycled sandbox)",
+            loop_id, stamp or "<none>",
+        )
+        return None
+    return obj
 
 
 async def _write_ledger(ledger: Dict[str, Any], *, session_id: str, user_id: str) -> None:
@@ -291,6 +315,13 @@ async def _run_worker_iteration(
 
     runtime = ontology_runtime or {"enabled": False, "packs": [], "review_level": "none"}
     hold_output = requires_output_review(runtime)
+
+    # Keep the sandbox session alive for the whole worker phase — see
+    # core/sandbox/keepalive.py for why (idle reaper vs long model-streaming
+    # phases with no sandbox calls).
+    from core.sandbox.keepalive import start_session_keepalive
+
+    _keepalive_task = start_session_keepalive(session_id)
     try:
         async for et, payload in sa.stream(
             [{"role": "user", "content": prompt}],
@@ -372,18 +403,10 @@ async def _run_worker_iteration(
             elif et == "tool_pending":
                 if emit:
                     await emit({"type": "tool_pending", **(payload or {})})
-            elif et == "model_progress":
-                # Liveness during long tool-call-arg generation: written to the
-                # Redis stream so the stale-run reaper sees a live run (its
-                # "quiet" check reads the last stream entry), but never
-                # forwarded to clients — follow_run_as_sse skips this type.
-                # Deliberately NOT forwarding "heartbeat" here: those fire even
-                # when the model is truly silent and would defeat the reaper.
-                if emit:
-                    await emit({"type": "model_progress"})
             elif et == "error":
                 logger.warning("[loop] worker stream error: %s", payload)
     finally:
+        _keepalive_task.cancel()
         usage = sa.get_usage()
         await close_clients(clients)
     if hold_output and text:
@@ -576,6 +599,7 @@ async def run_autonomous_loop(
 
     async def _persist_ledger(led: Dict[str, Any]) -> None:
         """Flush the ledger: dual-write to the sandbox (working cache) + DB mirror (reliable source of truth for resume)."""
+        led["loop_id"] = loop_id  # stamp: _read_ledger rejects foreign ledgers on recycled sandboxes
         await _write_ledger(led, session_id=session, user_id=user_id)
         if save_ledger:
             try:
@@ -598,9 +622,10 @@ async def run_autonomous_loop(
             db_ledger = load_ledger()
         except Exception as exc:  # noqa: BLE001
             logger.warning("[loop %s] DB ledger load failed: %s", loop_id, exc)
-    sbx_ledger = await _read_ledger(session_id=session, user_id=user_id)
+    sbx_ledger = await _read_ledger(session_id=session, user_id=user_id, loop_id=loop_id)
     ledger = _pick_fresher_ledger(db_ledger, sbx_ledger)
     if ledger is not None:
+        ledger["loop_id"] = loop_id  # stamp before any backfill (DB mirrors from older builds lack it)
         seq = int(ledger.get("iteration", 0) or 0)
         # Sandbox ledger missing/stale (sandbox wiped after restart or snapshot not flushed) →
         # backfill the authoritative ledger into the sandbox so the worker can read feature_list.json.

--- a/src/backend/orchestration/chat_run_executor.py
+++ b/src/backend/orchestration/chat_run_executor.py
@@ -477,15 +477,12 @@ async def _run_workflow(
             elif chunk_type == "tool_result":
                 await _emit(build_tool_result_event(chunk, chat_id, tool_calls_log))
 
-            elif chunk_type == "heartbeat":
-                # Not written to the stream — the SSE layer's own keep-alive cadence is handled by Nginx/StreamingResponse
-                continue
-
-            elif chunk_type == "model_progress":
-                # The model is still streaming (e.g. long tool-call-argument
-                # generation) even though nothing maps to an SSE event. Not
-                # written to the wire; merely receiving it resets the
-                # inactivity watchdog (is_activity excludes only "heartbeat").
+            elif chunk_type in ("heartbeat", "model_progress"):
+                # Neither is written to the stream. heartbeat = transport
+                # keep-alive (excluded from is_activity); model_progress = the
+                # model is still streaming (e.g. long tool-call-arg generation)
+                # with nothing mapping to an SSE event — merely receiving it
+                # resets the inactivity watchdog.
                 continue
 
             elif chunk_type == "tool_pending":
@@ -917,9 +914,10 @@ def _decode_entry(fields: Any) -> Optional[Dict[str, Any]]:
     """Decode the fields of a single Redis Stream entry into an SSE event dict.
 
     Returns None for undecodable entries and for internal liveness markers
-    (``model_progress``): those exist only so the stale-run reaper sees a live
-    stream (it reads entry timestamps, not payloads) and must never reach
-    clients — the frontend treats unknown event types as "pending ended".
+    (``model_progress``) — nothing writes them to streams anymore (the reaper
+    now trusts in-process task liveness), but entries from older builds may
+    survive within the stream TTL and must never reach clients (the frontend
+    treats unknown event types as "pending ended").
     Only used by follow_run_as_sse's replay/tail paths.
     """
     if not fields:
@@ -2052,6 +2050,16 @@ async def reap_stale_runs() -> int:
         hard_expired = began_at is not None and began_at < hard_cutoff
 
         if not hard_expired:
+            # A run whose asyncio task is alive in THIS process is never a
+            # zombie — the in-process inactivity watchdog owns hang detection
+            # for it. The stream-quiet check below is only for orphans whose
+            # worker vanished (process restart/crash). Without this guard, a
+            # healthy long run streaming huge tool-call args (which map to no
+            # stream events) past 30min would be reaped as "quiet".
+            task = _active_runs.get(rid)
+            if task is not None and not task.done():
+                logger.info("chat_run_stale_skip_inprocess", run_id=rid)
+                continue
             last_ms = await _stream_last_write_ms(rid)
             if last_ms is not None and (now_ms - last_ms) < _STALE_QUIET_SEC * 1000:
                 # The stream is still producing: this is a long task, not a zombie — skip this round

--- a/src/backend/orchestration/streaming.py
+++ b/src/backend/orchestration/streaming.py
@@ -240,9 +240,10 @@ class StreamingAgent:
         _stream_start = time.monotonic()
         _first_event_logged = False
         _poll_interval = 3.0
-        # Last time anything was yielded downstream — basis for the throttled
-        # model_progress liveness signal when upstream events map to nothing.
-        _last_out_ts = time.monotonic()
+        # Last model_progress emission — throttles the liveness signal emitted
+        # when upstream events map to nothing. Only the swallowed-event branch
+        # reads/updates the clock, keeping the mapped hot path free of it.
+        _last_progress_ts = _stream_start
 
         try:
             while True:
@@ -283,17 +284,15 @@ class StreamingAgent:
                         _first_event_logged = True
                     _mapped_any = True
                     yield out
-                if _mapped_any:
-                    _last_out_ts = time.monotonic()
-                else:
+                if not _mapped_any:
                     # The model is alive (an upstream event just arrived) but
                     # nothing was forwarded — typical of long tool-call-arg /
                     # suppressed-thinking streaming. Emit a throttled liveness
                     # signal so the inactivity watchdog doesn't misjudge a
                     # healthy run as hung.
                     _now = time.monotonic()
-                    if _now - _last_out_ts >= _MODEL_PROGRESS_MIN_INTERVAL_S:
-                        _last_out_ts = _now
+                    if _now - _last_progress_ts >= _MODEL_PROGRESS_MIN_INTERVAL_S:
+                        _last_progress_ts = _now
                         yield ("model_progress", None)
         except Exception as e:  # noqa: BLE001
             yield ("error", e)

--- a/src/backend/orchestration/subagents/loop_reviewer.py
+++ b/src/backend/orchestration/subagents/loop_reviewer.py
@@ -44,8 +44,6 @@ logger = get_logger(__name__)
 EmitFn = Callable[[Dict[str, Any]], Awaitable[None]]
 
 _VALID_VERDICTS = (DONE, CONTINUE, OFF_TRACK, NEED_HUMAN)
-# The reviewer itself needs to run a few tool steps (ls/read/grep) to gather evidence; give it a small but sufficient step cap.
-_REVIEWER_MAX_ITERS = 12
 
 
 def _build_review_prompt(
@@ -61,13 +59,17 @@ def _build_review_prompt(
         "你是一个自主循环的**独立产出评审员**。你不是执行者，是裁判。",
         "你和刚才干活的执行 agent 是**两个人**——你**绝不能**采信它自报的"
         "「我已完成 / 我加上了 / 我优化了」之类的话。你的唯一职责是：**亲自打开当前"
-        "项目里产出的真实文件**（用 ls / view_text_file / grep / glob / bash 等只读手段），"
+        "项目里产出的真实文件**（用你可用的只读工具：ls / read / grep / glob 等），"
         "核对下面这条需求到底有没有真正落地。",
         "\n## ⛔ 只读约束\n你**禁止**创建、修改、删除任何文件，也不要发布/构建改动。"
         "只允许读取、检索、运行**只读**命令来取证。",
         f"\n## 总目标\n{objective}",
-        f"\n## 本轮要核验的需求\n{requirement_desc}",
-        f"\n## 验收标准（逐条核对）\n{criteria}",
+        f"\n## 本轮要核验的需求（**你的判定单位**）\n{requirement_desc}",
+        f"\n## 全局验收标准（整个任务的最终标准，仅作参照）\n{criteria}\n"
+        "⚠️ 判定纪律：done/continue 只针对**本轮需求**——本轮需求描述的产出有确凿证据即"
+        "判 done。全局标准里未被本轮需求覆盖的项（通常由其他需求承载）**不构成**本轮"
+        "continue 的理由；只有当本轮需求本身就是最终交付（或明确引用了某条全局标准）时，"
+        "才逐条核对对应标准。",
     ]
     if worker_summary.strip():
         parts.append(
@@ -81,8 +83,13 @@ def _build_review_prompt(
         "2. 打开与本需求直接相关的文件，读它的真实内容。\n"
         "3. 对照验收标准逐条判断：内容里是否**确实**出现了需求要求的东西"
         "（如某个功能模块、某段文案、某种交互/布局），还是只是被声称做了。\n"
-        "4. 如需求涉及「能跑/能构建/能通过」，用只读命令实际验证（如 grep 关键实现、"
-        "查语法、必要时构建到临时目录）。"
+        "4. 如需求涉及「能跑/能构建/能通过」，在可用工具范围内用只读手段验证"
+        "（如 grep 关键实现、通读关键文件）。\n"
+        "5. 如验收标准涉及「已注册为可下载 artifact / sandbox_get_artifact /"
+        " pin_to_workspace 交付」：注册状态存在平台注册表里，沙箱文件系统查**不**到——"
+        "从执行 agent 自述中找到它报告的 file_id（找线索不算采信），用 `read_artifact`"
+        " 工具读取该 file_id：**能成功读到内容即证明已注册**（该工具直接读平台注册表），"
+        "顺带核验内容是否符合要求；读取失败或没有任何 file_id 线索才判未注册。"
     )
     if second_pass:
         parts.append(
@@ -95,8 +102,9 @@ def _build_review_prompt(
         '"criteria_hit": ["已确凿满足的验收标准原文", ...], '
         '"evidence": "你**亲自读到**的文件路径 + 关键内容片段/命令输出，作为判定依据", '
         '"feedback": "若未完成：具体还差什么、下一轮该改哪个文件的什么；若完成：一句话结论"}\n'
-        "判定纪律：**只有当每一条验收标准都能被你引用到的真实文件证据支撑时**才输出 done；"
+        "判定纪律：**本轮需求描述的每一项产出都能被你引用到的真实证据支撑时**才输出 done；"
         "证据不足、找不到对应产出、或只有自报没有实物，一律 continue（绝不放水）。"
+        "criteria_hit 只列本轮证据顺带确凿满足的全局标准，列不满不影响 done。"
     )
     return "\n".join(parts)
 
@@ -173,7 +181,21 @@ async def review_requirement(
         second_pass=second_pass,
     )
     try:
+        # Reuse the platform-registered builtin reviewer (builtin.reviewer) —
+        # same construction path as call_subagent: its DB-managed system prompt
+        # (Config console → prompt management → subagents/reviewer), read-only
+        # capability policy and max_iters govern here too, instead of a second
+        # hand-rolled reviewer definition. The spec lives in a static module
+        # tuple, so it is always present; a prompt-load failure raises into the
+        # except below (spawn failed → conservative continue).
+        from core.llm.builtin_subagents import (
+            build_builtin_runtime_profile,
+            get_builtin_subagent,
+        )
+
+        _spec = get_builtin_subagent("builtin.reviewer")
         agent, clients = await create_agent_executor(
+            user_agent=build_builtin_runtime_profile(_spec, None),
             current_user_id=user_id,
             model_name=model_name,
             sandbox_session_id=session_id,   # key: same sandbox as the worker → reads real output
@@ -181,8 +203,8 @@ async def review_requirement(
             chat_id=chat_id,
             enabled_skill_ids=[],             # pure verification, load no business skills
             isolated=True,                    # independent MCP client, avoid cross-task cancel-scope
-            max_iters=_REVIEWER_MAX_ITERS,
-            read_only=True,                   # read-only: register no file-modifying tools (the judge isn't a player)
+            read_only=_spec.read_only,
+            allow_bash=_spec.allow_bash,
         )
     except Exception as exc:  # noqa: BLE001 - a reviewer agent that won't start must not drag down the loop
         logger.warning("[loop-review] spawn reviewer failed: %s", exc)
@@ -192,6 +214,11 @@ async def review_requirement(
 
     sa = StreamingAgent(agent, clients)
     text = ""
+    # The review phase can also stream for minutes with no sandbox calls —
+    # same keepalive as the worker phase so the shared session survives it.
+    from core.sandbox.keepalive import start_session_keepalive
+
+    _keepalive_task = start_session_keepalive(session_id)
     try:
         # The reviewer's stream is **not forwarded** to the user bubble — it's an internal judge, only its final text verdict is collected.
         # subagent_scope attributes the reviewer's internal read/grep/... tool calls to this sub-agent log (auditable).
@@ -210,6 +237,7 @@ async def review_requirement(
     except Exception as exc:  # noqa: BLE001
         logger.warning("[loop-review] reviewer run failed: %s", exc)
     finally:
+        _keepalive_task.cancel()
         await close_clients(clients)
 
     async def _return(result: Dict[str, Any], *, log_status: str = "success") -> Dict[str, Any]:

--- a/src/backend/orchestration/workflow.py
+++ b/src/backend/orchestration/workflow.py
@@ -1647,14 +1647,12 @@ async def _astream_subagent_direct(
                         "citations": cit_dicts,
                     }
 
-                elif event_type == "heartbeat":
-                    yield {"type": "heartbeat"}
-
-                elif event_type == "model_progress":
-                    # Liveness signal from StreamingAgent: the model is still
-                    # streaming (tool-call args etc.) though nothing maps to an
-                    # SSE event. Forwarded so the run watchdog counts activity.
-                    yield {"type": "model_progress"}
+                elif event_type in ("heartbeat", "model_progress"):
+                    # heartbeat = transport keep-alive; model_progress = the
+                    # model is still streaming (tool-call args etc.) though
+                    # nothing maps to an SSE event — forwarded so the run
+                    # watchdog counts activity (it excludes only heartbeat).
+                    yield {"type": event_type}
 
                 elif event_type == "tool_pending":
                     yield {"type": "tool_pending", **(payload or {})}
@@ -2614,14 +2612,12 @@ async def astream_chat_workflow(
                             # we enforce it here defensively.
                             break
 
-                elif event_type == "heartbeat":
-                    yield {"type": "heartbeat"}
-
-                elif event_type == "model_progress":
-                    # Liveness signal from StreamingAgent: the model is still
-                    # streaming (tool-call args etc.) though nothing maps to an
-                    # SSE event. Forwarded so the run watchdog counts activity.
-                    yield {"type": "model_progress"}
+                elif event_type in ("heartbeat", "model_progress"):
+                    # heartbeat = transport keep-alive; model_progress = the
+                    # model is still streaming (tool-call args etc.) though
+                    # nothing maps to an SSE event — forwarded so the run
+                    # watchdog counts activity (it excludes only heartbeat).
+                    yield {"type": event_type}
 
                 elif event_type == "tool_pending":
                     yield {"type": "tool_pending", **(payload or {})}

--- a/src/backend/tests/orchestration/test_loop_reviewer_registry_tool.py
+++ b/src/backend/tests/orchestration/test_loop_reviewer_registry_tool.py
@@ -1,0 +1,34 @@
+"""Reviewer registry-verification tests.
+
+Artifact registration lives in the backend DB and is invisible to
+sandbox-filesystem forensics. The loop reviewer reuses the platform builtin
+``builtin.reviewer`` (its existing toolset — no extra tool bindings) and
+verifies registration autonomously via the unconditionally-registered
+``read_artifact`` tool: a successful read of the worker-reported file_id IS
+registry-backed proof.
+"""
+
+from core.llm.builtin_subagents import get_builtin_subagent
+from orchestration.subagents.loop_reviewer import _build_review_prompt
+
+
+def test_review_prompt_points_registry_criteria_at_read_artifact():
+    p = _build_review_prompt(
+        objective="生成报告",
+        requirement_desc="交付 docx",
+        acceptance_criteria=["已注册为可下载 artifact"],
+        worker_summary="我注册好了，file_id=fid_abc",
+        second_pass=False,
+    )
+    assert "read_artifact" in p
+    assert "注册表" in p
+    # 注册状态由 reviewer 自主调用工具核实，不再有编排层写死的事实注入
+    assert "平台侧权威事实" not in p
+
+
+def test_builtin_reviewer_spec_available():
+    # loop_reviewer 复用平台注册的 builtin.reviewer——spec 必须存在且只读
+    spec = get_builtin_subagent("builtin.reviewer")
+    assert spec is not None
+    assert spec.read_only is True
+    assert spec.max_iters > 0

--- a/src/backend/tests/orchestration/test_stale_reaper.py
+++ b/src/backend/tests/orchestration/test_stale_reaper.py
@@ -155,25 +155,56 @@ async def test_young_run_untouched(reaper_env):
 # ─── Reaping aligned with in-process task cancellation ──────────────────────────────────────────
 
 
-async def test_reap_cancels_local_worker_task(reaper_env, monkeypatch):
+async def test_quiet_over_age_run_with_live_task_survives(reaper_env, monkeypatch):
+    """A live in-process worker task is never a zombie — the inactivity watchdog
+    owns hang detection for it. Stream-quiet reaping killed healthy long runs
+    whose model was streaming huge tool-call args (which map to no stream
+    events); the quiet check now applies only to orphans."""
     session_factory, _ = reaper_env
     _insert_run(session_factory, "run_local", age_sec=executor._STALE_RUN_MAX_AGE_SEC + 300)
 
     task = asyncio.create_task(asyncio.sleep(3600))
     monkeypatch.setitem(executor._active_runs, "run_local", task)
 
+    assert await executor.reap_stale_runs() == 0
+    assert _get_run(session_factory, "run_local").status == "running"
+    assert not task.cancelled()
+    task.cancel()
+
+
+async def test_orphan_with_done_task_is_reaped(reaper_env, monkeypatch):
+    """A finished task left in _active_runs does not shield the run: quiet orphans are reaped."""
+    session_factory, _ = reaper_env
+    _insert_run(session_factory, "run_done", age_sec=executor._STALE_RUN_MAX_AGE_SEC + 300)
+
+    task = asyncio.create_task(asyncio.sleep(0))
+    await task  # completed task still parked in the registry
+    monkeypatch.setitem(executor._active_runs, "run_done", task)
+
+    assert await executor.reap_stale_runs() == 1
+    assert _get_run(session_factory, "run_done").status == "failed"
+
+
+async def test_hard_expired_cancels_local_worker_task(reaper_env, monkeypatch):
+    """Past the absolute lifetime cap, even a live in-process task is reaped and cancelled."""
+    session_factory, _ = reaper_env
+    _insert_run(session_factory, "run_local_hard", age_sec=executor._HARD_MAX_AGE_SEC + 300)
+
+    task = asyncio.create_task(asyncio.sleep(3600))
+    monkeypatch.setitem(executor._active_runs, "run_local_hard", task)
+
     assert await executor.reap_stale_runs() == 1
     await asyncio.sleep(0)  # let the cancel propagate
     assert task.cancelled()
 
 
-async def test_reap_leaves_plan_execute_task_to_cooperative_stop(reaper_env, monkeypatch):
+async def test_hard_expired_leaves_plan_execute_task_to_cooperative_stop(reaper_env, monkeypatch):
     """plan_execute does no cross-task cancel (anyio deadlock risk); it self-stops via polling."""
     session_factory, _ = reaper_env
     _insert_run(
         session_factory,
         "run_plan",
-        age_sec=executor._STALE_RUN_MAX_AGE_SEC + 300,
+        age_sec=executor._HARD_MAX_AGE_SEC + 300,
         kind="plan_execute",
     )
 

--- a/src/backend/tests/test_iter_budget_middleware.py
+++ b/src/backend/tests/test_iter_budget_middleware.py
@@ -27,17 +27,26 @@ def _reminder_texts(agent) -> list:
     return texts
 
 
+def _remind(mw, agent):
+    mw._maybe_remind(agent, *mw._budget(agent))
+
+
+def _force(mw, agent, input_kwargs):
+    max_iters, _cur, remaining = mw._budget(agent)
+    return mw._maybe_force_text(input_kwargs, max_iters, remaining)
+
+
 def test_no_remind_far_from_limit():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=5)  # 5 iterations left
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     assert agent.state.context == []
 
 
 def test_remind_at_threshold_mentions_remaining():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=8)  # 2 iterations left (including this one)
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     texts = _reminder_texts(agent)
     assert len(texts) == 1
     assert "system-reminder" in texts[0]
@@ -47,7 +56,7 @@ def test_remind_at_threshold_mentions_remaining():
 def test_last_round_forbids_tool_calls():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=9)  # last iteration
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     texts = _reminder_texts(agent)
     assert len(texts) == 1
     assert "最后一轮" in texts[0]
@@ -57,17 +66,17 @@ def test_last_round_forbids_tool_calls():
 def test_dedupe_same_round_reminds_once():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=8)
-    mw._maybe_remind(agent)
-    mw._maybe_remind(agent)  # same (reply_id, cur_iter) triggered again
+    _remind(mw, agent)
+    _remind(mw, agent)  # same (reply_id, cur_iter) triggered again
     assert len(_reminder_texts(agent)) == 1
 
 
 def test_escalates_across_rounds():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=8)
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     agent.state.cur_iter = 9  # enter the next iteration
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     texts = _reminder_texts(agent)
     assert len(texts) == 2
     assert "还剩 2 轮" in texts[0]
@@ -77,12 +86,12 @@ def test_escalates_across_rounds():
 def test_new_reply_resets_dedupe():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=9, reply_id="r1")
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     # New reply: cur_iter is reset to zero and then runs to the critical iteration again
     agent.state.reply_id = "r2"
     agent.state.cur_iter = 9
     agent.state.context.clear()
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     assert len(_reminder_texts(agent)) == 1
 
 
@@ -90,7 +99,7 @@ def test_new_reply_resets_dedupe():
 def test_tiny_budget_never_reminds(max_iters):
     mw = IterBudgetReminderMiddleware()  # threshold=2 -> max_iters<=3 skipped
     agent = _fake_agent(max_iters=max_iters, cur_iter=max(0, max_iters - 1))
-    mw._maybe_remind(agent)
+    _remind(mw, agent)
     assert agent.state.context == []
 
 
@@ -100,7 +109,7 @@ def test_tiny_budget_never_reminds(max_iters):
 def test_force_text_on_final_round():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=9)  # final round
-    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    out = _force(mw, agent, {"tool_choice": None})
     tc = out.get("tool_choice")
     assert tc is not None and tc.mode == "none"
 
@@ -108,7 +117,7 @@ def test_force_text_on_final_round():
 def test_no_force_text_before_final_round():
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=8)  # 2 left
-    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    out = _force(mw, agent, {"tool_choice": None})
     assert out.get("tool_choice") is None
 
 
@@ -116,7 +125,7 @@ def test_force_text_respects_explicit_tool_choice():
     sentinel = object()
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=9)
-    out = mw._maybe_force_text(agent, {"tool_choice": sentinel})
+    out = _force(mw, agent, {"tool_choice": sentinel})
     assert out["tool_choice"] is sentinel
 
 
@@ -124,7 +133,7 @@ def test_force_text_respects_explicit_tool_choice():
 def test_force_text_skips_tiny_budget(max_iters):
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=max_iters, cur_iter=max(0, max_iters - 1))
-    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    out = _force(mw, agent, {"tool_choice": None})
     assert out.get("tool_choice") is None
 
 
@@ -132,5 +141,5 @@ def test_force_text_kill_switch(monkeypatch):
     monkeypatch.setenv("CHAT_FINAL_ITER_FORCE_TEXT", "false")
     mw = IterBudgetReminderMiddleware()
     agent = _fake_agent(max_iters=10, cur_iter=9)
-    out = mw._maybe_force_text(agent, {"tool_choice": None})
+    out = _force(mw, agent, {"tool_choice": None})
     assert out.get("tool_choice") is None


### PR DESCRIPTION
## Summary

An end-to-end stress test (multi-hour, 200+ page report generation via the autonomous loop) surfaced seven gaps that prevented long-running tasks from completing. This PR fixes all of them across the run lifecycle, the sandbox session lifecycle, and the loop review pipeline.

## Fixes

1. **Stale reaper vs healthy long runs** — a run whose worker task is alive in-process is never judged a zombie by stream quietness: the inactivity watchdog owns hang detection for it, and a healthy run streaming huge tool-call arguments (which map to no stream events) past 30 minutes used to be reaped as "quiet". The quiet check now applies only to orphans; the absolute lifetime cap is unchanged.
2. **Liveness signal for the inactivity watchdog** — long tool-call-argument generation emits no SSE-mapped events; the streaming layer now yields a throttled process-internal `model_progress` marker so the watchdog can tell "still generating" from "hung".
3. **Sandbox session keepalive** — long model-streaming phases with no sandbox calls used to let the idle reaper destroy the session mid-run, wiping the workspace with no snapshot. `touch_session` is now part of the provider protocol, and both the loop worker and reviewer phases hold a keepalive.
4. **Final-round forced delivery** — on the last ReAct round the middleware forces `tool_choice=none`, so the model must deliver text instead of tripping the framework's max-iters hard stop (which discards the whole turn). `CHAT_MAIN_MAX_ITERS` env override added; kill-switch `CHAT_FINAL_ITER_FORCE_TEXT=false`.
5. **Reviewer can verify registry-backed criteria** — the loop reviewer now reuses the platform `builtin.reviewer` subagent and verifies registration-type acceptance criteria via the `read_artifact` tool (registration state lives in the backend registry, invisible to sandbox-filesystem forensics; false-negative re-reviews used to burn ~40% of a run's token budget).
6. **Review verdicts scoped to the requirement under review** — with fine-grained decompositions, applying global acceptance criteria to every requirement meant no single requirement could ever pass and the loop starved re-doing the first one until the budget ran out.
7. **Ledger loop_id stamping** — sandboxes are pool-recycled across sessions, so a brand-new loop could inherit the previous loop's `feature_list.json` and treat a dead loop's checkpoint (including attempt-blocked requirements) as its own. Foreign/unstamped sandbox ledgers are now ignored; legacy resumes go through the loop-keyed DB mirror.

## Validation

- End-to-end: a multi-hour autonomous-loop run produced a 221-page .docx (independently verified via PDF page count), 20 iterations, ~9.7M tokens, with zero sandbox losses and zero false reaps.
- A clean full-cycle validation loop (draft → docx → artifact registration) finished `completed` with score 1.0; the reviewer's evidence explicitly cites `read_artifact` reads against the platform registry.
- Unit tests added/updated: liveness signal throttling, force-text final round, reaper contract (live-task skip / orphan reap / hard-expiry cancel semantics), reviewer prompt tool guidance.

## Notes

- `model_progress` never reaches clients: the chat path drops it before the stream, and `follow_run_as_sse` filters entries written by older builds.
- Providers without a session lifecycle implement `touch_session` as a no-op.
