### PR TITLE
feat(chat): drag-and-drop file upload in the chat composer (desktop included)

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -561,6 +561,9 @@ fn toggle_quickask(app: &tauri::AppHandle) {
     let _ = WebviewWindowBuilder::new(app, "quickask", WebviewUrl::External(parsed))
         .title(format!("{} · 快速问答", brand::NAME))
         .additional_browser_args(WEBVIEW_BROWSER_ARGS)
+        // 关掉 webview 内建的拖放拦截：它会吞掉 OS 文件拖入，页面收不到带
+        // File 对象的 HTML5 drop 事件，输入框的拖拽上传（useFileDropZone）失效
+        .disable_drag_drop_handler()
         .inner_size(680.0, 540.0)
         .min_inner_size(480.0, 360.0)
         .always_on_top(true)
@@ -729,6 +732,8 @@ fn build_window(app: &tauri::AppHandle, url: &str) -> tauri::Result<()> {
     let builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::External(parsed))
         .title(brand::NAME)
         .additional_browser_args(WEBVIEW_BROWSER_ARGS)
+        // 同 quickask：禁用内建拖放拦截，HTML5 drop 事件才能携带文件进到页面
+        .disable_drag_drop_handler()
         .inner_size(width, height)
         .min_inner_size(min_width, min_height);
 

--- a/src/frontend/src/components/chat/InputArea.tsx
+++ b/src/frontend/src/components/chat/InputArea.tsx
@@ -21,6 +21,8 @@ import type { InstalledPluginItem } from '../../types';
 import { AgentMentionPopup, useAgentMention } from '../agent';
 import { SkillSlashPopup, useSkillSlash, type SlashEntry } from './SkillSlashPopup';
 import LoopPlanBar from '../loop/LoopPlanBar';
+import { useFileDropZone } from '../../hooks/useFileDropZone';
+import { DropOverlay } from '../common/DropOverlay';
 import LocalApprovalPill from './LocalApprovalPill';
 import DeploymentSwitcher from './DeploymentSwitcher';
 import { ContextGauge } from './ContextGauge';
@@ -592,8 +594,18 @@ export function InputArea({
 
   const hasAttachments = uploadedFiles.length > 0 || importedSpaceFiles.length > 0;
 
+  // 拖文件到输入区直接作为附件上传，复用点击"浏览"的同一条 handleFileSelect 管线
+  // （它只读 e.target.files，合成一个最小 change 事件即可）。
+  const { dragActive, dropZoneProps } = useFileDropZone(true, (files) => {
+    handleFileSelect(
+      { target: { files } } as unknown as React.ChangeEvent<HTMLInputElement>,
+      fileInputRef,
+    );
+  });
+
   return (
-    <div className="jx-inputArea">
+    <div className="jx-inputArea" {...dropZoneProps}>
+      <DropOverlay active={dragActive} hint={t('松开即可添加为附件')} className="jx-inputArea-dropOverlay" iconSize={20} />
       {/* 项目页 composer 不显示云端/本机切换：会话在哪执行由项目本身决定（云端项目在云端、
           本地项目在本机），不在项目内提供切换入口 */}
       {!projectComposer && <LoopPlanBar onContinue={continueLoop} />}

--- a/src/frontend/src/i18n/en/chat.ts
+++ b/src/frontend/src/i18n/en/chat.ts
@@ -234,4 +234,5 @@ export const CHAT_DICT: Record<string, string> = {
   '删除这条记忆': 'Delete this memory',
   '修改失败，请重试': 'Edit failed — please retry',
   '删除失败，请重试': 'Delete failed — please retry',
+  '松开即可添加为附件': 'Release to attach the files',
 };

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -18,6 +18,12 @@ import { installPreloadErrorReload } from './preloadReload'
 
 installPreloadErrorReload()
 
+// 文件拖到非拖放区时，阻止 webview 的默认行为（直接导航打开该文件、离开 SPA）。
+// 桌面端已禁用 Tauri 内建拖放拦截（disable_drag_drop_handler），全靠这层兜底；
+// 各拖放区（useFileDropZone）在自己的 onDrop 里 preventDefault，不受影响。
+window.addEventListener('dragover', (e) => e.preventDefault())
+window.addEventListener('drop', (e) => e.preventDefault())
+
 const isApiDocs = window.location.pathname.startsWith('/api-docs')
 const isSharePreview = new URLSearchParams(window.location.search).has('share')
 

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -1557,8 +1557,13 @@ textarea.jx-composer{
   background:#fff;
 }
 .jx-inputArea{
+  position:relative;
   padding-top:12px;
   width:100%;
+}
+/* 输入区拖拽上传高亮层：圆角与 composer 一致 */
+.jx-inputArea-dropOverlay{
+  border-radius:16px;
 }
 .jx-chatFooter::before{
   content:'';


### PR DESCRIPTION
## Problem

Dragging a file onto the chat composer did not upload it — users had to click the "browse" button and pick the file manually. On desktop it was doubly broken: even with frontend drop handling in place, Tauri's built-in webview drag-drop interceptor swallows OS file drops, so HTML5 drop events never carry File objects into the page.

## Changes

1. **Drop-zone in InputArea**: reuses the existing `useFileDropZone` + `DropOverlay` (same pair used by MySpace and the project right rail). Dragging files over the composer shows a "release to attach" highlight, and the drop feeds the exact same `handleFileSelect` upload pipeline as the browse button (attachment cards, OSS upload, and send logic unchanged). The chat page, empty-state home composer, and project composer all pick this up automatically.
2. **Desktop unlock**: the `main` / `quickask` WebviewWindowBuilder now calls `.disable_drag_drop_handler()`, letting HTML5 drag-and-drop events reach the page with real File objects (Tauri v2 intercepts them by default).
3. **Global fallback**: main.tsx registers window-level `dragover`/`drop` preventDefault handlers so a file dropped outside any drop zone can no longer make the webview navigate to the file and blank out the SPA (required once the built-in interceptor is disabled).

## Verification

- Frontend `npm run build` (i18n check + tsc + vite) passes; the EN string (`Release to attach the files`) is included.
- `cargo check` passes (pre-existing warnings only).
- Drag-and-drop and browse share a single upload path — no duplicated logic.