### PR TITLE
fix(automation): deliver full scheduled-task results; fix capability health 500

### DIFF
--- a/src/backend/api/routes/v1/automations.py
+++ b/src/backend/api/routes/v1/automations.py
@@ -4,14 +4,14 @@ import json
 from typing import Any, Dict, List, Optional
 
 from croniter import croniter
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from core.auth.backend import get_current_user, UserContext
 from core.db.engine import get_db
 from core.infra.responses import success_response, created_response
-from core.services.automation_service import AutomationService
+from core.services.automation_service import AutomationService, SUMMARY_LIMIT_LIST
 from core.infra.logging import get_logger
 
 logger = get_logger(__name__)
@@ -296,14 +296,18 @@ async def activate_sidebar(
 @router.get("/{task_id}/runs", summary="自动化任务运行历史")
 async def get_automation_runs(
     task_id: str,
-    limit: int = 10,
+    # 上界防护：result_summary 现在是全文，无上限的 limit 会把成百上千份完整报告拉进内存
+    limit: int = Query(10, ge=1, le=100),
     user: UserContext = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """获取指定自动化任务的运行历史记录，可通过 limit 限制返回条数。"""
     svc = AutomationService(db)
     runs = svc.get_task_runs(task_id, user.user_id, limit=limit)
-    return success_response(data=[AutomationService.run_to_dict(r) for r in runs])
+    # result_summary 存全文（渠道投递要用），列表只做两行摘要展示 → 截断防止响应体膨胀
+    return success_response(
+        data=[AutomationService.run_to_dict(r, summary_limit=SUMMARY_LIMIT_LIST) for r in runs]
+    )
 
 
 # ── Notifications (Redis-backed) ──────────────────────────────

--- a/src/backend/core/evolution/promotion.py
+++ b/src/backend/core/evolution/promotion.py
@@ -631,7 +631,16 @@ def find_retirement_candidates(
                     "reason": REASON_NEVER_OPENED,
                     "action": ACTION_LOWER_EXPOSURE,
                     "explanation": (
-                        f"已被挂载 {offers} 次、曝光 {exposure_days:.0f} 天，模型一次都没打开——"
+                        f"已被挂载 {offers} 次、"
+                        # A hand-authored skill has no release record and so no
+                        # finite exposure window — it has been there from the
+                        # start. Formatting that as a number printed "曝光 inf 天".
+                        + (
+                            "一直可用"
+                            if exposure_days == float("inf")
+                            else f"曝光 {exposure_days:.0f} 天"
+                        )
+                        + "，模型一次都没打开——"
                         "多半是描述没写清它解决什么问题，而不是能力本身没用"
                     ),
                     **stats,

--- a/src/backend/core/services/automation_service.py
+++ b/src/backend/core/services/automation_service.py
@@ -13,6 +13,20 @@ from core.infra.logging import get_logger
 
 logger = get_logger(__name__)
 
+# ── 运行结果摘要截断策略（单一真源）────────────────────────────────────
+# ScheduledTaskRun.result_summary 存的是**全文**：它同时是渠道（钉钉/飞书等）投递的正文，
+# 在写库/执行侧截断会让定时消息只发出开头一段。所以截断一律发生在展示侧，且统一走
+# truncate_summary，保证各处「被截断」的观感一致（都带省略号）。
+SUMMARY_LIMIT_LIST = 500   # 运行历史列表：前端只做两行 line-clamp 展示
+SUMMARY_LIMIT_BRIEF = 200  # 通知中心卡片 / MCP brief：进模型上下文或小卡片，要更短
+
+
+def truncate_summary(text: Optional[str], limit: Optional[int]) -> Optional[str]:
+    """按 limit 截断展示用摘要；``limit`` 为 None/0 表示不截断，原样返回。"""
+    if not limit or not text or len(text) <= limit:
+        return text
+    return text[:limit] + "…"
+
 
 def _channel_target_fields(extra_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Parse the first channel delivery target from a task's extra_data, filling in
@@ -383,13 +397,21 @@ class AutomationService:
         }
 
     @staticmethod
-    def run_to_dict(run: ScheduledTaskRun) -> Dict[str, Any]:
+    def run_to_dict(
+        run: ScheduledTaskRun, *, summary_limit: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """运行记录 → dict。
+
+        ``result_summary`` 存的是**全文**（渠道投递要用完整正文，见 automation_scheduler），
+        因此只展示摘要的消费方应传 ``summary_limit`` 自行截断，避免把一整篇报告塞进列表
+        响应/模型上下文。不传 = 原样返回全文（供需要完整结果的详情场景使用）。
+        """
         return {
             "run_id": run.run_id,
             "task_id": run.task_id,
             "status": run.status,
             "chat_id": run.chat_id,
-            "result_summary": run.result_summary,
+            "result_summary": truncate_summary(run.result_summary, summary_limit),
             "error_message": run.error_message,
             "started_at": run.started_at.isoformat() if run.started_at else None,
             "completed_at": run.completed_at.isoformat() if run.completed_at else None,

--- a/src/backend/mcp_servers/automation_task_mcp/impl.py
+++ b/src/backend/mcp_servers/automation_task_mcp/impl.py
@@ -185,7 +185,7 @@ def list_tasks(*, user_id: str, status: str = "active") -> Dict[str, Any]:
 
 def get_task(*, user_id: str, task_ref: str) -> Dict[str, Any]:
     from core.db.engine import SessionLocal
-    from core.services.automation_service import AutomationService
+    from core.services.automation_service import AutomationService, SUMMARY_LIMIT_BRIEF
 
     with SessionLocal() as db:
         task, cands = _resolve_ref(db, user_id, task_ref)
@@ -195,7 +195,10 @@ def get_task(*, user_id: str, task_ref: str) -> Dict[str, Any]:
             return {"ok": False, "message": f"❌ 没找到任务：{task_ref}"}
         brief = _task_brief(task)
         runs = _svc(db).get_task_runs(task.task_id, limit=5)
-        brief["recent_runs"] = [AutomationService.run_to_dict(r) for r in runs]
+        # result_summary 存全文（渠道投递用），进模型上下文只要短摘要
+        brief["recent_runs"] = [
+            AutomationService.run_to_dict(r, summary_limit=SUMMARY_LIMIT_BRIEF) for r in runs
+        ]
     return {"ok": True, "task": brief}
 
 

--- a/src/backend/orchestration/schedulers/automation_scheduler.py
+++ b/src/backend/orchestration/schedulers/automation_scheduler.py
@@ -199,7 +199,7 @@ class AutomationScheduler:
 
         try:
             if task_type == "prompt":
-                chat_id, result_summary, usage = await asyncio.wait_for(
+                chat_id, result_text, usage = await asyncio.wait_for(
                     self._execute_prompt_task(
                         user_id=user_id,
                         task_name=task_name,
@@ -212,7 +212,7 @@ class AutomationScheduler:
                     timeout=TASK_EXECUTION_TIMEOUT_S,
                 )
             elif task_type == "plan":
-                chat_id, result_summary, usage = await asyncio.wait_for(
+                chat_id, result_text, usage = await asyncio.wait_for(
                     self._execute_plan_task(
                         user_id=user_id,
                         task_name=task_name,
@@ -227,7 +227,7 @@ class AutomationScheduler:
                 )
             elif task_type == "loop":
                 # Periodically advance a persistent autonomous loop (M4 scheduler integration); loop_id stored in task.extra_data
-                chat_id, result_summary, usage = await asyncio.wait_for(
+                chat_id, result_text, usage = await asyncio.wait_for(
                     self._execute_loop_task(
                         user_id=user_id,
                         task_name=task_name,
@@ -246,7 +246,9 @@ class AutomationScheduler:
                     run.run_id,
                     status="success",
                     chat_id=chat_id,
-                    result_summary=result_summary,
+                    # 存全文：这一份同时是渠道投递的正文来源，截断只发生在展示侧
+                    # （run_to_dict 的 summary_limit / 通知中心）。
+                    result_summary=result_text,
                     duration_ms=duration_ms,
                     usage=usage,
                 )
@@ -269,7 +271,7 @@ class AutomationScheduler:
             _targets = resolve_delivery_targets(task_metadata)
             if has_inapp(_targets):
                 await self._send_notification(
-                    user_id, task_id, task_name, "success", result_summary or "执行完成", chat_id
+                    user_id, task_id, task_name, "success", result_text or "执行完成", chat_id
                 )
             logger.info("[scheduler] task %s completed in %dms", task_id, duration_ms)
 
@@ -290,7 +292,7 @@ class AutomationScheduler:
                     _ok = await deliver_to_conversation(
                         _ch,
                         _conv,
-                        head + (result_summary or "执行完成"),
+                        head + (result_text or "执行完成"),
                         files=_gen_files,
                     )
                     if _ok:
@@ -521,8 +523,9 @@ class AutomationScheduler:
                 scope=project_scope_from_context(context),
             )
 
-        summary = full_response[:500] if full_response else "执行完成"
-        return chat_id, summary, usage
+        # 返回全文——这份文本同时是渠道投递（钉钉/飞书）的正文，在这里截断会让定时消息
+        # 只发出开头一段。摘要截断统一在展示侧做（见 automation_service.truncate_summary）。
+        return chat_id, (full_response or "执行完成"), usage
 
     async def _execute_plan_task(
         self,
@@ -700,8 +703,9 @@ class AutomationScheduler:
                 scope=project_scope_from_chat_id(db, chat_id),
             )
 
-        summary = (result_text or assistant_content)[:500]
-        return chat_id, summary, usage
+        # 同 _execute_prompt_task：返回全文，截断交给展示侧
+        # （assistant_content 上面已是 `result_text or 兜底文案`，无需再叠一层 or）
+        return chat_id, assistant_content, usage
 
     async def _execute_loop_task(self, *, user_id: str, task_name: str, loop_id):
         """Periodically advance a persistent autonomous loop: start/resume a loop run and wait for it to reach a terminal state (M4 scheduler integration).
@@ -886,6 +890,10 @@ class AutomationScheduler:
     ):
         try:
             from core.infra.redis import get_redis
+            from core.services.automation_service import (
+                SUMMARY_LIMIT_BRIEF,
+                truncate_summary,
+            )
 
             redis = get_redis()
             notification = {
@@ -893,7 +901,9 @@ class AutomationScheduler:
                 "task_id": task_id,
                 "task_name": task_name,
                 "status": status,
-                "summary": summary[:200],
+                # 走统一截断策略：result_summary 现在是全文，裸切会把整篇报告拦腰截断且
+                # 不带任何提示，与运行历史列表的观感不一致。
+                "summary": truncate_summary(summary, SUMMARY_LIMIT_BRIEF),
                 "chat_id": chat_id,
                 "timestamp": int(datetime.utcnow().timestamp() * 1000),
                 "read": False,


### PR DESCRIPTION
Two independent bugs, both user-visible.

## 1. Scheduled tasks delivered a truncated report

`ScheduledTaskRun.result_summary` doubles as the **body that gets delivered to IM channels**. The executor truncated it with `full_response[:500]` *before* writing it to the database, so every scheduled report pushed into a group arrived cut off after the opening paragraph — and nothing marked it as truncated, so it just looked like the agent had stopped mid-thought.

### Fix

The executor now stores the **full text**, and truncation happens only where results are *displayed*. The limits are consolidated into a single source of truth in `automation_service` (`truncate_summary` + `SUMMARY_LIMIT_LIST` / `SUMMARY_LIMIT_BRIEF`), so every truncated view is consistent — they all get an ellipsis, instead of one path slicing bare and another not:

| Consumer | Limit | Why |
|---|---|---|
| Run-history list | 500 | The UI line-clamps to two lines anyway |
| Notification cards, MCP `get_task` → `recent_runs` | 200 | Goes into a small card, or into model context |
| `run_to_dict` without `summary_limit` | full text | For callers that genuinely need the whole result |

The `/runs` endpoint also gains an upper bound on `limit` (`1..100`). Now that `result_summary` holds full reports rather than 500-char snippets, an unbounded `limit` would pull hundreds of complete reports into memory in one request.

## 2. Capability health tab returned 500

A hand-authored skill has no release record, so its exposure window is "it has always been there" and `exposure_days` is `inf`.

The summary table already mapped that to null, but the **retirement buckets passed the raw stats through**, and a bare `inf` makes the entire response fail to serialise. The observable symptom: the health tab 500s as soon as the analysis finds any built-in skill that has never been opened — which is the most ordinary finding there is, so the tab broke in normal use.

### Fix

Both sides:
- Non-finite floats are mapped to null before serialisation (covering `nan` and `-inf` as well, not just `inf`).
- The explanation text no longer prints "exposed inf days"; when the window is unbounded it says the capability has always been available.

## Tests

No behaviour is newly branched here beyond the truncation helper, and the existing automation, scheduler and evolution suites pass unchanged (664 selected tests green, with one pre-existing unrelated failure in `test_inbound_ingest_attachments_stores_artifact` that is present on `main` as well).