### PR TITLE
feat(desktop): default to local mode on first-run setup

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugagent-desktop",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugagent-desktop",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": true,
   "description": "HugAgentOS 桌面客户端（远程连接 + Windows/macOS/Linux 离线本机服务）",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1687,7 +1687,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hugagent-desktop"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "axum",
  "bytes",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugagent-desktop"
-version = "0.2.14"
+version = "0.2.15"
 description = "HugAgentOS桌面客户端"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -390,6 +390,18 @@ pub fn run() {
                 }
             }
 
+            // 初始化页预填形态：全新安装（尚无 server.json）默认「本机模式」——桌面
+            // 包自带本机 server payload，本机开箱即用。瘦客户端（thin bundle，无本机
+            // 能力）与不支持本机服务的平台仍预填云端；已有配置沿用推断值（升级用户
+            // 预填不变）。
+            let init_mode_prefill = if !config_dir.join("server.json").is_file()
+                && local_payload::current_target() != "unsupported"
+            {
+                config::ProvisionMode::LocalOnly
+            } else {
+                cfg.provision_mode()
+            };
+
             let web_dir = resolve_web_dir(app);
 
             // 同步起反代拿到端口（仅绑定 + 后台 spawn，很快返回）。
@@ -401,6 +413,7 @@ pub fn run() {
                 local_server: local_server.clone(),
                 active_local: cfg.uses_local_server(),
                 provision_mode: cfg.provision_mode(),
+                init_mode_prefill,
                 cloud_server_base: cfg.cloud_base(),
                 local_base: local_server::LOCAL_SERVER_BASE.to_string(),
                 hybrid_local,

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -38,6 +38,9 @@ pub struct ProxyState {
     pub active_local: bool,
     /// 初始化选定的运行形态（本机 / 云端 / 双模式）。前端据此决定是否展示切换。
     pub provision_mode: ProvisionMode,
+    /// 初始化选择页的预填形态：全新安装（尚无 server.json）预填「本机模式」；
+    /// 已有配置（显式选过或遗留 deployment_mode）沿用推断值，升级用户预填不变。
+    pub init_mode_prefill: ProvisionMode,
     /// 记住的云端服务器地址，供初始化选择页预填。
     pub cloud_server_base: String,
     /// 混合架构（Dual）：本机执行面地址（http://127.0.0.1:32101）。
@@ -304,7 +307,7 @@ async fn setup_page(State(state): State<ProxyState>) -> Html<String> {
 /// 形态时展开服务器地址输入。提交整页导航到哨兵 `/__desktop/provision?mode=..&base=..`，
 /// 由主窗口的 Rust 导航守卫落盘并重启。`manage=1` 时是「稍后更改运行模式」入口。
 async fn init_page(State(state): State<ProxyState>) -> Html<String> {
-    let current_mode = match state.provision_mode {
+    let current_mode = match state.init_mode_prefill {
         ProvisionMode::LocalOnly => "local",
         ProvisionMode::CloudOnly => "cloud",
         ProvisionMode::Dual => "dual",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HugAgentOS",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "identifier": "com.hugagent.desktop",
   "build": {
     "frontendDist": "../../src/frontend/dist",


### PR DESCRIPTION
## Summary

- On a fresh install (no `server.json` yet), the first-run mode picker now pre-selects **Local mode** instead of Cloud. The desktop bundle ships the local server payload, so local works out of the box.
- Thin bundles (`HUGAGENT_DESKTOP_BUNDLE=thin`) and platforms without local-server support still pre-select Cloud.
- Existing configurations (explicit choice or legacy `deployment_mode`) keep their inferred pre-selection unchanged, so upgrades are unaffected.
- Bumps desktop version to **0.2.15** for the next release.

## Testing

- `cargo check` and `cargo test --lib` pass (39 tests).