### PR TITLE
fix(channels): strip inline <think> reasoning from channel replies

### DIFF
--- a/src/backend/core/channels/inbound.py
+++ b/src/backend/core/channels/inbound.py
@@ -215,7 +215,14 @@ async def _ingest_attachments(
 
 
 async def _collect_reply(run_id: str):
-    """Follow the run's event stream, accumulating assistant text + capturing artifact files generated this turn (meta.artifacts)."""
+    """Follow the run's event stream, accumulating assistant text + capturing artifact files generated this turn (meta.artifacts).
+
+    Structured-reasoning models emit thinking as separate ``thinking`` events (ignored
+    here), but inline-thinking models embed ``<think>…</think>`` in the content deltas
+    themselves — strip those before handing the text to the channel, or the raw chain
+    of thought goes out as message text (the web UI parses the tags; IM cannot).
+    """
+    from core.channels.markdown import strip_inline_thinking
     from orchestration import chat_run_executor
 
     full = ""
@@ -228,7 +235,7 @@ async def _collect_reply(run_id: str):
             arts = event.get("artifacts")
             if isinstance(arts, list):
                 artifacts = arts
-    return full.strip(), artifacts
+    return strip_inline_thinking(full).strip(), artifacts
 
 
 def _load_generated_files(artifacts: List[Dict[str, Any]]):
@@ -415,9 +422,10 @@ async def _process_inbound(msg: InboundMsg) -> None:
         enabled = _resolve_enabled(db, conn, owner_id)
         # Enable thinking: same as the web client's default in non-fast mode. With thinking off,
         # models (Qwen family especially) tend to emit shallow filler like "I'll get right on X"
-        # without actually landing on tool calls, idling repeatedly across turns. Thinking events
-        # are ignored by _collect_reply (which only accumulates content/meta), so they never leak
-        # into the channel reply.
+        # without actually landing on tool calls, idling repeatedly across turns. Thinking never
+        # leaks into the channel reply: structured-reasoning models emit separate thinking events
+        # (ignored by _collect_reply, which only accumulates content/meta), and inline-thinking
+        # models' <think>…</think> spans inside content are stripped by _collect_reply.
         context = build_runtime_context(
             model_name=None, user_id=owner_id, chat_id=chat_id, enable_thinking=True,
             uploaded_files=uploaded_files,

--- a/src/backend/core/channels/markdown.py
+++ b/src/backend/core/channels/markdown.py
@@ -41,6 +41,31 @@ def strip_citation_markers(text: str) -> str:
     return _REF_RE.sub("", text)
 
 
+def strip_inline_thinking(text: str) -> str:
+    """Drop inline ``<think>…</think>`` reasoning, keeping only the final answer body.
+
+    Channel sessions run with enable_thinking=True (see core/channels/inbound.py), and
+    models without a structured reasoning channel (DeepSeek R1 style / Qwen behind a
+    gateway without a reasoning parser) embed the chain of thought directly in the
+    content stream. The web UI parses the tags itself (utils/segments.ts: everything
+    before the **last** ``</think>`` renders as collapsible thinking; the opening
+    ``<think>`` is often absent); IM channels have no such layer, so without this the
+    raw reasoning would go out as message text. Mirrors the frontend's semantics:
+    keep only what follows the last ``</think>``, and drop a dangling unclosed
+    ``<think>`` tail (stream cut mid-thinking).
+    """
+    text = text or ""
+    if "<think>" not in text and "</think>" not in text:
+        return text
+    last_close = text.rfind("</think>")
+    if last_close != -1:
+        text = text[last_close + len("</think>"):]
+    open_idx = text.find("<think>")
+    if open_idx != -1:
+        text = text[:open_idx]
+    return text.strip()
+
+
 def derive_title(text: str, fallback: str = "新消息", limit: int = 20) -> str:
     """Distill a one-line plain-text title from Markdown body (DingTalk markdown
     messages require title; shown in conversation-list summaries/notifications).

--- a/src/backend/core/channels/outbound.py
+++ b/src/backend/core/channels/outbound.py
@@ -90,12 +90,14 @@ async def deliver_to_conversation(
     ok = True
     try:
         if text:
-            # [ref:tool-N] citation markers only render on the web frontend, so strip them before
-            # outbound; markdown rendering/downgrade is handled inside adapter.push per each
-            # channel's capability (e.g. DingTalk sends a markdown message).
-            from core.channels.markdown import strip_citation_markers
+            # [ref:tool-N] citation markers and inline <think> reasoning only make sense on the
+            # web frontend, so strip both before outbound (automation runs currently disable
+            # thinking, so the <think> strip is a safety net); markdown rendering/downgrade is
+            # handled inside adapter.push per each channel's capability (e.g. DingTalk sends a
+            # markdown message).
+            from core.channels.markdown import strip_citation_markers, strip_inline_thinking
 
-            r = await adapter.push(conn, msg, strip_citation_markers(text))
+            r = await adapter.push(conn, msg, strip_citation_markers(strip_inline_thinking(text)))
             if not r.success:
                 logger.warning(
                     "[channels] 主动文本投递失败 channel=%s conv=%s kind=%s detail=%s",

--- a/src/backend/tests/test_channel_bots.py
+++ b/src/backend/tests/test_channel_bots.py
@@ -736,6 +736,50 @@ def test_markdown_strip_citation_markers():
     assert strip_citation_markers("") == ""
 
 
+def test_markdown_strip_inline_thinking():
+    """Inline chain of thought must never reach the channel as message text.
+    Semantics mirror the web frontend (segments.ts): body = whatever follows the LAST </think>."""
+    from core.channels.markdown import strip_inline_thinking
+
+    # Full tag pair
+    assert strip_inline_thinking("<think>推理过程</think>\n最终回复") == "最终回复"
+    # Multi-round tool loop: one thinking block per round, opening <think> often absent
+    # (server-side template pre-fill) — only the text after the last close tag survives
+    assert strip_inline_thinking("先想想A</think>再想想B</think>正式答复") == "正式答复"
+    # Dangling opener (stream cut mid-thinking) → drop the unclosed tail
+    assert strip_inline_thinking("正文<think>没写完的思考") == "正文"
+    # All-thinking reply collapses to empty (caller then sends the no-text receipt)
+    assert strip_inline_thinking("<think>只有思考") == ""
+    # No tags → untouched
+    assert strip_inline_thinking("普通回复") == "普通回复"
+    assert strip_inline_thinking("") == ""
+
+
+def test_collect_reply_strips_inline_thinking(monkeypatch):
+    """_collect_reply: content deltas carrying inline <think> spans (channel runs use
+    enable_thinking=True, so the streaming layer forwards them raw) must be stripped
+    before delivery; thinking events stay ignored as before."""
+    from core.channels import inbound as inbound_mod
+    from orchestration import chat_run_executor
+
+    events = [
+        {"type": "thinking", "delta": "结构化思考,本就不进正文"},
+        {"type": "content", "delta": "<think>内联思"},
+        {"type": "content", "delta": "考跨 delta</think>你好,"},
+        {"type": "content", "delta": "这是答复"},
+        {"type": "meta", "artifacts": [{"file_id": "f1"}]},
+    ]
+
+    async def _fake_follow(run_id):
+        for ev in events:
+            yield ev
+
+    monkeypatch.setattr(chat_run_executor, "follow_run", _fake_follow)
+    reply, artifacts = asyncio.run(inbound_mod._collect_reply("run_x"))
+    assert reply == "你好,这是答复"
+    assert artifacts == [{"file_id": "f1"}]
+
+
 def test_markdown_derive_title():
     from core.channels.markdown import derive_title
 


### PR DESCRIPTION
## Problem

Channel sessions run with `enable_thinking=true` (models tend to idle without it), and models without a structured reasoning channel — DeepSeek R1 style, or Qwen served behind a gateway without a reasoning parser — embed their chain of thought as `<think>...</think>` directly in the content stream.

The web UI parses these tags itself and renders them as collapsible thinking blocks, but IM channels (DingTalk / Feishu / WeChat / WeCom) have no such layer: `_collect_reply` accumulated content deltas verbatim and `_deliver_reply` only stripped `[ref:tool-N]` citation markers, so the raw reasoning was delivered to the channel as message text.

## Fix

- **`core/channels/markdown.py`**: add `strip_inline_thinking`, mirroring the frontend's parsing semantics (`segments.ts`): the answer body is whatever follows the **last** `</think>` (multi-round tool loops concatenate one thinking block per round, and the opening `<think>` is often absent due to server-side template pre-fill); a dangling unclosed `<think>` tail is dropped as well. Text without tags passes through untouched.
- **`core/channels/inbound.py`**: apply it in `_collect_reply` — the single exit point for all channel replies (webhook and long-connection alike). An all-thinking reply now collapses to empty and takes the existing "no text reply" receipt path instead of leaking a wall of reasoning.
- **`core/channels/outbound.py`**: apply it in `deliver_to_conversation` as a safety net for proactive delivery (automation currently runs with thinking disabled, so this is belt-and-braces).

Structured-reasoning models are unaffected: their thinking arrives as separate `thinking` events, which `_collect_reply` already ignores. The web streaming path is untouched — the frontend keeps receiving raw tags for its own collapsible rendering.

## Tests

- `test_markdown_strip_inline_thinking`: tag pairs, multi-round closes without openers, dangling opener, all-thinking collapse, no-tag passthrough, empty string
- `test_collect_reply_strips_inline_thinking`: end-to-end `_collect_reply` with cross-delta `<think>` spans, verifying thinking events stay ignored and artifacts pass through