### PR TITLE
fix(evolution): restore memory settlement and composer reliability

### DIFF
--- a/src/backend/core/memory/extractors/gate.py
+++ b/src/backend/core/memory/extractors/gate.py
@@ -1,9 +1,9 @@
 """LLM write gate — one fast judgment call before any extractor runs.
 
 The regex classify answers "which extractors *could* this turn concern"; it is
-deliberately loose (procedural has no keyword gate at all), so on its own the
-pipeline extracts on nearly every substantive turn and the store fills with
-marginal entries. This gate adds the judgment the regex cannot make: **is there
+deliberately loose (identity, preference and procedural all clear it on any
+substantive turn), so on its own the pipeline extracts on nearly every
+substantive turn and the store fills with marginal entries. This gate adds the judgment the regex cannot make: **is there
 anything in this turn worth remembering long-term at all, and of which kinds?**
 
 Contract:

--- a/src/backend/core/memory/extractors/router.py
+++ b/src/backend/core/memory/extractors/router.py
@@ -1,19 +1,23 @@
 """Extractor router — decide what to extract, then dispatch concurrently.
 
-- `classify_conversation()`: which extractors this turn deserves. Identity,
-  preference and task stay keyword-gated: they are cheap to spot and their cues
-  are explicit ("我是…", "以后都用…"). **Procedural is not gated** — it runs on
-  every substantive turn.
+- `classify_conversation()`: which extractors this turn deserves. Every
+  substantive turn nominates identity, preference and procedural (plus graph
+  when deployed); the keyword cues only remain as a recall floor for turns too
+  short to clear the substance bar ("我叫张三"). Task stays keyword-gated: its
+  cues are explicit and it is session-scoped anyway.
 - `run_extractors_with_timeout()`: run the matched extractors concurrently, each with its own timeout, merging the returns.
 
