### PR TITLE
Fix terminal replies for channel-bound agents

### DIFF
--- a/src/backend/core/channels/inbound.py
+++ b/src/backend/core/channels/inbound.py
@@ -39,6 +39,10 @@ _MAX_INBOUND_FILE_BYTES = 50 * 1024 * 1024
 _conv_locks: "defaultdict[str, asyncio.Lock]" = defaultdict(asyncio.Lock)
 
 
+class ChannelRunError(RuntimeError):
+    """A user-facing terminal error emitted by the shared chat-run stream."""
+
+
 def _conv_key(msg: "InboundMsg") -> str:
     return f"{msg.channel_id}:{msg.external_conversation_id}"
 
@@ -235,6 +239,9 @@ async def _collect_reply(run_id: str):
             arts = event.get("artifacts")
             if isinstance(arts, list):
                 artifacts = arts
+        elif et == "error":
+            detail = str(event.get("error") or event.get("delta") or "").strip()
+            raise ChannelRunError(detail or "请求处理失败，请稍后重试")
     return strip_inline_thinking(full).strip(), artifacts
 
 
@@ -282,18 +289,26 @@ async def _recall_placeholder(adapter, conn, msg: InboundMsg, placeholder_id: st
         logger.debug("[channels] 占位撤回异常", exc_info=True)
 
 
-async def _replace_placeholder(adapter, conn, msg: InboundMsg, placeholder_id: str, text: str) -> None:
-    """Replace the placeholder message with text: edit in place if editable; otherwise recall (if supported) + resend.
+async def _replace_placeholder(
+    adapter, conn, msg: InboundMsg, placeholder_id: Optional[str], text: str
+) -> None:
+    """Finish a placeholder flow with text, always sending a terminal message.
+
+    Edit in place when the channel returned a placeholder ID; otherwise recall
+    (if supported) and resend. WeChat's send API does not return a message ID, so
+    it must take the direct-send path instead of silently leaving the placeholder
+    as the last visible message.
 
     Error notices / "no text reply" receipts go through here — the old logic only edited,
     and since DingTalk edits always fail, users were stuck on "processing" forever with
     no follow-up ever shown."""
     edit = getattr(adapter, "edit_message", None)
-    if edit is not None:
+    if placeholder_id and edit is not None:
         r = await edit(conn, placeholder_id, text)
         if r.success:
             return
-    await _recall_placeholder(adapter, conn, msg, placeholder_id)
+    if placeholder_id:
+        await _recall_placeholder(adapter, conn, msg, placeholder_id)
     fr = await adapter.send_text(conn, msg, text)
     if not fr.success:
         logger.warning("[channels] 占位替换消息发送失败 kind=%s detail=%s", fr.error_kind, fr.error_detail)
@@ -512,13 +527,17 @@ async def _process_inbound(msg: InboundMsg) -> None:
             request_payload={"channel_id": msg.channel_id, "source": "channel"}, model_name=None,
         )
         reply, gen_artifacts = await _collect_reply(run.run_id)
-    except Exception:
+    except Exception as exc:
         logger.exception("[channels] inbound run 失败 channel_id=%s", msg.channel_id)
-        if placeholder_id:
-            try:
-                await _replace_placeholder(adapter, conn, msg, placeholder_id, "⚠️ 处理出错了，请稍后重试。")
-            except Exception:  # noqa: BLE001
-                pass
+        notice = (
+            str(exc).strip()
+            if isinstance(exc, ChannelRunError) and str(exc).strip()
+            else "处理出错了，请稍后重试。"
+        )
+        try:
+            await _replace_placeholder(adapter, conn, msg, placeholder_id, f"⚠️ {notice}")
+        except Exception:  # noqa: BLE001
+            logger.debug("[channels] 失败消息回推异常", exc_info=True)
         return
 
     # Note: the assistant reply is **not persisted here**. start_run's background executor
@@ -532,7 +551,7 @@ async def _process_inbound(msg: InboundMsg) -> None:
     try:
         if reply:
             await _deliver_reply(adapter, conn, msg, reply, placeholder_id)
-        elif placeholder_id:
+        else:
             note = "已为你生成文件。" if gen_artifacts else "（本次无文本回复）"
             await _replace_placeholder(adapter, conn, msg, placeholder_id, note)
         if getattr(adapter, "push_file", None):

--- a/src/backend/orchestration/workflow.py
+++ b/src/backend/orchestration/workflow.py
@@ -60,6 +60,39 @@ def _extract_project_ctx(context: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return {k: context.get(k) for k in _PROJECT_CTX_KEYS}
 
 
+def _resolve_agent_model_runtime(
+    agent: Any, fallback_model_name: Any = ""
+) -> Tuple[str, int]:
+    """Return the effective model name and context window baked into an agent.
+
+    AgentScope chat models expose the upstream name as ``.model``. Some provider
+    wrappers expose ``.model_name`` instead, so accept both before consulting the
+    request fallback. Channel runs intentionally omit a model selection; converting
+    that ``None`` to the literal string ``"None"`` previously made direct sub-agent
+    conversations fail context-window lookup even though the resolved main model was
+    correctly configured.
+    """
+    model = getattr(agent, "model", None)
+    state = getattr(agent, "state", None)
+    candidates = (
+        getattr(model, "model", None),
+        getattr(model, "model_name", None),
+        getattr(state, "model_name", None),
+        fallback_model_name,
+    )
+    model_name = ""
+    for candidate in candidates:
+        text = str(candidate or "").strip()
+        if text and text.lower() != "none":
+            model_name = text
+            break
+
+    context_window = int(getattr(model, "context_size", 0) or 0)
+    if context_window <= 0:
+        context_window = resolve_model_context_window(model_name)
+    return model_name, context_window
+
+
 def _extract_skill_id_from_path(path: str) -> str:
     """Extract skill_id from a SKILL.md path (convention: .../skills/<skill_id>/SKILL.md)."""
     if not path:
@@ -1116,6 +1149,10 @@ def run_chat_workflow(
             except Exception as exc:  # noqa: BLE001
                 logger.warning("[workflow] set agent.state failed: %s", exc)
 
+            _actual_model, _ctx_window = _resolve_agent_model_runtime(
+                agent, _workflow_model_name
+            )
+
             # PreTurn compaction safety net (symmetric with the streaming path
             # — both workflow entry points protect themselves, and future new
             # callers get it automatically). Zero overhead below the threshold.
@@ -1123,9 +1160,11 @@ def run_chat_workflow(
             try:
                 from core.services.compaction_service import maybe_run_pre_turn_compaction
 
-                _actual_model = getattr(agent.model, "model_name", _workflow_model_name)
                 _pt_messages, _ = await maybe_run_pre_turn_compaction(
-                    context.get("chat_id"), session_messages, model_name=_actual_model
+                    context.get("chat_id"),
+                    session_messages,
+                    model_name=_actual_model,
+                    context_window=_ctx_window,
                 )
             except Exception as _pt_exc:  # noqa: BLE001
                 logger.warning("[workflow] pre-turn compaction failed: %s", _pt_exc)
@@ -1135,7 +1174,9 @@ def run_chat_workflow(
             if history and history[-1].get("role") in ("user", "human"):
                 history.pop()
 
-            _ctx_mgr = ContextWindowManager.for_model(_workflow_model_name)
+            _ctx_mgr = ContextWindowManager(
+                ContextBudget(model_context_window=_ctx_window)
+            )
             history = _ctx_mgr.trim_history(history)
 
             if history:
@@ -1457,8 +1498,12 @@ async def _astream_subagent_direct(
         # checkpoint system of its own); over budget it is trimmed directly to
         # the token budget (layer-C compression of oversized user messages
         # still happens inside manage_context).
-        _actual_model = getattr(agent.model, "model_name", _stream_model_name)
-        ctx_manager = ContextWindowManager.for_model(_actual_model)
+        _actual_model, _ctx_window = _resolve_agent_model_runtime(
+            agent, _stream_model_name
+        )
+        ctx_manager = ContextWindowManager(
+            ContextBudget(model_context_window=_ctx_window)
+        )
         trimmed, dropped_messages = ctx_manager.manage_context(session_messages)
         if dropped_messages:
             logger.warning(
@@ -2288,10 +2333,9 @@ async def astream_chat_workflow(
         # object do we fall back to resolve — unconfigured raises, fail loud,
         # never silently run with the wrong window.
         # preturn and manage_context below share the same value.
-        _actual_model = getattr(agent.model, "model_name", _stream_model_name)
-        _ctx_window = int(getattr(agent.model, "context_size", 0) or 0)
-        if _ctx_window <= 0:
-            _ctx_window = resolve_model_context_window(_actual_model)
+        _actual_model, _ctx_window = _resolve_agent_model_runtime(
+            agent, _stream_model_name
+        )
         try:
             from core.services.compaction_service import maybe_run_pre_turn_compaction
 

--- a/src/backend/tests/orchestration/test_workflow_model_runtime.py
+++ b/src/backend/tests/orchestration/test_workflow_model_runtime.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+from orchestration import workflow
+
+
+def test_resolve_agent_model_runtime_prefers_baked_model_over_none_fallback():
+    agent = SimpleNamespace(
+        model=SimpleNamespace(model="deepseekv4-flash", context_size=393_216),
+        state=SimpleNamespace(model_name=""),
+    )
+
+    assert workflow._resolve_agent_model_runtime(agent, None) == (
+        "deepseekv4-flash",
+        393_216,
+    )
+
+
+def test_resolve_agent_model_runtime_supports_wrapper_name_and_window_lookup(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        workflow,
+        "resolve_model_context_window",
+        lambda model_name: seen.append(model_name) or 131_072,
+    )
+    agent = SimpleNamespace(
+        model=SimpleNamespace(model_name="qwen-max", context_size=0),
+        state=SimpleNamespace(model_name=""),
+    )
+
+    assert workflow._resolve_agent_model_runtime(agent, "None") == (
+        "qwen-max",
+        131_072,
+    )
+    assert seen == ["qwen-max"]

--- a/src/backend/tests/test_channel_bots.py
+++ b/src/backend/tests/test_channel_bots.py
@@ -727,6 +727,46 @@ def test_replace_placeholder_falls_back_to_recall_and_send():
     assert calls["recalled"] == ["pqk_ph"] and calls["sent"] == ["⚠️ 出错了"]
 
 
+def test_replace_placeholder_without_message_id_sends_terminal_notice_directly():
+    """WeChat returns no placeholder ID, but users must still receive the terminal message."""
+    from core.channels.inbound import _replace_placeholder
+
+    calls = {"edited": 0, "sent": []}
+
+    class _Adapter:
+        async def edit_message(self, conn, mid, text):
+            calls["edited"] += 1
+            return SendResult.fail("bad_format", "不支持")
+
+        async def send_text(self, conn, msg, text):
+            calls["sent"].append(text)
+            return SendResult.ok()
+
+    msg = InboundMsg(
+        channel_id="c",
+        channel_type="weixin",
+        text="",
+        chat_type="p2p",
+        external_conversation_id="wx-user",
+    )
+    asyncio.run(_replace_placeholder(_Adapter(), object(), msg, None, "⚠️ 处理失败"))
+    assert calls == {"edited": 0, "sent": ["⚠️ 处理失败"]}
+
+
+def test_collect_reply_raises_user_facing_stream_error(monkeypatch):
+    from core.channels.inbound import ChannelRunError, _collect_reply
+    from orchestration import chat_run_executor
+
+    async def _events():
+        yield {"type": "thinking", "delta": "内部思考"}
+        yield {"type": "error", "error": "模型暂时不可用"}
+
+    monkeypatch.setattr(chat_run_executor, "follow_run", lambda run_id: _events())
+
+    with pytest.raises(ChannelRunError, match="模型暂时不可用"):
+        asyncio.run(_collect_reply("run_failed"))
+
+
 # ── Channel markdown adaptation (core/channels/markdown.py) ───────────────
 def test_markdown_strip_citation_markers():
     from core.channels.markdown import strip_citation_markers


### PR DESCRIPTION
## Summary

- Always deliver a terminal channel message when the placeholder send does not return a message ID, as is the case for WeChat.
- Surface orchestration stream errors to channel users instead of leaving the processing placeholder as the last visible state.
- Resolve sub-agent model names and context windows from the constructed runtime model, avoiding the literal `None` fallback used by channel-triggered runs.

## Root cause

Channel placeholder replacement was gated on a returned message ID. WeChat can successfully send the processing notice without returning such an ID, so success, empty-output, and error paths could all finish without a visible terminal reply. Separately, channel runs intentionally omit an explicit model selection; direct sub-agent routing converted that missing value into `"None"` during context-window lookup even though the runtime agent already held the resolved model and context size.

## Impact

WeChat users now receive the final answer, a no-text receipt, or an explicit error after the processing notice. Channel-bound sub-agents also use the configured runtime model context and no longer fail because a missing request-level model was treated as a model name.

## Validation

- CE derivation brand, binary-asset, and license gates
- CE import, OpenAPI, and ORM self-checks
- CE release regression suite
- CE frontend production build with Node.js 22.23.2
- 27 targeted channel and direct sub-agent tests
- `git diff --check`
