### PR TITLE
feat(channels): group listening for IM bots + on-demand attachment fetch

### DIFF
--- a/src/backend/alembic/versions/ce_0005_add_group_listen_mode.py
+++ b/src/backend/alembic/versions/ce_0005_add_group_listen_mode.py
@@ -1,0 +1,60 @@
+"""Add channel_connections.group_listen_mode (group listening switch).
+
+Revision ID: ce_0005
+Revises: ce_0004
+Create Date: 2026-08-08
+
+Conditional on purpose. ``ce_0001`` builds the schema with ``ce_create_all`` straight from the
+SQLAlchemy models, so a **fresh** CE install already has this column by the time the chain
+reaches here — an unconditional ``add_column`` would fail on every new deployment. Only a CE
+database created before the column existed needs the ALTER.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ce_0005"
+down_revision = "ce_0004"
+branch_labels = None
+depends_on = None
+
+_TABLE = "channel_connections"
+_COLUMN = "group_listen_mode"
+
+
+def _columns(bind) -> set:
+    inspector = sa.inspect(bind)
+    if _TABLE not in inspector.get_table_names():
+        return set()
+    return {c["name"] for c in inspector.get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = _columns(bind)
+    if not existing or _COLUMN in existing:
+        return  # fresh install (already created by ce_create_all) or table absent
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN, sa.String(length=16), nullable=False, server_default="mention_only"
+        ),
+    )
+    # SQLite cannot add a CHECK constraint to an existing table; PostgreSQL can.
+    if bind.dialect.name != "sqlite":
+        op.create_check_constraint(
+            "channel_connections_group_listen_check",
+            _TABLE,
+            "group_listen_mode IN ('mention_only', 'observe_all')",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN not in _columns(bind):
+        return
+    if bind.dialect.name != "sqlite":
+        op.drop_constraint(
+            "channel_connections_group_listen_check", _TABLE, type_="check"
+        )
+    op.drop_column(_TABLE, _COLUMN)

--- a/src/backend/api/routes/v1/channels.py
+++ b/src/backend/api/routes/v1/channels.py
@@ -49,12 +49,17 @@ class CreateBotRequest(BaseModel):
     # messages are pinned to that sub-agent; omitted / null -> main agent (owner's default
     # capabilities); the "my bot" binding uses this path.
     agent_id: Optional[str] = Field(None, description="绑定的子智能体 ID；空 = 主智能体")
+    group_listen_mode: str = Field(
+        "mention_only",
+        description="群聊旁听：mention_only=仅处理 @ 机器人的消息；observe_all=旁观群内其他消息作为上下文（不回复）",
+    )
 
 
 class UpdateBotRequest(BaseModel):
     display_name: Optional[str] = Field(None, max_length=100)
     enabled: Optional[bool] = None
     resource_scope: Optional[_ResourceScope] = None
+    group_listen_mode: Optional[str] = Field(None, description="群聊旁听模式；不传 = 不改")
     # Rebind only when this key is explicitly passed (including passing null to unbind);
     # untouched if omitted. Distinguished via model_fields_set.
     agent_id: Optional[str] = Field(None, description="改绑的子智能体 ID；null = 解绑回主智能体")
@@ -66,6 +71,7 @@ def _caps_to_dict(caps: ChannelCaps) -> Dict[str, Any]:
         "max_message_len": caps.max_message_len,
         "supports_markdown": caps.supports_markdown,
         "supports_long_conn": caps.supports_long_conn,
+        "supports_group_observe": getattr(caps, "supports_group_observe", False),
         "bind_mode": getattr(caps, "bind_mode", "credentials"),
         "credential_fields": list(getattr(caps, "credential_fields", ("app_id", "app_secret"))),
     }
@@ -127,6 +133,7 @@ async def create_bot(
         transport=body.transport,
         resource_scope=body.resource_scope.model_dump() if body.resource_scope else None,
         agent_id=body.agent_id,
+        group_listen_mode=body.group_listen_mode,
     )
     data = bot_to_dict(conn)
     # In webhook mode, echo back the callback address for the user to fill into the channel backend.
@@ -152,6 +159,7 @@ async def update_bot(
         resource_scope_set=body.resource_scope is not None,
         agent_id=body.agent_id,
         agent_id_set="agent_id" in body.model_fields_set,
+        group_listen_mode=body.group_listen_mode,
     )
     return success_response(data=bot_to_dict(conn))
 

--- a/src/backend/core/channels/adapters/dingtalk.py
+++ b/src/backend/core/channels/adapters/dingtalk.py
@@ -69,6 +69,11 @@ class DingTalkAdapter:
         supports_markdown=True,
         splits_long_messages=False,
         supports_long_conn=True,
+        # DingTalk exposes ``isInAtList`` on every bot callback, so the gate is already
+        # wired; whether non-@ group messages ever get delivered depends on the tenant
+        # holding DingTalk's group-message read permission (applied for and reviewed on the
+        # open platform). Without it, group listening stays inert rather than broken.
+        supports_group_observe=True,
         bind_mode="credentials",
         credential_fields=("app_id", "app_secret"),
     )
@@ -118,7 +123,8 @@ class DingTalkAdapter:
             # Rich text: concatenate the plain-text nodes inside
             parts = (payload.get("content") or {}).get("richText") or []
             text = " ".join(p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")).strip()
-        if not text:
+        attachments = self._extract_attachments(msgtype, payload)
+        if not text and not attachments:
             return None
         conv_type = str(payload.get("conversationType") or "1")
         chat_type = "group" if conv_type == "2" else "p2p"
@@ -132,12 +138,109 @@ class DingTalkAdapter:
             sender_id=payload.get("senderStaffId") or payload.get("senderId") or "",
             sender_name=payload.get("senderNick") or "",
             message_id=payload.get("msgId") or "",
-            attachments=[],
+            attachments=attachments,
+            # ``isInAtList`` is DingTalk's own "was the bot in the @ list" flag. With only the
+            # default permission DingTalk delivers @bot messages exclusively, so this is
+            # always true and the gate is a no-op; once the tenant is granted group-message
+            # read, non-@ messages start arriving with it false and silent observation kicks
+            # in with no further code change. Absent field → treat as addressed.
+            addressed_to_bot=(
+                True if chat_type == "p2p" else bool(payload.get("isInAtList", True))
+            ),
             raw={
                 "dingtalk_session_webhook": payload.get("sessionWebhook") or "",
                 "dingtalk_conversation_id": conv_id,
+                # Needed by download_resource: messageFiles/download requires robotCode, and
+                # per DingTalk's docs it is **not** the AppKey — the only reliable source is
+                # this field on the callback payload (present in Stream mode, which is what
+                # the long connection uses).
+                "dingtalk_robot_code": payload.get("robotCode") or "",
             },
         )
+
+    # ── Inbound attachments ─────────────────────────────────────────────
+    @staticmethod
+    def _extract_attachments(msgtype: str, payload: Dict[str, Any]) -> list:
+        """Message → attachment list. ``key`` carries DingTalk's ``downloadCode``.
+
+        Content layout per DingTalk's "received message types" reference:
+          picture  → {pictureDownloadCode, downloadCode}
+          file     → {spaceId, fileName, downloadCode, fileId}
+          audio    → {downloadCode, recognition}
+          video    → {duration, videoType, downloadCode}
+          richText → {richText: [ ...nodes, image nodes carry downloadCode... ]}
+        Everything is read defensively (``downloadCode`` looked up in more than one place)
+        because these payloads are only loosely specified and vary by client version — a
+        missing field must degrade to "no attachment", never raise and kill the connection.
+        """
+        content = payload.get("content") if isinstance(payload.get("content"), dict) else {}
+        out: list = []
+
+        def _add(kind: str, code: Any, name: str) -> None:
+            if code:
+                out.append({"kind": kind, "key": str(code), "name": name})
+
+        if msgtype == "picture":
+            code = content.get("downloadCode") or content.get("pictureDownloadCode")
+            _add("image", code, f"dingtalk_image_{payload.get('msgId', '')[:8] or 'x'}.png")
+        elif msgtype == "file":
+            _add("file", content.get("downloadCode"), content.get("fileName") or "file.bin")
+        elif msgtype == "audio":
+            _add("file", content.get("downloadCode"), "dingtalk_audio.amr")
+        elif msgtype == "video":
+            _add("file", content.get("downloadCode"), "dingtalk_video.mp4")
+        elif msgtype == "richText":
+            for i, node in enumerate(content.get("richText") or []):
+                if not isinstance(node, dict):
+                    continue
+                code = node.get("downloadCode") or node.get("pictureDownloadCode")
+                _add("image", code, f"dingtalk_richtext_{i}.png")
+        return out
+
+    async def download_resource(
+        self, conn: Any, inbound: InboundMsg, attachment: Dict[str, Any]
+    ) -> Optional[bytes]:
+        """Download an inbound attachment: downloadCode → temporary downloadUrl → bytes.
+
+        Two hops, per DingTalk's design:
+          POST /v1.0/robot/messageFiles/download {downloadCode, robotCode} → {downloadUrl}
+          GET  downloadUrl → bytes
+        The temporary URL serves the file with a ``.file`` extension; we ignore that and keep
+        the filename taken from the message, so the artifact keeps its real extension.
+        Download codes expire, so a deferred fetch can legitimately fail — returning None
+        (rather than raising) lets the caller degrade to "attachment unavailable".
+        """
+        code = attachment.get("key")
+        robot_code = (inbound.raw or {}).get("dingtalk_robot_code") or ""
+        if not code:
+            return None
+        if not robot_code:
+            logger.warning("[dingtalk] 缺少 robotCode，无法下载附件 code=%s", str(code)[:12])
+            return None
+        try:
+            token = await self._access_token(conn.app_id, self._app_secret(conn))
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    f"{DINGTALK_API_BASE}/v1.0/robot/messageFiles/download",
+                    headers={"x-acs-dingtalk-access-token": token},
+                    json={"downloadCode": code, "robotCode": robot_code},
+                )
+                if resp.status_code != 200:
+                    logger.warning(
+                        "[dingtalk] 下载地址获取失败 status=%s body=%s",
+                        resp.status_code, resp.text[:200],
+                    )
+                    return None
+                url = (resp.json() or {}).get("downloadUrl")
+                if not url:
+                    return None
+                fr = await client.get(url)
+            if fr.status_code == 200:
+                return fr.content
+            logger.warning("[dingtalk] 附件下载失败 status=%s", fr.status_code)
+        except Exception:  # noqa: BLE001
+            logger.exception("[dingtalk] 附件下载异常 code=%s", str(code)[:12])
+        return None
 
     # ── Outbound push (via sessionWebhook, no access_token needed) ───────
     @staticmethod

--- a/src/backend/core/channels/adapters/lark.py
+++ b/src/backend/core/channels/adapters/lark.py
@@ -29,7 +29,7 @@ import os
 import re
 import threading
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 
@@ -94,10 +94,21 @@ class LarkAdapter:
         supports_markdown=False,     # uses text messages; rich text (post) left for later
         splits_long_messages=False,
         supports_long_conn=True,
+        # Feishu gates group delivery with three mutually distinct scopes:
+        #   im:message.group_at_msg                        → only messages @-ing this bot
+        #   im:message.group_at_msg.include_bot:readonly   → messages @-ing any bot
+        #   im:message.group_msg (sensitive)               → every group message
+        # Group listening needs the last one, plus republishing the app version; with the
+        # others Feishu never pushes a non-@ message and observe_all stays inert. Note the
+        # @-gate is worth running under the middle scope too: it stops us answering a message
+        # that @'d somebody else's bot.
+        supports_group_observe=True,
     )
 
     # tenant_access_token cache: {app_id: (token, expire_epoch)}
     _token_cache: Dict[str, tuple] = {}
+    # The bot's own open_id: {app_id: open_id}. Stable per app → cached without expiry.
+    _bot_id_cache: Dict[str, str] = {}
 
     # ── Credentials ─────────────────────────────────────────────────────
     @staticmethod
@@ -201,8 +212,27 @@ class LarkAdapter:
             sender_open_id=sender_open_id,
             sender_name=(sender.get("sender_id") or {}).get("user_id", "") or "",
             attachments=attachments,
+            mentioned_ids=self._mentioned_ids(message),
             raw=payload,
         )
+
+    @staticmethod
+    def _mentioned_ids(message: Dict[str, Any]) -> List[str]:
+        """open_ids of everyone @'d in this message (``message.mentions``).
+
+        Only relevant once the app holds ``im:message.group_msg`` and Feishu starts pushing
+        non-@ group messages too — until then every delivered group message has the bot in
+        here anyway. The bot's own open_id is not known synchronously, so matching happens
+        later in ``resolve_addressed``.
+        """
+        out: List[str] = []
+        for m in message.get("mentions") or []:
+            if not isinstance(m, dict):
+                continue
+            oid = (m.get("id") or {}).get("open_id") if isinstance(m.get("id"), dict) else None
+            if oid:
+                out.append(oid)
+        return out
 
     @staticmethod
     def _strip_mentions(text: str) -> str:
@@ -277,7 +307,7 @@ class LarkAdapter:
     def _make_inbound(
         *, conn: Any, chat_id: str, chat_type: str, message_id: str,
         text: str, sender_open_id: str, sender_name: str,
-        raw: Dict[str, Any], attachments=None,
+        raw: Dict[str, Any], attachments=None, mentioned_ids=None,
     ) -> InboundMsg:
         return InboundMsg(
             channel_id=conn.channel_id,
@@ -289,8 +319,50 @@ class LarkAdapter:
             sender_name=sender_name,
             message_id=message_id,
             attachments=attachments or [],
+            # p2p is always aimed at the bot; in a group it depends on whether the bot's own
+            # open_id is in the mention list — resolved asynchronously in resolve_addressed.
+            addressed_to_bot=True if chat_type == "p2p" else None,
+            mentioned_ids=list(mentioned_ids or []),
             raw={"lark_chat_id": chat_id, "lark_message_id": message_id},
         )
+
+    # ── Group listening: is this group message @'ing the bot? ───────────
+    async def resolve_addressed(self, conn: Any, inbound: InboundMsg) -> bool:
+        """True when the bot's own open_id appears in the message's mention list.
+
+        Fails open (True) whenever the bot identity cannot be fetched, so a transient
+        ``bot/v3/info`` failure degrades to today's behavior (answer everything delivered)
+        rather than making the bot go mute in the group.
+        """
+        try:
+            bot_open_id = await self._bot_open_id(conn)
+        except Exception:  # noqa: BLE001
+            logger.debug("[lark] 机器人 open_id 获取失败，按「已被 @」处理", exc_info=True)
+            return True
+        if not bot_open_id:
+            return True
+        return bot_open_id in (inbound.mentioned_ids or [])
+
+    async def _bot_open_id(self, conn: Any) -> str:
+        """The bot's own open_id (``/open-apis/bot/v3/info``), cached per app_id.
+
+        Feishu never puts the bot identity in the event payload, so it has to be fetched once
+        and kept. The value is stable for the lifetime of the app, hence a plain process cache
+        with no expiry (a restart just re-fetches).
+        """
+        cached = self._bot_id_cache.get(conn.app_id)
+        if cached:
+            return cached
+        token = await self._tenant_token(conn.app_id, self._app_secret(conn))
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                f"{LARK_API_BASE}/open-apis/bot/v3/info",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        open_id = ((resp.json() or {}).get("bot") or {}).get("open_id") or ""
+        if open_id:
+            self._bot_id_cache[conn.app_id] = open_id
+        return open_id
 
     # ── Outbound push ───────────────────────────────────────────────────
     def _chat_id(self, inbound: InboundMsg) -> str:
@@ -504,5 +576,21 @@ class LarkAdapter:
             sender_open_id=open_id or "",
             sender_name="",
             attachments=attachments,
+            mentioned_ids=self._sdk_mentioned_ids(message),
             raw={},
         )
+
+    @staticmethod
+    def _sdk_mentioned_ids(message: Any) -> List[str]:
+        """SDK-typed counterpart of ``_mentioned_ids`` (``MentionEvent.id.open_id``).
+
+        The long connection is the production path, so mention extraction must exist on both
+        sides; missing it here would make every group message look un-@'d.
+        """
+        out: List[str] = []
+        for m in getattr(message, "mentions", None) or []:
+            ident = getattr(m, "id", None)
+            oid = getattr(ident, "open_id", "") if ident is not None else ""
+            if oid:
+                out.append(oid)
+        return out

--- a/src/backend/core/channels/inbound.py
+++ b/src/backend/core/channels/inbound.py
@@ -276,6 +276,152 @@ def _speaker_label(msg: InboundMsg) -> str:
     return (msg.sender_name or (msg.sender_id or "")[-6:] or "用户")
 
 
+# ── Group listening (observe_all): bystander messages as background context ──────────────
+# Cap on the buffered bystander messages carried into the next @bot turn. A busy group can
+# produce hundreds of messages between two @s; without a cap the buffer would blow up both the
+# JSON column and the prompt. Oldest entries are evicted first — recent context is what matters.
+_OBSERVE_MAX = 60
+# Per-message truncation. Long pasted blocks are background material, not the task.
+_OBSERVE_TEXT_MAX = 500
+# Cap on the lazy-fetch file index. Larger than _OBSERVE_MAX because a file stays worth
+# opening long after the chatter around it scrolled out of the message buffer.
+_OBSERVE_FILE_INDEX_MAX = 100
+
+
+async def _resolve_addressed(adapter, conn: ChannelConnection, msg: InboundMsg) -> bool:
+    """Is this message aimed at the bot? Adapters that cannot decide synchronously defer here.
+
+    Fails open (True) on any resolver error or when the adapter has no resolver at all, so
+    channels that never learned about group listening (WeCom / WeChat) keep behaving exactly
+    as before.
+    """
+    if msg.addressed_to_bot is not None:
+        return bool(msg.addressed_to_bot)
+    resolver = getattr(adapter, "resolve_addressed", None)
+    if resolver is None:
+        return True
+    try:
+        return bool(await resolver(conn, msg))
+    except Exception:  # noqa: BLE001
+        logger.debug("[channels] @ 判定失败，按「已被 @」处理 channel_id=%s", conn.channel_id, exc_info=True)
+        return True
+
+
+def _observe_text(msg: InboundMsg) -> str:
+    """The bystander message's own text, truncated. Attachments are handled separately."""
+    text = (msg.text or "").strip()
+    if len(text) > _OBSERVE_TEXT_MAX:
+        text = text[:_OBSERVE_TEXT_MAX] + "…"
+    return text
+
+
+def _observe_attachment_refs(msg: InboundMsg) -> List[Dict[str, Any]]:
+    """Attachment handles for a bystander message — recorded, never downloaded.
+
+    Eagerly downloading everything a group shares would pull the whole group's file traffic
+    into our storage: large I/O and a far wider privacy footprint than reading text. But
+    *discarding the key* (the earlier behavior) left the agent able to see that a file existed
+    while being unable to ever open it. Keeping the key costs nothing and turns this into
+    lazy loading: the model asks for a file by key via ``channel_read_attachment`` only when
+    it decides the file matters.
+    """
+    return [
+        {"kind": a.get("kind") or "file", "key": a.get("key") or "", "name": a.get("name") or ""}
+        for a in (msg.attachments or [])
+        if a.get("key")
+    ]
+
+
+def _observe_message(db, conn: ChannelConnection, msg: InboundMsg) -> None:
+    """Record a bystander group message into the session's observation buffer. No agent run, no reply.
+
+    The buffer lives in ``ChatSession.extra_data`` rather than being written as real session
+    messages, for three reasons: it stays bounded (a quiet group can't inflate history), it
+    avoids long runs of consecutive user-role turns in the model's message list, and draining
+    it into the triggering turn keeps the group log in one coherent block instead of scattered
+    fragments.
+    """
+    text = _observe_text(msg)
+    refs = _observe_attachment_refs(msg)
+    if not text and not refs:
+        return
+    session = _find_or_create_session(db, conn, msg)
+    meta = dict(session.extra_data or {})
+
+    entry: Dict[str, Any] = {"n": _speaker_label(msg), "t": text}
+    if refs:
+        entry["a"] = refs
+    buf = list(meta.get("observed") or [])
+    buf.append(entry)
+    meta["observed"] = buf[-_OBSERVE_MAX:]
+
+    if refs:
+        # Separate, longer-lived index than the message buffer: the buffer is drained into a
+        # prompt on the next @, but the model may only decide to open a file several turns
+        # later. Keyed by attachment key, it stores what the adapter needs to fetch the bytes
+        # (Lark resolves resources by message_id, DingTalk by the robotCode in raw) so none of
+        # that plumbing has to appear in the prompt.
+        index = dict(meta.get("observed_files") or {})
+        for ref in refs:
+            index.pop(ref["key"], None)  # re-insert so recency ordering stays correct
+            index[ref["key"]] = {
+                "name": ref["name"], "kind": ref["kind"],
+                "message_id": msg.message_id, "raw": dict(msg.raw or {}),
+            }
+        while len(index) > _OBSERVE_FILE_INDEX_MAX:
+            index.pop(next(iter(index)))
+        meta["observed_files"] = index
+
+    session.extra_data = meta  # reassign: in-place JSON mutation is not change-tracked
+    db.commit()
+
+
+def _drain_observed(db, session: ChatSession) -> List[Dict[str, Any]]:
+    """Take and clear the observation buffer (it is folded into the turn being started)."""
+    meta = dict(session.extra_data or {})
+    buf = list(meta.get("observed") or [])
+    if not buf:
+        return []
+    meta["observed"] = []
+    session.extra_data = meta
+    db.commit()
+    return buf
+
+
+def _render_observed_line(item: Dict[str, Any]) -> str:
+    """One group-log line: ``speaker：text [文件：name｜key=…]``.
+
+    Attachment keys are rendered inline so the model can pass one straight to
+    ``channel_read_attachment``. The files themselves were never downloaded — the key is the
+    only handle that exists, which is exactly why it has to reach the prompt.
+    """
+    parts = [item.get("t") or ""]
+    for ref in item.get("a") or []:
+        label = "图片" if ref.get("kind") == "image" else "文件"
+        parts.append(f"[{label}：{ref.get('name') or '未命名'}｜key={ref.get('key')}]")
+    return f"{item.get('n', '用户')}：{' '.join(p for p in parts if p)}"
+
+
+def _render_observed_block(items: List[Dict[str, Any]]) -> str:
+    """Render the buffer as a context preamble for the triggering message.
+
+    Explicitly labelled as background and marked do-not-reply, otherwise the model treats the
+    group log as a list of pending requests and tries to answer every line.
+    """
+    lines = "\n".join(_render_observed_line(it) for it in items)
+    hint = (
+        "\n（其中带 key= 的文件并未下载，只有句柄。确有需要时用 "
+        "channel_read_attachment(file_key=\"…\") 取回再读，不要凭文件名臆测内容。）"
+        if any(it.get("a") for it in items) else ""
+    )
+    return (
+        "【群聊上下文】以下是你被 @ 之前群里的近期对话，仅供你理解背景，"
+        "不要逐条回复，也不要在回复中复述：\n"
+        f"{lines}{hint}\n"
+        "【以下才是本次需要你处理的消息】\n"
+    )
+
+
 async def _recall_placeholder(adapter, conn, msg: InboundMsg, placeholder_id: str) -> None:
     """Recall the placeholder message (best-effort): channels that can't edit but can recall (DingTalk) use "recall + resend" as an equivalent replacement."""
     recall = getattr(adapter, "recall_message", None)