-Why procedural lost its keyword gate: a convention shows up in whatever words
-the user happened to use, and a regex listing "一律 / 必须先 / 口径是" decides
-*before the model ever sees the turn* whether that turn could contain one. Every
-procedure phrased outside the list was dropped silently and invisibly — the
-worst failure mode a memory system can have, because it looks identical to a
-turn that genuinely had nothing to learn. The extractor itself is a far better
-judge than the regex, and it already returns an empty list when there is nothing
-worth keeping.
+Why the keyword gates fell: a fact shows up in whatever words the user happened
+to use, and a regex listing "我是… / 一律 / 必须先" decides *before the model
+ever sees the turn* whether that turn could contain one. Everything phrased
+outside the list was dropped silently and invisibly — the worst failure mode a
+memory system can have, because it looks identical to a turn that genuinely had
+nothing to learn. Procedural learned this first; identity and preference had the
+same failure (the LLM write gate can only narrow the candidate set, so whatever
+the regex failed to nominate was unrecoverable — turns stating who the user is
+never produced an L1 write). The gate plus the extractors are far better judges
+than the regex, and both already return empty when there is nothing worth
+keeping.
 """
 
 from __future__ import annotations
@@ -80,6 +84,9 @@ def classify_conversation(user_msg: str, assistant_msg: str) -> set[ExtractorTyp
 
     classes: set[ExtractorType] = set()
 
+    # Keyword cues are a recall floor, not the gatekeeper: they catch turns too
+    # short to clear the substance bar below ("我叫张三" is 4 chars). Task keeps
+    # them as its only trigger — it is session-scoped and its cues are explicit.
     if _IDENTITY_CUES.search(user_msg):
         classes.add(ExtractorType.IDENTITY)
     if _PREFERENCE_CUES.search(user_msg):
@@ -87,18 +94,18 @@ def classify_conversation(user_msg: str, assistant_msg: str) -> set[ExtractorTyp
     if _TASK_CUES.search(user_msg):
         classes.add(ExtractorType.TASK)
 
-    # Procedural: no keyword gate, only a substance floor. The extractor decides
-    # whether the turn contained a reusable way of working; a regex cannot, and
-    # the procedures it missed were invisible.
+    # No keyword gate past this point, only a substance floor: the LLM write
+    # gate and the extractors decide what the turn actually contained. A regex
+    # cannot, and whatever it missed was dropped invisibly — the gate can only
+    # narrow this set, so anything not nominated here is unrecoverable.
     if (
         len(user_msg.strip()) >= _SUBSTANTIVE_USER_CHARS
         and len((assistant_msg or "").strip()) >= _SUBSTANTIVE_ASSISTANT_CHARS
     ):
         classes.add(ExtractorType.PROCEDURAL)
-        # L3 has the same substance floor as L2, but is deployment-gated. The
-        # extractor itself decides whether the turn contains a stable entity
-        # relation; keywords cannot do that without silently losing aliases,
-        # dependencies, and ownership statements phrased in new ways.
+        classes.add(ExtractorType.IDENTITY)
+        classes.add(ExtractorType.PREFERENCE)
+        # L3 has the same substance floor, but is deployment-gated on Neo4j.
         if settings.memory.graph_enabled:
             classes.add(ExtractorType.GRAPH)
 

--- a/src/backend/orchestration/memory_integration.py
+++ b/src/backend/orchestration/memory_integration.py
@@ -306,7 +306,7 @@ def save_memories_background(
 
     Inside `schedule_post_response_tasks`:
     - global Semaphore bounds concurrency (default 8)
-    - runs 0-4 extractors classified by keyword
+    - runs 0-5 extractors picked by the router's substance floor + LLM write gate
     - each extractor has its own 30s timeout
     - sanitize → write L1/L2/Session → audit
 

--- a/src/backend/orchestration/workflow.py
+++ b/src/backend/orchestration/workflow.py
@@ -1851,6 +1851,10 @@ async def _astream_subagent_direct(
         "citations": all_citations,
         "usage": _direct_usage,
         "ontology_governance": _ontology_governance_summary(_ontology_runtime),
+        # Same contract as the main route: memory writes are scheduled below,
+        # so the frame can only announce "settling" for the client's skeleton
+        # card. Without this marker subagent turns never showed their card.
+        "evolution_pending": _evolution_pending_marker(context, _mem0_write_enabled),
     }
 
     # ── [memory] Post-response pipeline (SSE already closed, user isn't waiting) ────
@@ -1864,9 +1868,26 @@ async def _astream_subagent_direct(
             workspace_id=_mem0_workspace_id,
             chat_id=_mem0_chat_id,
             scope_user_id=_mem0_scope_user_id,
+            message_id=str(context.get("message_id") or ""),
         )
     else:
         logger.debug("[subagent] memory save skipped: write_enabled=False (user=%s)", _mem0_user_id)
+
+    # ── [evolution] Evidence assembly — same contract as the main route. Without
+    # registration the settlement runner parks the memory report on a 45s
+    # watchdog before settling, which pushed subagent cards past the client's
+    # polling budget.
+    _assemble_episode_background(
+        message_id=str(context.get("message_id") or ""),
+        run_id=str(context.get("run_id") or ""),
+        chat_id=str(context.get("chat_id") or ""),
+        user_id=str(context.get("user_id") or ""),
+        objective=user_message,
+        agent=streaming_agent,
+        memory_task=_memory_task,
+        latency_ms=None,
+        memory_write_enabled=_mem0_write_enabled,
+    )
 
 
 # ------------------------------------------------------------------

--- a/src/backend/tests/memory/test_extractor_routing.py
+++ b/src/backend/tests/memory/test_extractor_routing.py
@@ -6,10 +6,13 @@ Two rules this file exists to hold:
    the moment it is written; remembering it makes the system recall a stale
    number instead of looking the current one up. There is no fact extractor to
    fall back to.
-2. **Procedural extraction is not keyword-gated.** A convention is stated in
-   whatever words the user happened to use, so a regex deciding before the model
-   ever reads the turn drops every procedure phrased outside its list — silently,
-   and indistinguishably from a turn that had nothing to teach.
+2. **Long-term extraction is not keyword-gated.** A convention — or an identity
+   or preference — is stated in whatever words the user happened to use, so a
+   regex deciding before the model ever reads the turn drops everything phrased
+   outside its list — silently, and indistinguishably from a turn that had
+   nothing to teach. The LLM write gate can only narrow the candidate set, so a
+   class the router fails to nominate is unrecoverable; substantive turns
+   nominate identity, preference and procedural alike and let the gate judge.
 """
 
 from core.memory.extractors.router import ExtractorType, classify_conversation
