### PR TITLE
chore(desktop): bump version to 0.2.14

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugagent-desktop",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS/Linux 离线本机服务）",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1687,7 +1687,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hugagent-desktop"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "axum",
  "bytes",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugagent-desktop"
-version = "0.2.13"
+version = "0.2.14"
 description = "HugAgentOS桌面客户端"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HugAgentOS",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "identifier": "com.hugagent.desktop",
   "build": {
     "frontendDist": "../../src/frontend/dist",


### PR DESCRIPTION
Version bump for the next desktop release, synchronizing the five version files via `npm --prefix desktop run version:desktop -- 0.2.14`.

Ships the evolution approval preview / memory-gate fixes (#60) to desktop users, whose bundled frontend only updates through a new release.