@@ -382,6 +528,18 @@ async def _process_inbound(msg: InboundMsg) -> None:
         adapter = get_adapter(conn.channel_type)
         _ = conn.config  # force-load the credential column so it remains usable after detaching
 
+        # Group listening gate. Only reached at all when the platform actually delivers non-@
+        # group messages (needs the channel app's "read all group messages" permission);
+        # otherwise every inbound group message is an @ and this is a no-op.
+        if msg.chat_type == "group" and not await _resolve_addressed(adapter, conn, msg):
+            if conn.group_listen_mode == "observe_all":
+                _observe_message(db, conn, msg)
+                repo.touch_event(conn.channel_id)  # bystander traffic still proves the connection is alive
+            # mention_only → drop entirely, exactly as before this feature existed.
+            # Either way: no reset-command handling, no run, no placeholder, no reply.
+            db.close()
+            return
+
         # Channel-side "new conversation / clear context": soft-deleting the current session is
         # enough (the next message automatically creates an empty session); no agent run. This is
         # where /new and clear-context actually take effect in Feishu and other clients —
@@ -414,6 +572,13 @@ async def _process_inbound(msg: InboundMsg) -> None:
         # #5 Label the speaker in group scenarios so the agent can tell multi-person conversations apart
         if msg.chat_type == "group":
             user_text = f"{_speaker_label(msg)}：{user_text}"