@@ -58,12 +61,22 @@ def test_an_unanswered_turn_is_not_examined():
     assert ExtractorType.PROCEDURAL not in classify_conversation("这个财务口径应该怎么算比较好", "")
 
 
-def test_identity_and_preference_stay_keyword_gated():
-    # Their cues are explicit and cheap to spot, so paying for an extra
-    # extraction on every turn would buy nothing.
-    assert ExtractorType.IDENTITY in classify_conversation("我是研发中心的负责人", LONG_ANSWER)
-    assert ExtractorType.IDENTITY not in classify_conversation("帮我算下这个季度的数", LONG_ANSWER)
-    assert ExtractorType.PREFERENCE in classify_conversation("以后回答简洁点", LONG_ANSWER)
+def test_identity_and_preference_are_nominated_on_substantive_turns():
+    # The gate can only narrow the router's set, so a class not nominated here
+    # can never be written: keyword-gating L1 meant identity stated in words
+    # outside the cue list never reached the profile — and never showed on the
+    # turn's card. Substantive turns nominate them and the gate judges.
+    classes = classify_conversation("顺便说下我上个月调到数据组了", LONG_ANSWER)
+    assert ExtractorType.IDENTITY in classes
+    assert ExtractorType.PREFERENCE in classes
+
+
+def test_identity_and_preference_cues_still_catch_short_turns():
+    # The keyword cues survive as a recall floor for turns too short to clear
+    # the substance bar — an explicit "我是…" deserves extraction even when the
+    # assistant's reply was a one-liner.
+    assert ExtractorType.IDENTITY in classify_conversation("我是研发中心的负责人", "好的")
+    assert ExtractorType.PREFERENCE in classify_conversation("以后回答简洁点", "好的")
 
 
 def test_graph_extraction_is_deployment_gated(monkeypatch):