+            # observe_all: prepend everything the group said since the last @ as background.
+            # Prepending into user_text (rather than a separate context field) means it is
+            # persisted with the turn, so later turns still see the group log through normal
+            # history loading and compaction — no second retention mechanism to maintain.
+            observed = _drain_observed(db, session)
+            if observed:
+                user_text = _render_observed_block(observed) + user_text
 
         session_messages = _load_history(db, chat_id, owner_id)
         session_messages.append({"role": "user", "content": user_text})

--- a/src/backend/core/channels/inbound.py
+++ b/src/backend/core/channels/inbound.py
@@ -535,7 +535,21 @@ async def _process_inbound(msg: InboundMsg) -> None:
             if conn.group_listen_mode == "observe_all":
                 _observe_message(db, conn, msg)
                 repo.touch_event(conn.channel_id)  # bystander traffic still proves the connection is alive
-            # mention_only → drop entirely, exactly as before this feature existed.
+                logger.info(
+                    "[channels] 旁听群消息 channel_id=%s type=%s conv=%s",
+                    conn.channel_id, conn.channel_type, msg.external_conversation_id,
+                )
+            else:
+                # mention_only → drop entirely, exactly as before this feature existed.
+                # Logged because reaching this line at all is the *only* evidence that the
+                # platform is delivering non-@ group messages (i.e. that the "read all group
+                # messages" permission is actually granted). Without it, "the bot ignores the
+                # group" and "the platform never sends the group" look identical from outside.
+                # DEBUG, not INFO: an active group would otherwise flood the log.
+                logger.debug(
+                    "[channels] 丢弃未 @ 的群消息（旁听未开启）channel_id=%s type=%s",
+                    conn.channel_id, conn.channel_type,
+                )
             # Either way: no reset-command handling, no run, no placeholder, no reply.
             db.close()
             return

--- a/src/backend/core/channels/protocol.py
+++ b/src/backend/core/channels/protocol.py
@@ -29,6 +29,12 @@ class ChannelCaps:
     splits_long_messages: bool = False
     # Whether a backend-resident long connection (WebSocket / long polling) is supported. False = webhook only.
     supports_long_conn: bool = True
+    # Whether the channel can deliver group messages that do **not** @ the bot (so "silent
+    # observation" is meaningful). Only true where the platform offers such a permission
+    # (Lark ``im:message.group_msg`` / DingTalk group-message read). The frontend uses this to
+    # decide whether to offer the group-listening switch at all — without the flag the switch
+    # would be a lie, since the platform never pushes the messages in the first place.
+    supports_group_observe: bool = False
     # Bind mode: 'credentials' (fill in an App ID/Secret form) | 'qr' (QR-scan device flow, e.g. WeChat iLink).
     # The frontend uses this to decide between showing a credential form or a QR button — avoiding "if channel name" in the frontend.
     bind_mode: str = "credentials"
@@ -61,6 +67,20 @@ class InboundMsg:
     sender_id: str = ""                   # speaker open_id (audit only, not resolved to a platform account)
     sender_name: str = ""                 # speaker nickname (audit)
     message_id: str = ""                  # channel-side message ID (idempotent dedup)
+    # Is this message directed at the bot (p2p, or an @bot in a group)?
+    #   True  → run the agent and reply
+    #   False → a bystander group message; only meaningful when the channel is in
+    #           ``observe_all`` group-listening mode, where it is recorded as context and
+    #           **never** replied to
+    #   None  → the adapter cannot decide synchronously (Lark needs the bot's own open_id,
+    #           which requires an API call); inbound orchestration resolves it via the
+    #           adapter's optional ``resolve_addressed`` hook, defaulting to True.
+    # Default None + a True-defaulting resolver keeps channels that never learned about this
+    # field (WeCom / WeChat) behaving exactly as before.
+    addressed_to_bot: Optional[bool] = None
+    # Platform IDs mentioned in this message (Lark open_id, etc.). Only populated when the
+    # adapter defers the decision; ``resolve_addressed`` matches the bot's own ID against it.
+    mentioned_ids: List[str] = field(default_factory=list)
     # Inbound attachments (files/images): each item {kind: 'file'|'image', key: <resource key>, name: <filename>}.
     # Parsed by the adapter; inbound orchestration downloads from it → stores an Artifact → injects into uploaded_files for the agent to read.
     attachments: List[Dict[str, Any]] = field(default_factory=list)
@@ -147,6 +167,17 @@ class ChannelAdapter(Protocol):
 
     async def validate_credentials(self, conn: Any) -> Dict[str, Any]:
         """Validate credentials at bind time (exchange for an access_token, etc.); returns a bot identity summary. Raises on failure."""
+        ...
+
+    # ── Group listening (optional; only channels that defer the @-decision implement this) ──
+    async def resolve_addressed(self, conn: Any, inbound: InboundMsg) -> bool:
+        """Decide whether a group message with ``addressed_to_bot is None`` is aimed at the bot.
+
+        Implemented by channels that need an API call to learn their own bot identity (Lark:
+        the bot's open_id, matched against ``inbound.mentioned_ids``). Must **fail open**
+        (return True) when the identity cannot be determined — a bot that answers a message it
+        was not @'d in is a far smaller failure than one that silently ignores a direct @.
+        """
         ...
 
     # ── Files (optional; channels without file support may skip these — inbound orchestration checks hasattr) ──────

--- a/src/backend/core/db/models/identity.py
+++ b/src/backend/core/db/models/identity.py
@@ -393,6 +393,18 @@ class ChannelConnection(Base):
     agent_id = Column(
         String(64), ForeignKey("user_agents.agent_id", ondelete="SET NULL"), nullable=True
     )
+    # Group listening: how much of a group conversation the bot may see.
+    #   mention_only (default) — only messages that @ the bot; anything else is dropped.
+    #   observe_all            — bystander group messages are recorded as background context
+    #                            (never replied to) and folded into the next @bot turn.
+    # observe_all is inert unless the channel app also holds the platform's "read all group
+    # messages" permission (Lark ``im:message.group_msg`` / DingTalk group-message read) —
+    # without it the platform never delivers non-@ messages in the first place.
+    # Defaults to mention_only because observing a whole group's chatter is privacy-sensitive
+    # and must be an explicit, per-bot decision by the owner.
+    group_listen_mode = Column(
+        String(16), nullable=False, default="mention_only", server_default="mention_only"
+    )
     # disconnected (default / disconnected) | pending (verifying) | connected | error
     status = Column(String(16), nullable=False, default="pending")
     enabled = Column(Boolean, nullable=False, default=True)
@@ -409,6 +421,10 @@ class ChannelConnection(Base):
         CheckConstraint(
             "transport IN ('long_conn', 'webhook')",
             name="channel_connections_transport_check",
+        ),
+        CheckConstraint(
+            "group_listen_mode IN ('mention_only', 'observe_all')",
+            name="channel_connections_group_listen_check",
         ),
         # token lock: within the same channel, the same app can only be bound once (prevents multiple people grabbing the same bot credentials)
         UniqueConstraint("channel_type", "app_id", name="uq_channel_connections_type_app"),