--- a/src/frontend/src/components/chat/InputArea.tsx
+++ b/src/frontend/src/components/chat/InputArea.tsx
@@ -518,6 +518,10 @@ export function InputArea({
 
   // ── Keyboard ──
   function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    // Let the IME own every key while it is composing. In particular, Enter and
+    // Tab may confirm a candidate instead of sending or selecting a popup item.
+    if (composingRef.current || e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
     // Slash popup: Enter/Tab → select skill
     if (slashVisible && (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey))) {
       e.preventDefault();
@@ -584,7 +588,7 @@ export function InputArea({
     }
   }
 
-  const isEmpty = !input.trim() && !activeMention && !activeSkill && !activePlugin && !isComposing;
+  const showPlaceholder = !input.trim() && !activeMention && !activeSkill && !activePlugin && !isComposing;
 
   const hasAttachments = uploadedFiles.length > 0 || importedSpaceFiles.length > 0;
 
@@ -670,9 +674,7 @@ export function InputArea({
           ref={editorRef}
           contentEditable
           suppressContentEditableWarning
-          className={`jx-composer jx-composerEditor${isEmpty ? ' jx-composerEditor--empty' : ''}`}
-          data-placeholder={placeholder}
-          data-mobile-placeholder={mobilePlaceholder || placeholder}
+          className="jx-composer jx-composerEditor"
           onInput={() => { if (!composingRef.current) syncText(); }}
           onCompositionStart={() => { composingRef.current = true; setIsComposing(true); }}
           onCompositionEnd={() => { composingRef.current = false; setIsComposing(false); syncText(); }}
@@ -684,6 +686,14 @@ export function InputArea({
           }}
           onBlur={() => { setTimeout(() => { setMentionVisible(false); setSlashVisible(false); }, 200); }}
         />
+        {showPlaceholder && (
+          <div
+            className="jx-composerPlaceholder"
+            data-placeholder={placeholder}
+            data-mobile-placeholder={mobilePlaceholder || placeholder}
+            aria-hidden="true"
+          />
+        )}
 
         <div className="jx-composerBar">
           {(() => {

--- a/src/frontend/src/components/chat/InputArea.tsx
+++ b/src/frontend/src/components/chat/InputArea.tsx
@@ -596,7 +596,7 @@ export function InputArea({
     <div className="jx-inputArea">
       {/* 项目页 composer 不显示云端/本机切换：会话在哪执行由项目本身决定（云端项目在云端、
           本地项目在本机），不在项目内提供切换入口 */}
-      <LoopPlanBar onContinue={continueLoop} />
+      {!projectComposer && <LoopPlanBar onContinue={continueLoop} />}
       {hasAttachments && (
         <div className="jx-inputAttachments">
           <AnimatePresence initial={false}>

--- a/src/frontend/src/hooks/useEvolutionSettlement.ts
+++ b/src/frontend/src/hooks/useEvolutionSettlement.ts
@@ -20,9 +20,11 @@ import type { EvolutionSummary } from '../types';
  * ordinary conversations. Only the backend declares a real failure.
  */
 const POLL_INTERVAL_MS = 3000;
-// ~60s: the memory pipeline's extractors have their own 30s timeout, and
-// settlement waits for their real write count before reporting.
-const MAX_ATTEMPTS = 20;
+// ~90s: the memory pipeline's extractors have their own 30s timeout, and the
+// settlement runner waits up to another 45s (its watchdog) for their real write
+// count before reporting — a 60s budget quietly outran slow-but-successful
+// settlements, so this sits beyond the backend's worst case.
+const MAX_ATTEMPTS = 30;
 
 const TERMINAL_STATES: EvolutionSummary['state'][] = ['settled', 'failed', 'empty'];
 

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -2881,12 +2881,24 @@ textarea.jx-composer{
   overflow-anchor: none;
   cursor: text;
 }
-/* Placeholder — must be absolute so it doesn't push the cursor */
-.jx-composerEditor--empty::before {
-  content: attr(data-placeholder);
+/* Keep placeholder rendering outside contentEditable so IME composition never
+   causes React to mutate the editor element itself. */
+.jx-composerPlaceholder {
+  box-sizing: border-box;
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  padding: 16px 16px 60px;
+  font-size: 16px;
+  line-height: 1.5715;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow: hidden;
   color: #B3B3B3;
   pointer-events: none;
-  position: absolute;
+}
+.jx-composerPlaceholder::before {
+  content: attr(data-placeholder);
 }
 
 /* ── Inline chips inside the editor (same text flow) ── */

--- a/src/frontend/src/styles/evolution.css
+++ b/src/frontend/src/styles/evolution.css
@@ -56,7 +56,8 @@
 .jx-evolutionCard-entry.is-busy { opacity: .6; pointer-events: none; }
 
 /* Which layer the memory landed in. L1 is who the user is, L2 is how work is
-   done here — different enough that collapsing them would hide what changed. */
+   done here, L3 is how entities relate — different enough that collapsing them
+   would hide what changed. */
 .jx-evolutionCard-layer {
   flex: none;
   margin-top: 1px;
@@ -69,6 +70,7 @@
 }
 .jx-evolutionCard-layer.is-l1 { background: rgba(37, 99, 235, .10); color: #1d4ed8; }
 .jx-evolutionCard-layer.is-l2 { background: rgba(16, 185, 129, .12); color: #047857; }
+.jx-evolutionCard-layer.is-l3 { background: rgba(139, 92, 246, .12); color: #6d28d9; }
 
 .jx-evolutionCard-entryBody { flex: 1 1 auto; min-width: 0; }
 

--- a/src/frontend/src/styles/mobile.css
+++ b/src/frontend/src/styles/mobile.css
@@ -369,7 +369,8 @@
     box-shadow:0 10px 30px rgba(42,61,94,.075);
   }
 
-  .jx-projectDetail-inputWrap .jx-composerEditor{
+  .jx-projectDetail-inputWrap .jx-composerEditor,
+  .jx-projectDetail-inputWrap .jx-composerPlaceholder{
     min-height:132px;
     max-height:260px;
     padding:17px 16px 58px;
@@ -806,7 +807,8 @@
   }
 
   .jx-emptyPage--main .jx-homeInput .jx-composer,
-  .jx-emptyPage--main .jx-homeInput .jx-composerEditor{
+  .jx-emptyPage--main .jx-homeInput .jx-composerEditor,
+  .jx-emptyPage--main .jx-homeInput .jx-composerPlaceholder{
     width:100% !important;
     height:90px !important;
     min-height:90px !important;
@@ -816,7 +818,7 @@
     line-height:1.45;
   }
 
-  .jx-emptyPage--main .jx-homeInput .jx-composerEditor--empty::before{
+  .jx-emptyPage--main .jx-homeInput .jx-composerPlaceholder::before{
     content:attr(data-mobile-placeholder);
     color:#929bab;
     font-size:15px;
@@ -1683,7 +1685,8 @@
 
   .jx-emptyPage--main .jx-homeInput .jx-composerWrap,
   .jx-emptyPage--main .jx-homeInput .jx-composer,
-  .jx-emptyPage--main .jx-homeInput .jx-composerEditor{
+  .jx-emptyPage--main .jx-homeInput .jx-composerEditor,
+  .jx-emptyPage--main .jx-homeInput .jx-composerPlaceholder{
     height:82px !important;
     min-height:82px !important;
   }


### PR DESCRIPTION
## Summary / 概述

This maintainer sync regenerates the Community Edition from the latest upstream FULL branch and brings three related reliability fixes into the public tree.

- Broaden long-term memory nomination so substantive turns can reach the identity and preference extractors even when the user does not use a fixed keyword phrase. Explicit short statements remain covered by the keyword fallback, while the LLM write gate still decides whether anything is durable enough to store.
- Complete the direct-subagent evolution contract by publishing the pending marker, attaching the message ID, and assembling episode evidence. The client now polls long enough to cover the backend watchdog and renders a distinct L3 relationship badge.
- Keep the empty-composer placeholder outside the active `contentEditable` node and ignore Enter, Tab, and legacy key-code 229 events while an IME owns the composition session.
- Hide the global loop-status bar inside project composers, where execution state is controlled by the project itself.

**Root causes**

- The memory router treated its keyword list as a hard gate. Identity or preference statements phrased outside that list never reached the LLM gate and therefore could not be recovered later.
- The direct-subagent path did not emit the same settlement metadata or episode evidence as the main route, so its evolution card could be missing or settle after the previous 60-second polling budget.
- The empty placeholder was implemented by changing the active editor's class at `compositionstart`, which can interrupt Chinese IME pre-edit text in Chromium. The keyboard handler also processed Enter and Tab before checking IME ownership.
- Project composers reused a global loop-status component that is not meaningful in project-scoped execution.

**Validation**

- `python scripts/build_ce.py --import-check --pytest-check --frontend-check`
  - CE brand, path, binary allowlist, and license gates passed.
  - CE import/OpenAPI/ORM self-check passed.
  - CE release regression tests passed.
  - CE frontend production build passed.
- `git diff --check`
- The FULL frontend production build and Docker rebuild completed successfully; frontend, backend, and MCP containers were healthy.

**Manual verification**

The exact browser and Chinese IME combination reported in #63 is not available locally. Synthetic composition events are not equivalent to a real OS IME session, so the original empty-input scenario should be verified on the reporter's environment before this draft is marked ready.

## Related issue / 关联 Issue

Refs #63

## Type of change / 变更类型

- [ ] 📖 Documentation (`document/**`, `README*.md`)
- [ ] 🧩 Example / sample (`examples/**`)
- [ ] 🔧 Repo meta (CI, templates, `.github/**`)
- [x] Other (please describe / 请说明): maintainer-generated upstream CE sync

## Checklist / 检查项

- [ ] My change only touches non-generated paths (docs / examples / repo meta). 仅改动非生成路径。
  - This is an authorized maintainer sync of generated code from the upstream source repository.
- [x] Links and code snippets were verified. 链接与代码片段已验证。
- [x] For bilingual docs, I updated both `document/en/**` and `document/zh-CN/**` where applicable. 双语文档已同步更新（如适用）。
  - Not applicable: this PR does not change documentation.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md). 我已阅读贡献指南。