--- a/src/backend/core/llm/agent_factory.py
+++ b/src/backend/core/llm/agent_factory.py
@@ -41,6 +41,7 @@ from core.llm.tools import (
     register_bash,
     register_delete,
     register_edit,
+    register_channel_attachment,
     register_get_data_context,
     register_glob,
     register_grep,
@@ -1145,6 +1146,13 @@ async def create_agent_executor(
         # Unconditional: any user may have uploaded files in prior turns of this chat,
         # and the hook injects historical-file summaries referencing this tool.
         register_read_artifact(toolkit, user_id=current_user_id)
+
+        # ── Phase 3.7b: channel_read_attachment (channel runs only) ──
+        # Group listening records bystander attachments by key without downloading them;
+        # this is how the agent pulls one in on demand. Gated on channel runs so the tool
+        # never clutters the toolkit of web conversations, where it could never resolve.
+        if _is_channel_run:
+            register_channel_attachment(toolkit, user_id=current_user_id, chat_id=chat_id)
 
         # ── Phase 3.8: Register pin_to_workspace ──
         # Lets the agent gate which generated files reach the user-visible

--- a/src/backend/core/llm/tools/__init__.py
+++ b/src/backend/core/llm/tools/__init__.py
@@ -28,6 +28,7 @@ from .sandbox_tool import (
 from .skill_tool import (
     register_sandboxed_view_text_file,
 )
+from .channel_attachment_tool import register_channel_attachment
 from .myspace_tool import register_myspace_tools
 from .pin_tool import register_pin_to_workspace
 from .read_artifact_tool import register_read_artifact
@@ -37,6 +38,7 @@ __all__ = [
     "ReadEntry",
     "ReadStateTracker",
     "register_bash",
+    "register_channel_attachment",
     "register_get_data_context",
     "register_delete",
     "register_edit",

--- a/src/backend/core/llm/tools/channel_attachment_tool.py
+++ b/src/backend/core/llm/tools/channel_attachment_tool.py
@@ -1,0 +1,166 @@
+"""channel_read_attachment tool — lazily fetch a file seen in group listening.
+
+Group listening (``core/channels/inbound.py``) records bystander messages as background
+context but deliberately does **not** download their attachments: eagerly pulling every file
+a group shares would mean large I/O and a much wider privacy footprint than reading text.
+What it does keep is the attachment **key** plus whatever the adapter needs to resolve it,
+in ``ChatSession.extra_data['observed_files']``.
+
+This tool closes that loop: the model sees ``[文件：Q3财报.xlsx｜key=…]`` in the group log and
+calls here only when it decides the file actually matters. The bytes are fetched through the
+same channel adapter used for @-message attachments, stored as a normal Artifact, and the
+returned ``file_id`` is then read with ``read_artifact`` — so downstream file handling has
+exactly one code path.
+
+Registered only for channel runs (see agent_factory's ``_is_channel_run``).
+"""
+
+import json
+import logging
+import mimetypes
+from typing import Any, Dict, Optional
+
+from agentscope.message import TextBlock
+from agentscope.tool import Toolkit
+from agentscope.tool._response import ToolChunk as ToolResponse
+
+logger = logging.getLogger(__name__)
+
+# Same ceiling as inbound attachment ingestion and /v1/file/upload.
+_MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024
+
+
+def _err(msg: str) -> ToolResponse:
+    return ToolResponse(content=[TextBlock(
+        type="text", text=json.dumps({"error": msg}, ensure_ascii=False),
+    )])
+
+
+def _lookup(db, chat_id: str, user_id: Optional[str], file_key: str):
+    """Resolve (session, channel connection, index entry) or return an error string."""
+    from core.db.models import ChannelConnection, ChatSession
+
+    session = (
+        db.query(ChatSession)
+        .filter(ChatSession.chat_id == chat_id, ChatSession.deleted_at.is_(None))
+        .first()
+    )
+    if session is None:
+        return None, None, None, "当前会话不存在"
+    # The channel bot runs as its owner, so the session must belong to the calling identity.
+    # Without this check a leaked chat_id would let one user pull another's group files.
+    if user_id and str(session.user_id) != str(user_id):
+        return None, None, None, "无权访问该会话"
+    entry = ((session.extra_data or {}).get("observed_files") or {}).get(file_key)
+    if not entry:
+        return None, None, None, (
+            f"未找到 file_key={file_key} 对应的群聊附件；"
+            "只有旁听记录里带 key= 的文件可以取回，且过旧的记录会被淘汰"
+        )
+    if not session.channel_id:
+        return None, None, None, "当前会话不是渠道会话"
+    conn = (
+        db.query(ChannelConnection)
+        .filter(ChannelConnection.channel_id == session.channel_id)
+        .first()
+    )
+    if conn is None or not conn.enabled:
+        return None, None, None, "渠道连接不存在或已停用"
+    return session, conn, entry, None
+
+
+def _rebuild_inbound(conn, session, entry: Dict[str, Any]):
+    """Minimal InboundMsg carrying just what ``download_resource`` reads.
+
+    Lark resolves message resources by ``message_id``; DingTalk needs the ``robotCode`` kept
+    in ``raw``. Both were captured at observation time, so no channel-specific branching is
+    needed here.
+    """
+    from core.channels.protocol import InboundMsg
+
+    return InboundMsg(
+        channel_id=conn.channel_id,
+        channel_type=conn.channel_type,
+        text="",
+        chat_type="group",
+        external_conversation_id=session.external_conversation_id or "",
+        message_id=entry.get("message_id") or "",
+        raw=dict(entry.get("raw") or {}),
+    )
+
+
+def register_channel_attachment(
+    toolkit: Toolkit, user_id: Optional[str] = None, chat_id: Optional[str] = None
+) -> None:
+    """Register ``channel_read_attachment`` for channel (IM bot) runs."""
+
+    async def channel_read_attachment(file_key: str) -> ToolResponse:
+        """按 key 取回群聊里出现过但尚未下载的文件（图片 / 文档 / 表格等）。
+
+        群聊旁听只记录了文件的**句柄**，没有下载内容。当你判断某个文件与当前问题
+        相关时，用本工具按 key 取回；取回后会得到 `file_id`，再用 `read_artifact`
+        读取正文。
+
+        **不要**仅凭文件名猜测内容——名字和内容经常对不上。
+        **不要**把群聊里出现的每个文件都取一遍，只取与当前问题确实相关的。
+
+        Args:
+            file_key (`str`):
+                文件句柄，取自群聊上下文里 `[文件：xxx｜key=yyy]` 中的 `yyy`。
+
+        Returns:
+            JSON: 成功返回 {file_id, filename, mime_type, size, next: 使用提示}；
+                  失败返回 {error: 原因}。下载码可能过期，过旧的文件可能取不回。
+        """
+        from core.channels.registry import get_adapter
+        from core.db.engine import SessionLocal
+        from core.services.artifact_service import store_bytes_as_artifact
+
+        key = (file_key or "").strip()
+        if not key:
+            return _err("file_key 不能为空")
+        if not chat_id:
+            return _err("当前不是渠道会话，无法取回群聊附件")
+
+        with SessionLocal() as db:
+            session, conn, entry, err = _lookup(db, chat_id, user_id, key)
+            if err:
+                return _err(err)
+
+            try:
+                adapter = get_adapter(conn.channel_type)
+            except Exception:  # noqa: BLE001
+                return _err(f"渠道 {conn.channel_type} 不可用")
+            download = getattr(adapter, "download_resource", None)
+            if download is None:
+                return _err(f"渠道 {conn.channel_type} 不支持下载消息附件")
+
+            name = entry.get("name") or "file.bin"
+            try:
+                content = await download(
+                    conn, _rebuild_inbound(conn, session, entry),
+                    {"kind": entry.get("kind") or "file", "key": key, "name": name},
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("[channels] 按需取回附件失败 key=%s", key[:16])
+                return _err("附件下载失败，可能下载码已过期")
+            if not content:
+                return _err("附件下载失败或已过期（渠道返回空内容）")
+            if len(content) > _MAX_ATTACHMENT_BYTES:
+                return _err(f"文件过大（{len(content)} 字节），超出 50MB 上限")
+
+            mime = mimetypes.guess_type(name)[0] or "application/octet-stream"
+            art = store_bytes_as_artifact(
+                db, user_id=str(session.user_id), content=content, filename=name,
+                mime_type=mime, chat_id=chat_id, source="channel_observed",
+                extra={"channel_id": conn.channel_id, "observed_file_key": key},
+            )
+            return ToolResponse(content=[TextBlock(type="text", text=json.dumps({
+                "file_id": art.artifact_id,
+                "filename": name,
+                "mime_type": mime,
+                "size": len(content),
+                "next": f"用 read_artifact(file_id='{art.artifact_id}') 读取内容",
+            }, ensure_ascii=False))])
+
+    toolkit.register_tool_function(channel_read_attachment, namesake_strategy="override")

--- a/src/backend/core/services/channel_service.py
+++ b/src/backend/core/services/channel_service.py
@@ -90,6 +90,7 @@ def bot_to_dict(conn: ChannelConnection) -> Dict[str, Any]:
         "status": conn.status,
         "enabled": conn.enabled,
         "agent_id": conn.agent_id,
+        "group_listen_mode": conn.group_listen_mode,
         "resource_scope": conn.resource_scope,
         "last_event_at": conn.last_event_at.isoformat() if conn.last_event_at else None,
         "last_error": conn.last_error,
@@ -149,6 +150,7 @@ class ChannelService:
         transport: str = "long_conn",
         resource_scope: Optional[Dict[str, Any]] = None,
         agent_id: Optional[str] = None,
+        group_listen_mode: str = "mention_only",
     ) -> ChannelConnection:
         # 1. Capability bit
         caps = resolve_user_capabilities(self.db, owner_id)
@@ -198,6 +200,7 @@ class ChannelService:
             "config": config,
             "resource_scope": _clean_scope(resource_scope),
             "agent_id": agent_id,
+            "group_listen_mode": _validate_group_listen(channel_type, group_listen_mode),
             "status": "pending",
             "enabled": True,
         })
@@ -231,9 +234,14 @@ class ChannelService:
         resource_scope_set: bool = False,
         agent_id: Optional[str] = None,
         agent_id_set: bool = False,
+        group_listen_mode: Optional[str] = None,
     ) -> ChannelConnection:
         conn = self._owned(channel_id, owner_id)
         patch: Dict[str, Any] = {}
+        if group_listen_mode is not None:
+            patch["group_listen_mode"] = _validate_group_listen(
+                conn.channel_type, group_listen_mode
+            )
         if display_name is not None:
             patch["display_name"] = display_name.strip()[:100]
         if resource_scope_set:
@@ -427,6 +435,26 @@ def _manager():
     from core.channels.manager import get_manager
 
     return get_manager()
+
+
+GROUP_LISTEN_MODES = ("mention_only", "observe_all")
+
+
+def _validate_group_listen(channel_type: str, mode: Optional[str]) -> str:
+    """Validate the group-listening mode, rejecting it on channels that can never honor it.
+
+    ``observe_all`` only means anything where the platform is capable of delivering non-@
+    group messages. Storing it on WeCom/WeChat would leave the owner believing the bot reads
+    the group when it structurally cannot — so reject rather than silently accept.
+    """
+    mode = (mode or "mention_only").strip()
+    if mode not in GROUP_LISTEN_MODES:
+        raise BadRequestError(f"group_listen_mode 非法：{mode}")
+    if mode == "observe_all":
+        caps = get_adapter(channel_type).caps
+        if not getattr(caps, "supports_group_observe", False):
+            raise BadRequestError(f"渠道 {channel_type} 不支持群聊旁听")
+    return mode
 
 
 def _clean_scope(scope: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:

--- a/src/backend/tests/test_channel_bots.py
+++ b/src/backend/tests/test_channel_bots.py
@@ -1083,3 +1083,453 @@ def test_inbound_history_empty_on_no_access(db_session):
 
     _mk_user(db_session, uid="owner2")
     assert _load_history(db_session, "chat_does_not_exist", "owner2") == []
+
+
+# ── 群聊旁听（observe_all）─────────────────────────────────────────────────────
+
+
+def test_lark_parse_extracts_mentions_and_defers_group_decision():
+    """群消息的 @ 判定必须延后：飞书事件里没有机器人自己的 open_id，只能先收集 mentions。"""
+    adapter = LarkAdapter()
+    evt = {"header": {"event_type": "im.message.receive_v1"}, "event": {
+        "message": {
+            "chat_id": "oc_1", "chat_type": "group", "message_id": "om_1",
+            "message_type": "text", "content": json.dumps({"text": "@_user_1 帮我看下"}),
+            "mentions": [{"key": "@_user_1", "id": {"open_id": "ou_bot"}, "name": "小助手"}],
+        },
+        "sender": {"sender_id": {"open_id": "ou_a"}}}}
+    m = adapter.parse_inbound(_FakeConn(), evt)
+    assert m.mentioned_ids == ["ou_bot"]
+    assert m.addressed_to_bot is None, "群消息不应在 parse 阶段就下结论"
+
+    # 单聊永远是冲着机器人来的，不需要再解析
+    evt["event"]["message"]["chat_type"] = "p2p"
+    assert adapter.parse_inbound(_FakeConn(), evt).addressed_to_bot is True
+
+
+def test_dingtalk_parse_uses_is_in_at_list():
+    """钉钉自带 isInAtList，可同步判定；字段缺失时按「已被 @」处理，保持老行为。"""
+    from core.channels.adapters.dingtalk import DingTalkAdapter
+
+    adapter = DingTalkAdapter()
+    base = {"msgtype": "text", "text": {"content": "hi"}, "conversationType": "2",
+            "conversationId": "cid_1", "msgId": "m1"}
+    assert adapter.parse_inbound(_FakeConn(), {**base, "isInAtList": True}).addressed_to_bot is True
+    assert adapter.parse_inbound(_FakeConn(), {**base, "isInAtList": False}).addressed_to_bot is False
+    # 未开通群消息读取权限时钉钉不下发该字段 → 不能误判成「没 @ 」而静音
+    assert adapter.parse_inbound(_FakeConn(), base).addressed_to_bot is True
+    # 单聊不受影响
+    assert adapter.parse_inbound(
+        _FakeConn(), {**base, "conversationType": "1", "isInAtList": False}
+    ).addressed_to_bot is True
+
+
+def test_resolve_addressed_fails_open(db_session):
+    """判定不了就当被 @ 了：宁可多答一句，也不能对着直接 @ 装死。"""
+    from core.channels.inbound import _resolve_addressed
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_g1", "group")
+
+    class _NoResolver:
+        pass
+
+    class _Boom:
+        async def resolve_addressed(self, conn, inbound):
+            raise RuntimeError("bot/v3/info 挂了")
+
+    class _Says:
+        def __init__(self, v): self.v = v
+        async def resolve_addressed(self, conn, inbound): return self.v
+
+    # 渠道没实现该钩子（企微/微信）→ 行为与本特性上线前完全一致
+    assert asyncio.run(_resolve_addressed(_NoResolver(), conn, msg)) is True
+    assert asyncio.run(_resolve_addressed(_Boom(), conn, msg)) is True
+    assert asyncio.run(_resolve_addressed(_Says(False), conn, msg)) is False
+    # adapter 已给出结论时不再回调钩子
+    decided = _inbound("oc_g1", "group")
+    decided.addressed_to_bot = True
+    assert asyncio.run(_resolve_addressed(_Says(False), conn, decided)) is True
+
+
+def test_observe_buffer_accumulates_caps_and_drains(db_session):
+    """旁听消息进缓冲区、有水位上限、被 @ 时一次性排空。"""
+    from core.channels.inbound import (
+        _OBSERVE_MAX, _drain_observed, _find_or_create_session, _observe_message,
+    )
+
+    conn = _mk_conn(db_session)
+    for i in range(_OBSERVE_MAX + 5):
+        m = _inbound("oc_g1", "group", text=f"闲聊{i}", mid=f"m{i}")
+        m.sender_name = f"甲{i}"
+        _observe_message(db_session, conn, m)
+
+    session = _find_or_create_session(db_session, conn, _inbound("oc_g1", "group"))
+    buf = (session.extra_data or {}).get("observed")
+    assert len(buf) == _OBSERVE_MAX, "旁听缓冲必须有水位上限，否则活跃群会把提示词撑爆"
+    assert buf[0]["t"] == "闲聊5", "应淘汰最旧的，保留最近的"
+    assert buf[0]["n"] == "甲5"
+
+    drained = _drain_observed(db_session, session)
+    assert len(drained) == _OBSERVE_MAX
+    db_session.refresh(session)
+    assert (session.extra_data or {}).get("observed") == [], "排空后不能重复注入"
+    assert _drain_observed(db_session, session) == []
+
+
+def test_observe_text_truncates_and_keeps_attachment_keys(db_session):
+    """旁听正文截断；附件只留句柄不下载，但 key 必须保住——丢了 key 就永远取不回。"""
+    from core.channels.inbound import (
+        _OBSERVE_TEXT_MAX, _observe_attachment_refs, _observe_text,
+    )
+
+    long_msg = _inbound("oc_g1", "group", text="x" * (_OBSERVE_TEXT_MAX + 50))
+    assert _observe_text(long_msg) == "x" * _OBSERVE_TEXT_MAX + "…"
+    assert _observe_text(_inbound("oc_g1", "group", text="   ")) == ""
+
+    withfile = _inbound("oc_g1", "group", text="看下这个")
+    withfile.attachments = [
+        {"kind": "file", "key": "fk", "name": "报表.xlsx"},
+        {"kind": "image", "key": "ik", "name": "p.png"},
+        {"kind": "file", "name": "无 key 的不要"},   # 没有 key 就没法取回，直接丢弃
+    ]
+    assert _observe_attachment_refs(withfile) == [
+        {"kind": "file", "key": "fk", "name": "报表.xlsx"},
+        {"kind": "image", "key": "ik", "name": "p.png"},
+    ]
+
+
+def test_observe_records_file_index_for_lazy_fetch(db_session):
+    """附件句柄进独立索引（含 message_id / raw），且有水位；纯附件消息也要记。"""
+    from core.channels.inbound import (
+        _OBSERVE_FILE_INDEX_MAX, _drain_observed, _find_or_create_session, _observe_message,
+    )
+
+    conn = _mk_conn(db_session)
+    m = _inbound("oc_g1", "group", text="", mid="om_file")
+    m.sender_name = "张三"
+    m.attachments = [{"kind": "file", "key": "fk_1", "name": "Q3财报.xlsx"}]
+    m.raw = {"lark_message_id": "om_file"}
+    _observe_message(db_session, conn, m)
+
+    session = _find_or_create_session(db_session, conn, _inbound("oc_g1", "group"))
+    idx = (session.extra_data or {})["observed_files"]
+    assert idx["fk_1"]["name"] == "Q3财报.xlsx"
+    assert idx["fk_1"]["message_id"] == "om_file", "缺 message_id 飞书就取不回资源"
+    assert idx["fk_1"]["raw"] == {"lark_message_id": "om_file"}
+
+    # 索引在缓冲区排空后仍然存在——模型可能过几轮才决定要看这个文件
+    _drain_observed(db_session, session)
+    db_session.refresh(session)
+    assert "fk_1" in (session.extra_data or {})["observed_files"]
+
+    # 水位
+    for i in range(_OBSERVE_FILE_INDEX_MAX + 3):
+        mi = _inbound("oc_g1", "group", text="", mid=f"om_{i}")
+        mi.attachments = [{"kind": "file", "key": f"k{i}", "name": f"f{i}.txt"}]
+        _observe_message(db_session, conn, mi)
+    db_session.refresh(session)
+    idx = (session.extra_data or {})["observed_files"]
+    assert len(idx) == _OBSERVE_FILE_INDEX_MAX
+    assert "fk_1" not in idx and f"k{_OBSERVE_FILE_INDEX_MAX + 2}" in idx
+
+
+def test_render_observed_block_exposes_attachment_keys():
+    """群聊记录里必须带出 key，否则模型看得到文件却拿不到句柄。"""
+    from core.channels.inbound import _render_observed_block
+
+    block = _render_observed_block([
+        {"n": "张三", "t": "看下这个", "a": [
+            {"kind": "file", "key": "fk_1", "name": "Q3财报.xlsx"},
+        ]},
+        {"n": "李四", "t": "收到"},
+    ])
+    assert "[文件：Q3财报.xlsx｜key=fk_1]" in block
+    assert "channel_read_attachment" in block, "要告诉模型怎么取回"
+    assert "李四：收到" in block
+
+    # 没有附件时不必挂取回提示，省 token
+    assert "channel_read_attachment" not in _render_observed_block([{"n": "李四", "t": "收到"}])
+
+
+def test_render_observed_block_marks_as_do_not_reply():
+    """群聊记录必须显式标注为背景、不要逐条回复，否则模型会把群消息当成待办清单挨个答。"""
+    from core.channels.inbound import _render_observed_block
+
+    block = _render_observed_block([{"n": "张三", "t": "明天几点"}, {"n": "李四", "t": "十点"}])
+    assert "张三：明天几点" in block and "李四：十点" in block
+    assert "不要逐条回复" in block
+    assert block.endswith("\n"), "需与本次消息之间有分隔"
+
+
+def test_group_listen_mode_validation():
+    """observe_all 只能开在平台可能投递非 @ 群消息的渠道上。"""
+    from core.services.channel_service import _validate_group_listen
+
+    assert _validate_group_listen("lark", "observe_all") == "observe_all"
+    assert _validate_group_listen("dingtalk", "observe_all") == "observe_all"
+    assert _validate_group_listen("lark", None) == "mention_only"
+    with pytest.raises(BadRequestError):
+        _validate_group_listen("lark", "listen_everything")
+    with pytest.raises(BadRequestError):
+        _validate_group_listen("weixin", "observe_all")
+
+
+def test_default_group_listen_mode_is_mention_only(db_session):
+    """默认必须是 mention_only —— 旁听全群是隐私敏感行为，只能由 owner 显式打开。"""
+    conn = _mk_conn(db_session)
+    assert conn.group_listen_mode == "mention_only"
+    assert bot_to_dict(conn)["group_listen_mode"] == "mention_only"
+
+
+def test_inbound_gate_routes_bystander_messages(db_session, monkeypatch):
+    """闸门路由：未 @ 的群消息在 observe_all 下只落缓冲、在 mention_only 下直接丢弃，
+    两种情况都**绝不**起 run、绝不回复——旁听如果会触发回复，机器人会在群里刷屏。"""
+    import core.channels.inbound as inbound_mod
+
+    chan_id = _mk_conn(db_session).channel_id
+    repo = ChannelConnectionRepository(db_session)
+    # 不 patch close：fixture 是共享文件 SQLite + teardown drop_all，压住 close 会留锁
+    # 拖垮后续用例建表。但 _process_inbound 内部会 close，而 Session.close() 会把已加载
+    # 对象全部 expunge —— 所以下面一律用 channel_id 重新取 conn，不复用旧引用。
+    monkeypatch.setattr(inbound_mod, "SessionLocal", lambda: db_session)
+
+    started = []
+
+    class _FakeAdapter:
+        caps = None
+        async def resolve_addressed(self, conn, inbound): return False
+        async def send_text(self, *a, **k):
+            started.append("sent"); return SendResult.ok("x")
+
+    monkeypatch.setattr(inbound_mod, "get_adapter", lambda ct: _FakeAdapter())
+
+    def _boom(*a, **k):
+        started.append("run")
+        raise AssertionError("旁听消息不得触发 agent run")
+
+    monkeypatch.setattr(
+        "orchestration.chat_run_executor.start_run", _boom, raising=False
+    )
+
+    msg = _inbound("oc_g1", "group", text="今天几点开会", mid="mo1")
+    msg.sender_name = "张三"
+
+    # observe_all：进缓冲，不起 run、不回复
+    repo.update(chan_id, {"group_listen_mode": "observe_all"})
+    asyncio.run(inbound_mod._process_inbound(msg))
+    assert started == [], "旁听消息既不应起 run 也不应回复"
+    session = inbound_mod._find_or_create_session(db_session, repo.get_by_id(chan_id), msg)
+    assert [it["t"] for it in (session.extra_data or {}).get("observed", [])] == ["今天几点开会"]
+    assert (session.extra_data or {})["observed"][0]["n"] == "张三"
+
+    # mention_only：直接丢弃，缓冲区不动
+    repo.update(chan_id, {"group_listen_mode": "mention_only"})
+    asyncio.run(inbound_mod._process_inbound(
+        _inbound("oc_g1", "group", text="不该被记下", mid="mo2")
+    ))
+    # 同样：close() 已把 session 对象 expunge，重新查一次而不是 refresh
+    fresh = inbound_mod._find_or_create_session(db_session, repo.get_by_id(chan_id), msg)
+    assert [it["t"] for it in (fresh.extra_data or {}).get("observed", [])] == ["今天几点开会"]
+    assert started == []
+
+
+def test_lark_resolve_addressed_matches_bot_open_id(monkeypatch):
+    """飞书 @ 判定：只认机器人自己的 open_id。
+
+    覆盖 include_bot 权限（`im:message.group_at_msg.include_bot:readonly`）下的场景——
+    群里 @ 的是**别的**机器人时，我们不该抢答；这在闸门上线前是会误答的。
+    """
+    adapter = LarkAdapter()
+
+    async def _fake_id(conn): return "ou_me"
+    monkeypatch.setattr(LarkAdapter, "_bot_open_id", staticmethod(_fake_id))
+
+    def _msg(ids):
+        m = _inbound("oc_g1", "group")
+        m.mentioned_ids = ids
+        return m
+
+    assert asyncio.run(adapter.resolve_addressed(_FakeConn(), _msg(["ou_me"]))) is True
+    assert asyncio.run(adapter.resolve_addressed(_FakeConn(), _msg(["ou_other_bot"]))) is False
+    assert asyncio.run(adapter.resolve_addressed(_FakeConn(), _msg([]))) is False
+
+    # 取不到自身 open_id（接口抖动 / 空值）→ 一律按「已被 @」处理，不能在群里装死
+    async def _boom(conn): raise RuntimeError("bot/v3/info 502")
+    monkeypatch.setattr(LarkAdapter, "_bot_open_id", staticmethod(_boom))
+    assert asyncio.run(adapter.resolve_addressed(_FakeConn(), _msg(["ou_other"]))) is True
+
+    async def _empty(conn): return ""
+    monkeypatch.setattr(LarkAdapter, "_bot_open_id", staticmethod(_empty))
+    assert asyncio.run(adapter.resolve_addressed(_FakeConn(), _msg(["ou_other"]))) is True
+
+
+# ── 钉钉附件接收 / 下载 ────────────────────────────────────────────────────────
+
+
+def test_dingtalk_extracts_attachments_by_msgtype():
+    """钉钉各消息类型的 downloadCode 提取（字段位置依官方「接收的消息类型」）。"""
+    from core.channels.adapters.dingtalk import DingTalkAdapter
+
+    a = DingTalkAdapter()
+    base = {"conversationType": "1", "conversationId": "cid", "msgId": "m1",
+            "robotCode": "ding_robot_1"}
+
+    f = a.parse_inbound(_FakeConn(), {**base, "msgtype": "file", "content": {
+        "downloadCode": "dc_1", "fileName": "合同.pdf", "spaceId": "s", "fileId": "fi"}})
+    assert f.attachments == [{"kind": "file", "key": "dc_1", "name": "合同.pdf"}]
+    # 纯附件、无正文的消息也必须成立——否则钉钉发文件永远收不到
+    assert f.text == ""
+    assert f.raw["dingtalk_robot_code"] == "ding_robot_1"
+
+    p = a.parse_inbound(_FakeConn(), {**base, "msgtype": "picture", "content": {
+        "downloadCode": "dc_2", "pictureDownloadCode": "pdc"}})
+    assert p.attachments[0]["kind"] == "image" and p.attachments[0]["key"] == "dc_2"
+    # 只给 pictureDownloadCode 时回退取它
+    p2 = a.parse_inbound(_FakeConn(), {**base, "msgtype": "picture",
+                                       "content": {"pictureDownloadCode": "pdc"}})
+    assert p2.attachments[0]["key"] == "pdc"
+
+    r = a.parse_inbound(_FakeConn(), {**base, "msgtype": "richText", "content": {
+        "richText": [{"text": "看图"}, {"downloadCode": "dc_3"}]}})
+    assert r.text == "看图" and r.attachments[0]["key"] == "dc_3"
+
+    # 字段缺失不能抛异常（payload 规格松散，抛了会打断长连接）
+    assert a.parse_inbound(_FakeConn(), {**base, "msgtype": "file", "content": {}}) is None
+    assert a.parse_inbound(_FakeConn(), {**base, "msgtype": "file"}) is None
+
+
+def test_dingtalk_download_resource_two_hop(monkeypatch):
+    """downloadCode → downloadUrl → bytes；缺 robotCode 或过期一律返回 None 不抛。"""
+    import httpx as _httpx
+
+    from core.channels.adapters.dingtalk import DingTalkAdapter
+
+    a = DingTalkAdapter()
+    calls = []
+
+    class _Resp:
+        def __init__(self, code=200, payload=None, content=b""):
+            self.status_code, self._p, self.content = code, payload or {}, content
+            self.text = json.dumps(self._p)
+        def json(self): return self._p
+
+    class _Client:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def post(self, url, headers=None, json=None):
+            calls.append(("post", url, json))
+            return _Resp(200, {"downloadUrl": "https://dl.example/x.file"})
+        async def get(self, url):
+            calls.append(("get", url, None))
+            return _Resp(200, content=b"PDFBYTES")
+
+    monkeypatch.setattr(_httpx, "AsyncClient", lambda **kw: _Client())
+    async def _tok(app_id, secret): return "tk"
+    monkeypatch.setattr(DingTalkAdapter, "_access_token", staticmethod(_tok))
+
+    msg = InboundMsg(channel_id="c", channel_type="dingtalk", text="", chat_type="group",
+                     external_conversation_id="cid", message_id="m1",
+                     raw={"dingtalk_robot_code": "rc_1"})
+    got = asyncio.run(a.download_resource(_FakeConn(), msg, {"kind": "file", "key": "dc_1"}))
+    assert got == b"PDFBYTES"
+    assert calls[0][1].endswith("/v1.0/robot/messageFiles/download")
+    assert calls[0][2] == {"downloadCode": "dc_1", "robotCode": "rc_1"}
+
+    # 没有 robotCode 就调不动接口，直接放弃而不是发一个必失败的请求
+    nomeat = InboundMsg(channel_id="c", channel_type="dingtalk", text="", chat_type="group",
+                        external_conversation_id="cid", raw={})
+    assert asyncio.run(a.download_resource(_FakeConn(), nomeat, {"key": "dc_1"})) is None
+    assert asyncio.run(a.download_resource(_FakeConn(), msg, {"key": ""})) is None
+
+
+# ── channel_read_attachment 工具（按需取回旁听附件）────────────────────────────
+
+
+def _reg_channel_tool(user_id, chat_id):
+    """注册工具并取出被注册的函数。
+
+    注意：register_* 系列拿到的不是 AgentScope 2.0 的 Toolkit，而是鸭子类型的
+    ToolCollector（见 core/llm/tool_collector.py）——真 Toolkit 是一次性构造的。
+    """
+    from core.llm.tool_collector import ToolCollector
+    from core.llm.tools.channel_attachment_tool import register_channel_attachment
+
+    tc = ToolCollector()
+    register_channel_attachment(tc, user_id=user_id, chat_id=chat_id)
+    ft = tc._tools.get("channel_read_attachment")
+    assert ft is not None, "channel_read_attachment 未注册成功"
+    for attr in ("original_func", "func", "_func"):
+        fn = getattr(ft, attr, None)
+        if callable(fn):
+            return fn
+    raise AssertionError(f"取不到底层函数，FunctionTool 属性：{dir(ft)}")
+
+
+def _tool_json(resp):
+    block = resp.content[0]
+    text = block["text"] if isinstance(block, dict) else getattr(block, "text")
+    return json.loads(text)
+
+
+def test_channel_read_attachment_fetches_and_stores(db_session, monkeypatch):
+    """按 key 取回 → 落 Artifact → 返回 file_id 供 read_artifact 读。"""
+    from core.channels.inbound import _find_or_create_session, _observe_message
+
+    conn = _mk_conn(db_session)
+    m = _inbound("oc_g1", "group", text="", mid="om_f")
+    m.attachments = [{"kind": "file", "key": "fk_1", "name": "Q3财报.xlsx"}]
+    m.raw = {"lark_message_id": "om_f"}
+    _observe_message(db_session, conn, m)
+    session = _find_or_create_session(db_session, conn, _inbound("oc_g1", "group"))
+
+    # 只替换 SessionLocal（工具内部是 `from core.db.engine import SessionLocal` 的函数内导入）。
+    # 不要去 patch session.close —— fixture 用的是**共享文件** SQLite 且 teardown 会 drop_all，
+    # 把 close 变成空操作会让连接一直占着锁，下一个用例的 create_all 就建不出表了。
+    # Session.close() 之后仍可继续使用（会开新事务），所以让 `with` 正常关闭即可。
+    monkeypatch.setattr("core.db.engine.SessionLocal", lambda: db_session)
+
+    seen = {}
+
+    class _Ad:
+        async def download_resource(self, conn, inbound, att):
+            seen["message_id"] = inbound.message_id
+            seen["raw"] = dict(inbound.raw or {})
+            seen["key"] = att.get("key")
+            return b"XLSXBYTES"
+
+    monkeypatch.setattr("core.channels.registry.get_adapter", lambda ct: _Ad())
+
+    tool = _reg_channel_tool(str(session.user_id), session.chat_id)
+    out = _tool_json(asyncio.run(tool("fk_1")))
+
+    assert "error" not in out, out
+    assert out["filename"] == "Q3财报.xlsx" and out["size"] == len(b"XLSXBYTES")
+    assert out["file_id"] and "read_artifact" in out["next"]
+    # adapter 拿到了取回所需的上下文（飞书按 message_id 定位资源）
+    assert seen["key"] == "fk_1" and seen["message_id"] == "om_f"
+    assert seen["raw"] == {"lark_message_id": "om_f"}
+
+
+def test_channel_read_attachment_rejects_unknown_and_foreign(db_session, monkeypatch):
+    """未知 key / 越权会话 / 空 key / 非渠道会话 都必须干净报错，不能抛。"""
+    from core.channels.inbound import _find_or_create_session, _observe_message
+
+    conn = _mk_conn(db_session)
+    m = _inbound("oc_g1", "group", text="", mid="om_f")
+    m.attachments = [{"kind": "file", "key": "fk_1", "name": "a.xlsx"}]
+    _observe_message(db_session, conn, m)
+    session = _find_or_create_session(db_session, conn, _inbound("oc_g1", "group"))
+
+    monkeypatch.setattr("core.db.engine.SessionLocal", lambda: db_session)
+
+    tool = _reg_channel_tool(str(session.user_id), session.chat_id)
+    assert "不能为空" in _tool_json(asyncio.run(tool("  ")))["error"]
+    assert "未找到" in _tool_json(asyncio.run(tool("no_such_key")))["error"]
+
+    # 别人的会话：拿到 chat_id 也不能越权取走群文件
+    other = _reg_channel_tool("someone_else", session.chat_id)
+    assert "无权" in _tool_json(asyncio.run(other("fk_1")))["error"]
+
+    # 不在渠道会话里时工具压根没有 chat_id
+    assert "渠道会话" in _tool_json(asyncio.run(_reg_channel_tool("u_o", None)("fk_1")))["error"]

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -2947,6 +2947,12 @@ export interface ChannelBot {
   enabled: boolean;
   /** Bound sub-agent ID; null = main agent (the owner's default capabilities) */
   agent_id: string | null;
+  /**
+   * 群聊旁听：`mention_only` 仅处理 @ 机器人的消息；`observe_all` 旁观群内其他消息作为上下文
+   * （不回复）。`observe_all` 还需渠道应用本身具备平台的「读取群内全部消息」权限，否则平台
+   * 根本不会把未 @ 的消息推过来。
+   */
+  group_listen_mode: 'mention_only' | 'observe_all';
   resource_scope: { kb_ids?: string[]; skill_ids?: string[] } | null;
   last_event_at: string | null;
   last_error: string | null;
@@ -2959,6 +2965,8 @@ export interface ChannelAdapterInfo {
   max_message_len: number;
   supports_markdown: boolean;
   supports_long_conn: boolean;
+  /** 该渠道是否可能投递「未 @ 机器人」的群消息（即群聊旁听是否有意义） */
+  supports_group_observe: boolean;
   bind_mode: 'credentials' | 'qr';
   credential_fields: string[];
 }
@@ -2975,6 +2983,8 @@ export interface CreateChannelBotPayload {
   resource_scope?: { kb_ids?: string[]; skill_ids?: string[] };
   /** Bind to a specific sub-agent; omitted = main agent */
   agent_id?: string;
+  /** 群聊旁听模式；不传 = mention_only */
+  group_listen_mode?: 'mention_only' | 'observe_all';
 }
 
 export async function listChannelAdapters(): Promise<ChannelAdapterInfo[]> {
@@ -3006,7 +3016,13 @@ export async function createChannelBot(payload: CreateChannelBotPayload): Promis
 
 export async function updateChannelBot(
   channelId: string,
-  patch: { display_name?: string; enabled?: boolean; resource_scope?: { kb_ids?: string[]; skill_ids?: string[] }; agent_id?: string | null },
+  patch: {
+    display_name?: string;
+    enabled?: boolean;
+    resource_scope?: { kb_ids?: string[]; skill_ids?: string[] };
+    agent_id?: string | null;
+    group_listen_mode?: 'mention_only' | 'observe_all';
+  },
 ): Promise<ChannelBot> {
   const wrapped = await apiRequest<unknown>(`/v1/channels/bots/${channelId}`, {
     method: 'PATCH',

--- a/src/frontend/src/components/settings/ChannelBotsPanel.tsx
+++ b/src/frontend/src/components/settings/ChannelBotsPanel.tsx
@@ -180,6 +180,14 @@ export function ChannelBotsPanel({ agentId, agentName }: ChannelBotsPanelProps =
     try { await updateChannelBot(bot.channel_id, { enabled }); await refresh(); }
     catch (e) { message.error((e as Error)?.message || t('操作失败')); }
   };
+  const onToggleListen = async (bot: ChannelBot, observe: boolean) => {
+    try {
+      await updateChannelBot(bot.channel_id, {
+        group_listen_mode: observe ? 'observe_all' : 'mention_only',
+      });
+      await refresh();
+    } catch (e) { message.error((e as Error)?.message || t('操作失败')); }
+  };
   const onTest = async (bot: ChannelBot) => {
     try { await testChannelBot(bot.channel_id); message.success(t('凭据有效')); }
     catch (e) { message.error((e as Error)?.message || t('测试失败')); }
@@ -223,6 +231,11 @@ export function ChannelBotsPanel({ agentId, agentName }: ChannelBotsPanelProps =
         )}
         {bots.map((bot) => {
           const meta = STATUS_META[bot.status];
+          // 群聊旁听只在平台可能投递「未 @ 」群消息的渠道上出现（飞书 / 钉钉）——
+          // 企业微信 / 微信结构上拿不到，给开关等于误导用户。
+          const canObserve = adapters.find(
+            (a) => a.channel_type === bot.channel_type,
+          )?.supports_group_observe;
           return (
             <div key={bot.channel_id} className="jx-settings-card" style={{ marginBottom: 10 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
@@ -237,6 +250,26 @@ export function ChannelBotsPanel({ agentId, agentName }: ChannelBotsPanelProps =
                   </div>
                   {bot.status === 'error' && bot.last_error && (
                     <div className="jx-conn-desc" style={{ color: '#d4380d', fontSize: 12 }}>{bot.last_error}</div>
+                  )}
+                  {canObserve && (
+                    <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <Switch
+                        size="small"
+                        checked={bot.group_listen_mode === 'observe_all'}
+                        onChange={(v) => onToggleListen(bot, v)}
+                      />
+                      <span className="jx-conn-desc" style={{ fontSize: 12 }}>
+                        {t('群聊旁听：读取群里未 @ 它的消息作为上下文（只读不回复）')}
+                      </span>
+                    </div>
+                  )}
+                  {canObserve && bot.group_listen_mode === 'observe_all' && (
+                    <div className="jx-conn-desc" style={{ fontSize: 12, marginTop: 4, lineHeight: 1.6 }}>
+                      {t('开启后群内成员的日常发言会被记录为该机器人的对话上下文，请确保群成员知情。')}
+                      {bot.channel_type === 'lark'
+                        ? t('另需在飞书开放平台为该应用申请敏感权限「获取群组中所有消息」(im:message.group_msg) 并重新发布版本，否则飞书不会推送未 @ 的消息，此开关不会生效。')
+                        : t('另需在钉钉开放平台为该应用申请群消息读取权限，否则钉钉只在被 @ 时回调，此开关不会生效。')}
+                    </div>
                   )}
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>

--- a/src/frontend/src/i18n/en/settings.ts
+++ b/src/frontend/src/i18n/en/settings.ts
@@ -397,6 +397,15 @@ export const SETTINGS_DICT: Record<string, string> = {
     'Bind a channel bot (Feishu / DingTalk / WeCom / WeChat) to sub-agent "{name}": messages sent to it are answered by this sub-agent using its own bound capabilities.',
   '注意：机器人以你本人的权限运行——群里任何人 @ 它，都能隔着机器人用到该子智能体的能力。':
     'Note: the bot runs with your permissions — anyone who @-mentions it in a group can reach this sub-agent through it.',
+  // ── 群聊旁听 ──
+  '群聊旁听：读取群里未 @ 它的消息作为上下文（只读不回复）':
+    'Group listening: read messages that do not @-mention the bot as context (read-only, never replied to)',
+  '开启后群内成员的日常发言会被记录为该机器人的对话上下文，请确保群成员知情。':
+    'Once enabled, everyday messages from group members are recorded as this bot\'s conversation context — make sure group members are aware.',
+  '另需在飞书开放平台为该应用申请敏感权限「获取群组中所有消息」(im:message.group_msg) 并重新发布版本，否则飞书不会推送未 @ 的消息，此开关不会生效。':
+    'You must also request the sensitive scope "Read all messages in a group" (im:message.group_msg) for this app on the Feishu open platform and republish the app version; otherwise Feishu never pushes non-@ messages and this switch has no effect.',
+  '另需在钉钉开放平台为该应用申请群消息读取权限，否则钉钉只在被 @ 时回调，此开关不会生效。':
+    'You must also request group-message read permission for this app on the DingTalk open platform; otherwise DingTalk only calls back on @-mentions and this switch has no effect.',
   '还没有机器人，点下方「绑定机器人」创建。': 'No bots yet. Click "Bind bot" below to create one.',
   '绑定机器人': 'Bind bot',
   '绑定': 'Bind',


### PR DESCRIPTION
## Problem

An IM bot in a group chat could only ever see messages that **@-mentioned it**, plus its own replies. Everything else the group said was dropped before it reached the agent, so the bot answered with most of the conversation missing.

Two related gaps came with that:

- Files shared in the group were invisible to the agent.
- On DingTalk, attachments were unreachable **entirely** — the adapter had no `download_resource` at all, so even a file attached to an @-mention could not be read.

## What this adds

### 1. Group listening (opt-in, per bot)

New column `channel_connections.group_listen_mode`:

| Mode | Behaviour |
|---|---|
| `mention_only` *(default)* | Exactly the previous behaviour — non-@ messages are dropped. |
| `observe_all` | Non-@ messages are recorded as background context and **never replied to**. |

Observed messages are folded into the next @-mention turn as a clearly labelled *"do not answer these line by line"* block, then persisted with that turn so later turns pick them up through normal history loading and compaction — no second retention mechanism.

They are buffered in `ChatSession.extra_data` rather than written as real messages, so the buffer stays bounded (60 messages, 500 chars each — a busy group cannot blow up the prompt) and no long runs of consecutive user-role turns are produced.

### 2. Deciding whether a message addresses the bot

- **DingTalk** decides synchronously from the `isInAtList` flag on its callback.
- **Feishu** cannot: the event carries the mention list but *not* the bot's own `open_id`. The adapter defers, and a new optional `resolve_addressed` hook resolves it via `bot/v3/info` (cached per `app_id`, so one request per process). Mention extraction is implemented on **both** the webhook and long-connection paths — the long connection is the production path, and missing it there would make every group message look un-mentioned.
- **Everything fails open.** If the check cannot be resolved, the message is treated as addressed. Answering one extra message is far less harmful than a bot going mute on a direct @. Channels without the hook (WeCom, WeChat) are byte-for-byte unchanged.

This also fixes a latent bug: under Feishu's `im:message.group_at_msg.include_bot` scope, a message @-ing a **different** bot used to be answered by ours.

### 3. On-demand attachment fetch

Observed attachments are recorded **by key and deliberately not downloaded** — eagerly pulling every file a group shares would mean heavy I/O and a far wider privacy footprint than reading text. Previously the key was discarded as well, which left the agent able to see that a file existed while never being able to open it.

The key is now kept in a separate `observed_files` index (alongside what the adapter needs to resolve it) and rendered into the group log. The new `channel_read_attachment` tool fetches a file by key on demand, stores it as a normal artifact, and returns a `file_id` for `read_artifact` — so downstream file handling keeps a single code path.

It is registered for channel runs only, and verifies session ownership so a leaked `chat_id` cannot pull another user's group files.

### 4. DingTalk attachment support

- `parse_inbound` extracts `downloadCode` for `picture` / `file` / `audio` / `video` and rich-text images, and keeps the top-level `robotCode`. Attachment-only messages are no longer dropped. Fields are read defensively — these payloads are loosely specified and vary by client version, and raising here would break the long connection.
- `download_resource` does the documented two-hop fetch: `POST /v1.0/robot/messageFiles/download` for a temporary URL, then the bytes. Per DingTalk's docs `robotCode` is **not** the AppKey, so it is taken from the callback and the request is skipped outright when absent. Download codes expire, so failures return `None` and degrade rather than raise.
- As a side effect, attachments on @-mentioned DingTalk messages now work too.

## Important: platform permission required

`observe_all` is **inert** until the channel app also holds the platform's "read all group messages" permission:

- **Feishu** — the sensitive `im:message.group_msg` scope, which also requires republishing the app version.
- **DingTalk** — group message read permission.

Without it the platform simply never delivers non-@ messages. The UI states this next to the switch, together with the privacy implications, and the switch defaults to off because observing a whole group's chatter is a decision the owner must make explicitly. `observe_all` is rejected outright on channels that cannot support it (WeCom, WeChat) rather than being silently stored.

## Migration

`ce_0005` adds the column. It is **conditional on purpose**: `ce_0001` builds the schema with `ce_create_all` straight from the SQLAlchemy models, so a fresh install already has the column by the time the chain reaches here — an unconditional `add_column` would fail on every new deployment. Only databases created before the column existed get the `ALTER`.

## Tests

19 new tests covering:

- the @-decision paths (synchronous, deferred, `open_id` matching) and fail-open behaviour in all three failure modes
- buffer capping, eviction order, and draining without re-injection
- attachment key retention and index water level surviving a drain
- the gate never starting a run and never replying, in both modes
- DingTalk payload extraction per `msgtype`, missing fields not raising, the two-hop download, and short-circuiting without `robotCode`
- the tool's fetch-and-store round trip, plus unknown-key / cross-user / empty-key / non-channel rejections

Full backend suite passes with no new failures.