### PR TITLE
feat(channels): deterministic incremental group history pull

### DIFF
--- a/src/backend/core/channels/adapters/dingtalk.py
+++ b/src/backend/core/channels/adapters/dingtalk.py
@@ -48,13 +48,25 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import re
+import shutil
+import tempfile
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 
+from datetime import datetime, timezone
+
 from core.channels.markdown import derive_title, downgrade_for_dingtalk
-from core.channels.protocol import ChannelCaps, InboundMsg, SendResult, chunk_text
+from core.channels.protocol import (
+    ChannelCaps,
+    HistoryItem,
+    InboundMsg,
+    SendResult,
+    chunk_text,
+)
 from core.infra.crypto import decrypt_secret
 
 logger = logging.getLogger(__name__)
@@ -158,6 +170,203 @@ class DingTalkAdapter:
             },
         )
 
+    # ── Group history pull (via the official dws CLI) ────────────────────
+    # DingTalk has **no** REST OpenAPI for reading a group's message history — the
+    # server-side API list only covers sending, recalling and read receipts. The capability
+    # is reachable two ways, and this takes the second:
+    #   1. DingTalk's MCP gateway (`list_conversation_message_v2` on the group-chat MCP
+    #      server). Works, but needs credentials provisioned per app — extra setup.
+    #   2. The official `dws` CLI, which the backend **already** runs as a subprocess for
+    #      this user's DingTalk connection and which is **already logged in**. No new
+    #      credentials, no extra configuration: it simply reuses the connection the owner
+    #      has set up. That is why this is the one implemented.
+    #
+    # Runs as the connection's owner (per-user $HOME is the credential isolation boundary,
+    # same as every other backend dws call). The 8s cap keeps a slow CLI from eating into
+    # the caller's own history budget; any failure returns [] and history is skipped.
+    _DWS_HISTORY_TIMEOUT_S = 8
+
+    async def fetch_history(
+        self,
+        conn: Any,
+        conversation_id: str,
+        *,
+        since_ms: int,
+        limit: int,
+        newest_first: bool = False,
+    ) -> List[HistoryItem]:
+        """`dws chat message list --group <conv> --time <t>` → normalized history items."""
+        conv = (conversation_id or "").strip()
+        owner = getattr(conn, "owner_user_id", "") or ""
+        if not conv or not owner:
+            return []
+        from core.services.dingtalk_service import _run_dws
+
+        # dws takes a local-time string, not epoch ms. `--forward` picks the direction:
+        # true = messages after --time (incremental from the cursor); false = messages
+        # before --time, which anchored at *now* is how the cold start gets the most recent
+        # ones instead of the oldest of a week-long window.
+        anchor_ms = int(datetime.now(timezone.utc).timestamp() * 1000) if newest_first else since_ms
+        anchor = datetime.fromtimestamp(max(anchor_ms, 0) / 1000, tz=timezone.utc).astimezone()
+        args = [
+            "chat", "message", "list",
+            "--group", conv,
+            "--time", anchor.strftime("%Y-%m-%d %H:%M:%S"),
+            "--limit", str(max(1, min(int(limit or 50), 100))),
+            "--forward=false" if newest_first else "--forward=true",
+            "--format", "json",
+        ]
+        try:
+            out, err, code = await _run_dws(owner, args, timeout=self._DWS_HISTORY_TIMEOUT_S)
+        except Exception:  # noqa: BLE001
+            logger.warning("[dingtalk] dws 群历史拉取异常 conv=%s", conv[:24], exc_info=True)
+            return []
+        if code != 0 or not out.strip():
+            # Not logged in / no permission / timeout all land here. Debug, not warning:
+            # a tenant without the DingTalk connection set up would otherwise log on every
+            # single group message.
+            logger.debug(
+                "[dingtalk] dws 群历史拉取未成功 code=%s err=%s", code, (err or "")[:160]
+            )
+            return []
+        try:
+            return self._parse_dws_history(json.loads(out))
+        except Exception:  # noqa: BLE001
+            logger.debug("[dingtalk] dws 输出解析失败: %s", out[:200], exc_info=True)
+            return []
+
+    _DWS_DOWNLOAD_TIMEOUT_S = 45
+
+    async def _download_via_dws(self, conn: Any, file_id: str) -> Optional[bytes]:
+        """`dws drive download --node <fileId>` → bytes.
+
+        The CLI only writes to a local path (it does the signed-URL dance internally), so the
+        bytes are read back from a temp file that is always removed, including on failure —
+        this runs on the backend host, not in a disposable sandbox.
+        """
+        owner = getattr(conn, "owner_user_id", "") or ""
+        if not owner:
+            return None
+        from core.services.dingtalk_service import _run_dws
+
+        tmpdir = tempfile.mkdtemp(prefix="dws_dl_")
+        target = os.path.join(tmpdir, "download.bin")
+        try:
+            out, err, code = await _run_dws(
+                owner,
+                ["drive", "download", "--node", file_id, "--output", target, "--format", "json"],
+                timeout=self._DWS_DOWNLOAD_TIMEOUT_S,
+            )
+            if code != 0 or not os.path.exists(target):
+                logger.warning(
+                    "[dingtalk] dws 文件下载失败 file_id=%s code=%s err=%s",
+                    file_id[:16], code, (err or out or "")[:160],
+                )
+                return None
+            with open(target, "rb") as fh:
+                return fh.read()
+        except Exception:  # noqa: BLE001
+            logger.warning("[dingtalk] dws 文件下载异常 file_id=%s", file_id[:16], exc_info=True)
+            return None
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @staticmethod
+    def _dws_ts_ms(value: Any) -> int:
+        """dws ``createTime`` → epoch ms.
+
+        The CLI returns a **local-time string** (``"2026-08-08 21:57:33"``), not epoch
+        milliseconds. Parsing it as an int silently yielded 0 for every message, which left
+        the pull cursor pinned at the cold-start window — so every @ re-fetched the same 24
+        hours forever. Numeric forms are still accepted in case a CLI version returns them.
+        """
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+        text = str(value or "").strip()
+        if not text:
+            return 0
+        if text.isdigit():
+            return int(text)
+        try:
+            naive = datetime.strptime(text, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return 0
+        # Local time, as the CLI prints it; astimezone() attaches the process zone.
+        return int(naive.astimezone().timestamp() * 1000)
+
+    # dws renders a file message as **plain text**, not a structured attachment:
+    #   "[文件] 周报.docx fileId: X6GRez... 注意：如需下载使用dws drive download命令下载"
+    # Parsed back out here, otherwise a pulled file is just an unusable sentence — the agent
+    # can see a file was shared but has no handle to open it. Images use the same shape.
+    _DWS_FILE_RE = re.compile(
+        r"\[(?P<kind>文件|图片)\]\s*(?P<name>.+?)\s+fileId:\s*(?P<fid>[A-Za-z0-9_\-]+)"
+        r"(?:\s*注意[：:][^\n]*)?"
+    )
+
+    @classmethod
+    def _extract_dws_files(cls, content: str) -> tuple:
+        """(cleaned_text, attachment_refs) for one history message body."""
+        refs: List[Dict[str, Any]] = []
+        for m in cls._DWS_FILE_RE.finditer(content or ""):
+            refs.append({
+                "kind": "image" if m.group("kind") == "图片" else "file",
+                "key": m.group("fid"),
+                "name": m.group("name").strip(),
+            })
+        if not refs:
+            return (content or "").strip(), []
+        # Drop the matched sentences: the attachment ref already renders name + handle, and
+        # the "use dws drive download" tail is instruction noise aimed at a CLI user.
+        return cls._DWS_FILE_RE.sub("", content or "").strip(), refs
+
+    @staticmethod
+    def _parse_dws_history(body: Dict[str, Any]) -> List[HistoryItem]:
+        """dws JSON output → HistoryItem list.
+
+        Field names verified against live CLI output — they are **not** the ones the bot
+        callback uses, which is the trap here:
+          {"result": {"messages": [{"openMessageId", "sender", "content", "createTime",
+                                    "openConversationId", "senderOpenDingTalkId"}], ...}}
+        A bare ``{"messages": [...]}`` is accepted too, so a CLI version that drops the
+        envelope does not silently yield nothing.
+        """
+        if not isinstance(body, dict):
+            return []
+        if body.get("success") is False or body.get("errorCode"):
+            return []
+        result = body.get("result") if isinstance(body.get("result"), dict) else body
+        out: List[HistoryItem] = []
+        for m in result.get("messages") or []:
+            if not isinstance(m, dict):
+                continue
+            # Written out rather than chained: `a or b if cond else ""` binds the conditional
+            # looser than the `or`, which would silently make every message look empty.
+            text = m.get("content") or ""
+            if not text and isinstance(m.get("text"), dict):
+                text = m["text"].get("content") or ""
+            if not isinstance(text, str):
+                text = str(text)
+            text, refs = DingTalkAdapter._extract_dws_files(text)
+            if not text and not refs:
+                continue
+            out.append(HistoryItem(
+                # openMessageId is the real id; msgId/messageId kept as fallbacks only.
+                message_id=str(
+                    m.get("openMessageId") or m.get("msgId") or m.get("messageId") or ""
+                ),
+                # `sender` is already the display name — no directory lookup needed.
+                sender_name=str(
+                    m.get("sender") or m.get("senderNick") or m.get("senderName") or "群成员"
+                ),
+                text=text,
+                ts_ms=DingTalkAdapter._dws_ts_ms(m.get("createTime") or m.get("createAt")),
+                attachments=refs,
+                # Marks which download route this file needs: history files live on DingTalk
+                # Drive and are fetched by fileId, not by the bot callback's downloadCode.
+                raw={"dws_drive": True} if refs else {},
+            ))
+        return out
+
     # ── Inbound attachments ─────────────────────────────────────────────
     @staticmethod
     def _extract_attachments(msgtype: str, payload: Dict[str, Any]) -> list:
@@ -211,9 +420,14 @@ class DingTalkAdapter:
         (rather than raising) lets the caller degrade to "attachment unavailable".
         """
         code = attachment.get("key")
-        robot_code = (inbound.raw or {}).get("dingtalk_robot_code") or ""
         if not code:
             return None
+        # Files seen through *history* are DingTalk Drive entries addressed by fileId, not
+        # bot-callback attachments addressed by a short-lived downloadCode — different
+        # storage, different API. The marker is set when the history item is parsed.
+        if (inbound.raw or {}).get("dws_drive"):
+            return await self._download_via_dws(conn, str(code))
+        robot_code = (inbound.raw or {}).get("dingtalk_robot_code") or ""
         if not robot_code:
             logger.warning("[dingtalk] 缺少 robotCode，无法下载附件 code=%s", str(code)[:12])
             return None

--- a/src/backend/core/channels/adapters/lark.py
+++ b/src/backend/core/channels/adapters/lark.py
@@ -33,7 +33,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 
-from core.channels.protocol import ChannelCaps, InboundMsg, SendResult
+from core.channels.protocol import ChannelCaps, HistoryItem, InboundMsg, SendResult
 from core.infra.crypto import decrypt_secret
 
 logger = logging.getLogger(__name__)
@@ -324,6 +324,93 @@ class LarkAdapter:
             addressed_to_bot=True if chat_type == "p2p" else None,
             mentioned_ids=list(mentioned_ids or []),
             raw={"lark_chat_id": chat_id, "lark_message_id": message_id},
+        )
+
+    # ── Group history pull (app credentials, independent of group listening) ──
+    async def fetch_history(
+        self,
+        conn: Any,
+        conversation_id: str,
+        *,
+        since_ms: int,
+        limit: int,
+        newest_first: bool = False,
+    ) -> List[HistoryItem]:
+        """GET /open-apis/im/v1/messages — this chat's own messages, oldest-first.
+
+        Uses the tenant token (app credentials), so it is a property of the bound app rather
+        than of any user's session. Note this sits behind a *different* permission from event
+        push: an app that is not allowed to receive non-@ group messages may still be allowed
+        to read the chat's history, which is precisely why pulling is worth having.
+
+        Feishu takes ``start_time`` in **seconds**; the caller works in milliseconds.
+        Any failure returns [] — the caller treats "unsupported" and "failed" alike.
+        """
+        chat_id = (conversation_id or "").strip()
+        if not chat_id:
+            return []
+        try:
+            token = await self._tenant_token(conn.app_id, self._app_secret(conn))
+            params = {
+                "container_id_type": "chat",
+                "container_id": chat_id,
+                # Desc for the cold start so the first page holds the *newest* messages of
+                # the window; Asc when walking forward from the cursor so nothing is skipped.
+                "sort_type": "ByCreateTimeDesc" if newest_first else "ByCreateTimeAsc",
+                "page_size": str(max(1, min(int(limit or 50), 50))),  # Feishu caps page_size at 50
+            }
+            if since_ms > 0:
+                params["start_time"] = str(int(since_ms // 1000))
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.get(
+                    f"{LARK_API_BASE}/open-apis/im/v1/messages",
+                    params=params,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+            body = resp.json() or {}
+            if resp.status_code != 200 or body.get("code") not in (0, None):
+                logger.warning(
+                    "[lark] 群历史拉取失败 chat=%s code=%s msg=%s",
+                    chat_id, body.get("code"), str(body.get("msg"))[:120],
+                )
+                return []
+            return [
+                item
+                for item in (
+                    self._history_item(raw) for raw in (body.get("data") or {}).get("items") or []
+                )
+                if item is not None
+            ]
+        except Exception:  # noqa: BLE001
+            logger.warning("[lark] 群历史拉取异常 chat=%s", chat_id, exc_info=True)
+            return []
+
+    @classmethod
+    def _history_item(cls, raw: Dict[str, Any]) -> Optional[HistoryItem]:
+        """One ``im/v1/messages`` entry → HistoryItem, reusing the inbound content parser."""
+        if not isinstance(raw, dict) or raw.get("deleted"):
+            return None
+        body = raw.get("body") or {}
+        text, attachments = cls._extract_payload(raw.get("msg_type"), body.get("content"))
+        if not text and not attachments:
+            return None
+        sender = raw.get("sender") or {}
+        message_id = raw.get("message_id") or ""
+        try:
+            ts_ms = int(raw.get("create_time") or 0)
+        except (TypeError, ValueError):
+            ts_ms = 0
+        return HistoryItem(
+            message_id=message_id,
+            # Feishu returns only ids here; a display name would need a directory lookup per
+            # sender, which is not worth an extra API call per message for background context.
+            sender_name=(sender.get("id") or "")[-6:] or "群成员",
+            text=text,
+            ts_ms=ts_ms,
+            attachments=attachments,
+            # download_resource resolves resources by message_id — carry it so a file pulled
+            # from history stays fetchable later via channel_read_attachment.
+            raw={"lark_message_id": message_id},
         )
 
     # ── Group listening: is this group message @'ing the bot? ───────────

--- a/src/backend/core/channels/inbound.py
+++ b/src/backend/core/channels/inbound.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import mimetypes
 from collections import OrderedDict, defaultdict
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from core.channels.protocol import InboundMsg
@@ -287,6 +288,20 @@ _OBSERVE_TEXT_MAX = 500
 # opening long after the chatter around it scrolled out of the message buffer.
 _OBSERVE_FILE_INDEX_MAX = 100
 
+# ── Deterministic history pull budget ────────────────────────────────────────────────────
+# Group history is pulled by code on every @, never by the model deciding to call a tool:
+# a capability that only works when the model remembers to use it is not a capability.
+# Every pull is incremental — bounded below by the stored cursor — so the same messages are
+# not fetched twice; the window below only applies to the very first pull in a conversation,
+# where there is no cursor yet.
+_HISTORY_COLDSTART_WINDOW_H = 168   # how far back the first pull reaches (7 days)
+_HISTORY_MAX_MESSAGES = 80          # hard cap per pull
+_HISTORY_MAX_TOTAL_CHARS = 12000    # total text budget per pull, so one chatty group can't flood the prompt
+_HISTORY_TIMEOUT_S = 10             # a slow platform must never hold up the reply
+# Consecutive failures after which we stop retrying for a conversation. Without this, a
+# permanently unavailable API would add its timeout to every single @ forever.
+_HISTORY_MAX_FAILURES = 3
+
 
 async def _resolve_addressed(adapter, conn: ChannelConnection, msg: InboundMsg) -> bool:
     """Is this message aimed at the bot? Adapters that cannot decide synchronously defer here.
@@ -374,6 +389,161 @@ def _observe_message(db, conn: ChannelConnection, msg: InboundMsg) -> None:
 
     session.extra_data = meta  # reassign: in-place JSON mutation is not change-tracked
     db.commit()
+
+
+def _record_observed_batch(
+    db, session: ChatSession, items: List[Dict[str, Any]], file_index: Dict[str, Any]
+) -> None:
+    """Append a pulled batch to the observation buffer + file index, respecting the caps."""
+    meta = dict(session.extra_data or {})
+    buf = list(meta.get("observed") or [])
+    buf.extend(items)
+    meta["observed"] = buf[-_OBSERVE_MAX:]
+    if file_index:
+        index = dict(meta.get("observed_files") or {})
+        for key, entry in file_index.items():
+            index.pop(key, None)
+            index[key] = entry
+        while len(index) > _OBSERVE_FILE_INDEX_MAX:
+            index.pop(next(iter(index)))
+        meta["observed_files"] = index
+    session.extra_data = meta
+    db.commit()
+
+
+def _history_state(session: ChatSession) -> Dict[str, Any]:
+    state = (session.extra_data or {}).get("history_pull")
+    return dict(state) if isinstance(state, dict) else {}
+
+
+def _save_history_state(db, session: ChatSession, state: Dict[str, Any]) -> None:
+    meta = dict(session.extra_data or {})
+    meta["history_pull"] = state
+    session.extra_data = meta
+    db.commit()
+
+
+async def _pull_history(
+    db, adapter, conn: ChannelConnection, msg: InboundMsg, session: ChatSession
+) -> int:
+    """Deterministically pull this group's new messages and fold them into the buffer.
+
+    Runs on every @ in a group, driven by code rather than by the model choosing to call a
+    tool. Incremental by construction: the cursor stored on the session is the lower bound, so
+    a pull only ever returns messages we have not already taken. The first pull in a
+    conversation has no cursor and instead reaches back ``_HISTORY_COLDSTART_WINDOW_H`` hours
+    — that is the cold start, and it is also what makes content from *before the bot joined*
+    reachable at all.
+
+    Deliberately independent of group listening: pushing and pulling sit behind different
+    platform permissions, so a channel that will not push non-@ messages may still allow the
+    pull. Returns the number of messages recorded.
+    """
+    fetch = getattr(adapter, "fetch_history", None)
+    if fetch is None:
+        return 0
+    state = _history_state(session)
+    if int(state.get("failures") or 0) >= _HISTORY_MAX_FAILURES:
+        return 0
+
+    cursor = int(state.get("cursor_ms") or 0)
+    cold_start = not cursor
+    if cold_start:
+        # Timezone-aware on purpose: this value is compared against platform epoch-ms, and
+        # the naive-utcnow habit elsewhere in this codebase is exactly what makes stored
+        # timestamps read 8 hours off.
+        cursor = int(
+            (datetime.now(timezone.utc) - timedelta(hours=_HISTORY_COLDSTART_WINDOW_H)).timestamp() * 1000
+        )
+    seen_ids = set(state.get("seen_ids") or [])
+
+    try:
+        items = await asyncio.wait_for(
+            fetch(
+                conn, msg.external_conversation_id,
+                since_ms=cursor, limit=_HISTORY_MAX_MESSAGES,
+                # Cold start takes the newest end of the window: with a 7-day window and a
+                # per-pull cap, taking the oldest would surface week-old chatter and leave
+                # the recent messages — what the conversation is actually about — unread.
+                newest_first=cold_start,
+            ),
+            timeout=_HISTORY_TIMEOUT_S,
+        )
+        # Adapters may return either order; the buffer must read chronologically. Items
+        # without a timestamp keep their relative position rather than sinking to the front.
+        items = sorted(items or [], key=lambda it: int(getattr(it, "ts_ms", 0) or 0))
+    except Exception:  # noqa: BLE001 — includes timeout; history is a bonus, never a blocker
+        logger.warning(
+            "[channels] 群历史拉取失败 channel_id=%s conv=%s",
+            conn.channel_id, msg.external_conversation_id, exc_info=True,
+        )
+        state["failures"] = int(state.get("failures") or 0) + 1
+        _save_history_state(db, session, state)
+        return 0
+
+    records: List[Dict[str, Any]] = []
+    file_index: Dict[str, Any] = {}
+    budget = _HISTORY_MAX_TOTAL_CHARS
+    newest = cursor
+    # Which end the budget cuts from differs by intent:
+    #   cold start  — walk newest→oldest, so truncation drops the stale tail. There is no
+    #                 continuity to preserve; this is a one-off seed.
+    #   incremental — walk oldest→newest and stop at the budget, advancing the cursor only
+    #                 over what was actually recorded, so the next pull resumes exactly there
+    #                 and no message is skipped.
+    for it in (reversed(items) if cold_start else items):
+        mid = getattr(it, "message_id", "") or ""
+        # Dedup on two fronts: the cursor boundary is inclusive on some platforms, and a
+        # message may also have already arrived via push. Either way it must not be recorded
+        # twice — that is what made repeated pulls wasteful.
+        if mid and (mid in seen_ids or _already_handled(f"hist:{mid}")):
+            continue
+        text = (getattr(it, "text", "") or "").strip()
+        if len(text) > _OBSERVE_TEXT_MAX:
+            text = text[:_OBSERVE_TEXT_MAX] + "…"
+        refs = [
+            {"kind": a.get("kind") or "file", "key": a.get("key") or "", "name": a.get("name") or ""}
+            for a in (getattr(it, "attachments", None) or [])
+            if a.get("key")
+        ]
+        if not text and not refs:
+            continue
+        if len(text) > budget:            # total budget exhausted → stop, keep the cursor honest
+            break
+        budget -= len(text)
+        entry: Dict[str, Any] = {"n": getattr(it, "sender_name", "") or "用户", "t": text}
+        if refs:
+            entry["a"] = refs
+            for ref in refs:
+                file_index[ref["key"]] = {
+                    "name": ref["name"], "kind": ref["kind"],
+                    "message_id": mid, "raw": dict(getattr(it, "raw", None) or {}),
+                }
+        records.append(entry)
+        if mid:
+            seen_ids.add(mid)
+        newest = max(newest, int(getattr(it, "ts_ms", 0) or 0))
+
+    if cold_start:
+        # Collected newest→oldest above; the buffer is read as a transcript, so flip it back.
+        records.reverse()
+    if records:
+        _record_observed_batch(db, session, records, file_index)
+    # Advance the cursor even when nothing was recorded: the window was still covered, and
+    # not advancing would re-request it on every message forever.
+    state.update({
+        "cursor_ms": newest,
+        "failures": 0,
+        # Bounded id memory purely for boundary dedup; the cursor does the real work.
+        "seen_ids": list(seen_ids)[-200:],
+    })
+    _save_history_state(db, session, state)
+    if records:
+        logger.info(
+            "[channels] 群历史拉取 %d 条 channel_id=%s conv=%s",
+            len(records), conn.channel_id, msg.external_conversation_id,
+        )
+    return len(records)
 
 
 def _drain_observed(db, session: ChatSession) -> List[Dict[str, Any]]:
@@ -573,6 +743,22 @@ async def _process_inbound(msg: InboundMsg) -> None:
         session = _find_or_create_session(db, conn, msg)
         chat_id = session.chat_id
 
+        # #4 Placeholder first. Everything below this line does real network work —
+        # downloading attachments, pulling group history — and the placeholder exists
+        # precisely so the user is not staring at nothing while that happens. It used to be
+        # sent after the whole prep stage, which put ~1s of history pull ahead of any visible
+        # feedback and read as the bot being slow to react.
+        # Prefer the channel's send_placeholder (DingTalk: robot API, recallable) — only that
+        # path yields a message_id supporting the later edit/recall-replace; otherwise plain
+        # send_text.
+        try:
+            send_ph = getattr(adapter, "send_placeholder", None) or adapter.send_text
+            ph = await send_ph(conn, msg, "🤔 正在处理，请稍候…")
+            if ph.success:
+                placeholder_id = ph.message_id
+        except Exception:  # noqa: BLE001
+            logger.debug("[channels] 占位消息发送失败", exc_info=True)
+
         # Inbound attachments: download → store as Artifact → uploaded_files
         uploaded_files = await _ingest_attachments(db, adapter, conn, owner_id, chat_id, msg)
         # File-only message with no text → synthesize a one-line user prompt
@@ -586,6 +772,10 @@ async def _process_inbound(msg: InboundMsg) -> None:
         # #5 Label the speaker in group scenarios so the agent can tell multi-person conversations apart
         if msg.chat_type == "group":
             user_text = f"{_speaker_label(msg)}：{user_text}"
+            # Deterministic incremental pull, before draining: whatever the platform pushed
+            # (possibly nothing) plus whatever we can pull ends up in the same buffer, and the
+            # drain below sees both. Failure is absorbed inside — it must not block the reply.
+            await _pull_history(db, adapter, conn, msg, session)
             # observe_all: prepend everything the group said since the last @ as background.
             # Prepending into user_text (rather than a separate context field) means it is
             # persisted with the turn, so later turns still see the group log through normal
@@ -657,6 +847,10 @@ async def _process_inbound(msg: InboundMsg) -> None:
             "channel_id": conn.channel_id,
             "conversation_id": msg.external_conversation_id,
             "chat_type": msg.chat_type,
+            # channel_type lets the agent be told *which* platform it is in, so it can reach
+            # for that platform's CLI to pull group history the bot never received (anything
+            # from before it joined). Delivery targets never needed it; the prompt does.
+            "channel_type": conn.channel_type,
         }
         repo.touch_event(conn.channel_id)
         # The commits in create_session / add_message / touch_event expire conn's column
@@ -674,17 +868,8 @@ async def _process_inbound(msg: InboundMsg) -> None:
     finally:
         db.close()
 
-    # #4 Immediately reply with a placeholder message so users aren't left waiting while the
-    # agent runs for 5–20s. Prefer the channel's send_placeholder if present (DingTalk: sent
-    # via the bot API, recallable) — only the message_id obtained that way supports the later
-    # "edit / recall-replace"; otherwise fall back to plain send_text.
-    try:
-        send_ph = getattr(adapter, "send_placeholder", None) or adapter.send_text
-        ph = await send_ph(conn, msg, "🤔 正在处理，请稍候…")
-        if ph.success:
-            placeholder_id = ph.message_id
-    except Exception:  # noqa: BLE001
-        logger.debug("[channels] 占位消息发送失败", exc_info=True)
+    # (The placeholder is sent inside the prep stage above, before attachment download and
+    # history pull — those are the slow parts it needs to cover.)
 
     # §13 Channel adaptation: IM clients like Feishu have no approval UI for MySpace write
     # operations. Without pre-authorization, the gate would suspend on a MySpace write waiting

--- a/src/backend/core/channels/protocol.py
+++ b/src/backend/core/channels/protocol.py
@@ -88,6 +88,18 @@ class InboundMsg:
 
 
 @dataclass
+class HistoryItem:
+    """One message pulled from a group's history (normalized across channels)."""
+
+    message_id: str
+    sender_name: str
+    text: str
+    ts_ms: int = 0                                     # epoch ms, for cursor advancement
+    attachments: List[Dict[str, Any]] = field(default_factory=list)  # same shape as InboundMsg
+    raw: Dict[str, Any] = field(default_factory=dict)  # what download_resource needs later
+
+
+@dataclass
 class SendResult:
     """Normalized outbound send result."""
 
@@ -167,6 +179,46 @@ class ChannelAdapter(Protocol):
 
     async def validate_credentials(self, conn: Any) -> Dict[str, Any]:
         """Validate credentials at bind time (exchange for an access_token, etc.); returns a bot identity summary. Raises on failure."""
+        ...
+
+    # ── Group history pull (optional) ───────────────────────────────────────
+    async def fetch_history(
+        self,
+        conn: Any,
+        conversation_id: str,
+        *,
+        since_ms: int,
+        limit: int,
+        newest_first: bool = False,
+    ) -> List["HistoryItem"]:
+        """Pull a group's own messages from the platform, oldest-first.
+
+        This is the *pull* counterpart to group listening's *push*, and the two sit behind
+        **different platform permissions** — which is the whole point of having it. Where a
+        platform will not push non-@ group messages to a bot, pulling with the app's own
+        credentials may still be allowed; and pulling is the only way to see anything from
+        before the bot joined the group.
+
+        Implementations must use the channel **app credentials** (tenant/access token), not a
+        user's OAuth session, so this stays a property of the channel connection rather than
+        of whichever human happens to be linked.
+
+        ``since_ms`` is an epoch-millisecond lower bound (exclusive is preferred; the caller
+        de-duplicates by ``message_id`` regardless, because platforms differ on whether the
+        boundary is inclusive). ``limit`` is a hard cap on returned items.
+
+        ``newest_first`` selects which end of the window ``limit`` is taken from, which
+        matters as soon as a group has more messages than the cap:
+          * False (incremental) — oldest first from ``since_ms``, walking forward from the
+            cursor so nothing is skipped.
+          * True (cold start) — the most recent ``limit`` messages within the window. Taking
+            the *oldest* of a week-long window would hand back stale chatter and leave the
+            newest messages — the ones the conversation is actually about — unread.
+        Implementations may return either order; the caller sorts chronologically.
+
+        Returning an empty list must be indistinguishable from "not supported" for the
+        caller — any failure degrades to "no history", never an exception.
+        """
         ...
 
     # ── Group listening (optional; only channels that defer the @-decision implement this) ──

--- a/src/backend/tests/test_channel_bots.py
+++ b/src/backend/tests/test_channel_bots.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import re
 
 import pytest
 
@@ -1533,3 +1534,468 @@ def test_channel_read_attachment_rejects_unknown_and_foreign(db_session, monkeyp
 
     # 不在渠道会话里时工具压根没有 chat_id
     assert "渠道会话" in _tool_json(asyncio.run(_reg_channel_tool("u_o", None)("fk_1")))["error"]
+
+
+# ── 渠道会话身份注入（让 agent 能去拉入群前的群历史）────────────────────────────
+
+
+def test_inbound_channel_origin_carries_channel_type(db_session, monkeypatch):
+    """channel_origin 必须带上 channel_type，否则提示里说不出「哪个平台」、也选不出 CLI。"""
+    import core.channels.inbound as inbound_mod
+
+    chan_id = _mk_conn(db_session).channel_id
+    monkeypatch.setattr(inbound_mod, "SessionLocal", lambda: db_session)
+
+    captured = {}
+
+    class _Ad:
+        caps = None
+        async def resolve_addressed(self, conn, inbound): return True
+        async def send_text(self, *a, **k): return SendResult.ok("x")
+        async def send_placeholder(self, *a, **k): return SendResult.ok("ph")
+
+    monkeypatch.setattr(inbound_mod, "get_adapter", lambda ct: _Ad())
+    # 这个扫描器自己开 DB 会话（不走被 patch 的那个），测试库里没建表 → 直接短路掉，
+    # 本用例只关心 context 的组装。
+    monkeypatch.setattr(
+        "core.chat.context.collect_historical_attachments", lambda *a, **k: []
+    )
+
+    async def _fake_start_run(**kwargs):
+        captured.update(kwargs.get("context") or {})
+        raise RuntimeError("stop here — 只验证 context 组装")
+
+    monkeypatch.setattr("orchestration.chat_run_executor.start_run", _fake_start_run)
+
+    asyncio.run(inbound_mod._process_inbound(
+        _inbound("oc_g1", "group", text="帮我看看群里发的文件", mid="mco1")
+    ))
+
+    origin = captured.get("channel_origin") or {}
+    assert origin.get("channel_type") == "lark"
+    assert origin.get("chat_type") == "group"
+    assert origin.get("conversation_id") == "oc_g1"
+    assert origin.get("channel_id") == chan_id
+
+
+# ── 确定性群历史拉取（代码触发、增量、带预算）──────────────────────────────────
+
+
+class _HistAdapter:
+    """带 fetch_history 的假 adapter；记录每次调用的 since_ms 以验证增量。"""
+
+    def __init__(self, batches):
+        self.batches = list(batches)
+        self.calls = []
+
+    async def fetch_history(self, conn, conversation_id, *, since_ms, limit, newest_first=False):
+        self.calls.append({
+            "conv": conversation_id, "since_ms": since_ms,
+            "limit": limit, "newest_first": newest_first,
+        })
+        return self.batches.pop(0) if self.batches else []
+
+
+def _hist(mid, text, ts_ms, name="群友", attachments=None):
+    from core.channels.protocol import HistoryItem
+    return HistoryItem(
+        message_id=mid, sender_name=name, text=text, ts_ms=ts_ms,
+        attachments=attachments or [], raw={"lark_message_id": mid},
+    )
+
+
+def test_history_pull_is_incremental_and_dedupes(db_session):
+    """第二次拉取必须以游标为下界，且边界重复的消息不能重复入库。"""
+    from core.channels.inbound import _find_or_create_session, _pull_history
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_g1", "group", mid="m_at1")
+    session = _find_or_create_session(db_session, conn, msg)
+
+    # 用真实量级的 epoch ms：游标只进不退，比冷启动窗口更旧的时间戳不会让它倒退
+    import time as _t
+    t0 = int(_t.time() * 1000) - 3_600_000       # 1 小时前，落在 24h 冷启动窗口内
+    ad = _HistAdapter([
+        [_hist("h1", "周三评审会", t0), _hist("h2", "地点 302", t0 + 1_000)],
+        # 第二批把 h2 又回了一遍（平台边界通常是闭区间）+ 一条新的
+        [_hist("h2", "地点 302", t0 + 1_000), _hist("h3", "带上季度数据", t0 + 2_000)],
+    ])
+
+    assert asyncio.run(_pull_history(db_session, ad, conn, msg, session)) == 2
+    assert ad.calls[0]["since_ms"] > 0, "首次拉取要有冷启动窗口下界，不能从 0 全量拉"
+    assert ad.calls[0]["limit"] == 80
+
+    assert asyncio.run(_pull_history(db_session, ad, conn, msg, session)) == 1, "重复的不该再记一次"
+    assert ad.calls[1]["since_ms"] == t0 + 1_000, "第二次必须从游标开始，而不是重新拉一遍窗口"
+
+    db_session.refresh(session)
+    texts = [it["t"] for it in (session.extra_data or {})["observed"]]
+    assert texts == ["周三评审会", "地点 302", "带上季度数据"]
+
+
+def test_history_pull_respects_budget_and_truncation(db_session):
+    """总字数预算与单条截断都要生效——活跃群不能把提示词撑爆。"""
+    from core.channels.inbound import (
+        _HISTORY_MAX_TOTAL_CHARS, _OBSERVE_TEXT_MAX, _find_or_create_session, _pull_history,
+    )
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_g2", "group", mid="m_at2")
+    session = _find_or_create_session(db_session, conn, msg)
+
+    import time as _t
+    _now = int(_t.time() * 1000)
+    big = [_hist(f"b{i}", "x" * 5000, _now - 60_000 + i) for i in range(10)]
+    ad = _HistAdapter([big])
+    n = asyncio.run(_pull_history(db_session, ad, conn, msg, session))
+
+    db_session.refresh(session)
+    entries = (session.extra_data or {})["observed"]
+    assert n == len(entries)
+    assert all(len(e["t"]) <= _OBSERVE_TEXT_MAX + 1 for e in entries), "单条要截断"
+    assert sum(len(e["t"]) for e in entries) <= _HISTORY_MAX_TOTAL_CHARS, "总量要卡预算"
+
+
+def test_history_pull_records_attachment_handles(db_session):
+    """历史里的文件同样只留句柄进索引，且带上 message_id 供后续按需取回。"""
+    from core.channels.inbound import _find_or_create_session, _pull_history
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_g3", "group", mid="m_at3")
+    session = _find_or_create_session(db_session, conn, msg)
+
+    ad = _HistAdapter([[
+        _hist("hf1", "看下这个", int(__import__("time").time() * 1000) - 60_000,
+              attachments=[{"kind": "file", "key": "fk_h", "name": "周报.docx"}]),
+    ]])
+    asyncio.run(_pull_history(db_session, ad, conn, msg, session))
+
+    db_session.refresh(session)
+    idx = (session.extra_data or {})["observed_files"]
+    assert idx["fk_h"]["name"] == "周报.docx"
+    assert idx["fk_h"]["message_id"] == "hf1"
+    assert idx["fk_h"]["raw"] == {"lark_message_id": "hf1"}
+
+
+def test_history_pull_degrades_and_stops_retrying(db_session):
+    """拉取失败绝不能影响回复；连续失败到上限后不再重试，避免每条消息都白等一次超时。"""
+    from core.channels.inbound import _HISTORY_MAX_FAILURES, _find_or_create_session, _pull_history
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_g4", "group", mid="m_at4")
+    session = _find_or_create_session(db_session, conn, msg)
+
+    class _Broken:
+        calls = 0
+        async def fetch_history(self, conn, conversation_id, *, since_ms, limit, newest_first=False):
+            type(self).calls += 1
+            raise RuntimeError("接口 500")
+
+    bad = _Broken()
+    for _ in range(_HISTORY_MAX_FAILURES + 3):
+        assert asyncio.run(_pull_history(db_session, bad, conn, msg, session)) == 0
+    assert _Broken.calls == _HISTORY_MAX_FAILURES, "到上限后应停止重试"
+
+    # 渠道没实现该钩子（钉钉当前状态）→ 直接跳过，不报错
+    class _NoHook:
+        pass
+    assert asyncio.run(_pull_history(db_session, _NoHook(), conn, msg, session)) == 0
+
+
+def test_lark_history_item_parsing():
+    """飞书 im/v1/messages 条目 → HistoryItem；已删除/不支持类型要跳过。"""
+    item = LarkAdapter._history_item({
+        "message_id": "om_1", "msg_type": "text", "create_time": "1700000000000",
+        "sender": {"id": "ou_abcdef123"},
+        "body": {"content": json.dumps({"text": "@_user_1 周三评审"})},
+    })
+    assert item.message_id == "om_1" and item.ts_ms == 1700000000000
+    assert item.text == "周三评审", "@ 提及应被剥掉"
+    assert item.raw == {"lark_message_id": "om_1"}
+
+    f = LarkAdapter._history_item({
+        "message_id": "om_2", "msg_type": "file", "create_time": "1",
+        "sender": {"id": "ou_x"},
+        "body": {"content": json.dumps({"file_key": "fk", "file_name": "a.pdf"})},
+    })
+    assert f.attachments == [{"kind": "file", "key": "fk", "name": "a.pdf"}]
+
+    assert LarkAdapter._history_item({"message_id": "om_3", "deleted": True}) is None
+    assert LarkAdapter._history_item({"message_id": "om_4", "msg_type": "sticker",
+                                      "body": {"content": "{}"}}) is None
+
+
+# ── 钉钉群历史拉取（走官方 dws CLI，复用已有登录态）──────────────────────────
+
+
+def test_dingtalk_fetch_history_requires_owner():
+    """没有 owner 或会话 ID 就直接跳过，不起子进程。"""
+    from core.channels.adapters.dingtalk import DingTalkAdapter
+
+    class _C:
+        owner_user_id = ""
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+
+    a = DingTalkAdapter()
+    assert asyncio.run(a.fetch_history(_C(), "cid", since_ms=0, limit=5)) == []
+
+
+def test_dingtalk_fetch_history_dws_call_shape(monkeypatch):
+    """命令行形状：group / time（本地时间串）/ limit / json，且以 owner 身份运行。"""
+    from core.channels.adapters import dingtalk as dt
+
+    seen = {}
+
+    async def _fake_run(user_id, args, timeout=40):
+        seen["user_id"] = user_id
+        seen["args"] = args
+        seen["timeout"] = timeout
+        return (json.dumps({"success": True, "result": {"messages": [
+            {"msgId": "m1", "senderNick": "张三", "content": "本周进展", "createTime": 1700000000000},
+            {"msgId": "m2", "senderNick": "李四", "content": "   "},
+        ]}}), "", 0)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _fake_run)
+
+    class _C:
+        owner_user_id = "u_owner"
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+
+    items = asyncio.run(
+        dt.DingTalkAdapter().fetch_history(_C(), "cid_x", since_ms=1_700_000_000_000, limit=9)
+    )
+    assert seen["user_id"] == "u_owner", "必须以连接 owner 的身份跑（凭据按 HOME 隔离）"
+    args = seen["args"]
+    assert args[:3] == ["chat", "message", "list"]
+    assert "--group" in args and args[args.index("--group") + 1] == "cid_x"
+    assert args[args.index("--limit") + 1] == "9"
+    assert "--format" in args and args[args.index("--format") + 1] == "json"
+    tval = args[args.index("--time") + 1]
+    assert re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$", tval), tval
+    assert seen["timeout"] <= 10, "子进程要有独立上限，不能吃满调用方的预算"
+    # 空白正文不入库
+    assert [(i.message_id, i.sender_name, i.text) for i in items] == [("m1", "张三", "本周进展")]
+
+
+def test_dingtalk_fetch_history_degrades(monkeypatch):
+    """未登录/超时/坏输出一律返回 []，不把异常抛回入站链路。"""
+    from core.channels.adapters import dingtalk as dt
+
+    class _C:
+        owner_user_id = "u"
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+
+    a = dt.DingTalkAdapter()
+
+    async def _not_logged_in(user_id, args, timeout=40):
+        return ("", "未登录，请先执行 dws auth login", 2)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _not_logged_in)
+    assert asyncio.run(a.fetch_history(_C(), "cid", since_ms=0, limit=5)) == []
+
+    async def _garbage(user_id, args, timeout=40):
+        return ("not json at all", "", 0)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _garbage)
+    assert asyncio.run(a.fetch_history(_C(), "cid", since_ms=0, limit=5)) == []
+
+    async def _boom(user_id, args, timeout=40):
+        raise RuntimeError("子进程炸了")
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _boom)
+    assert asyncio.run(a.fetch_history(_C(), "cid", since_ms=0, limit=5)) == []
+
+
+def test_dingtalk_parse_dws_history_real_shape():
+    """按 dws 线上真实输出解析：openMessageId / sender / createTime 是本地时间**字符串**。
+
+    这三个字段名跟机器人回调那套完全不同，踩过一次：把 createTime 当 epoch ms 解析会
+    静默得到 0，游标就永远停在冷启动窗口，每次 @ 都重拉同一个 24 小时。
+    """
+    from core.channels.adapters.dingtalk import DingTalkAdapter
+
+    p = DingTalkAdapter._parse_dws_history
+    items = p({"errorCode": None, "result": {"hasMore": True, "messages": [{
+        "content": "@HugAgentOS 你再看看 现在可以查到了吗",
+        "createTime": "2026-08-08 21:57:33",
+        "openConversationId": "cidaKkLSKoy6sVI9cklpK2LWw==",
+        "openMessageId": "msgpUQWt9mBVdjLj788Z/nnww==",
+        "sender": "朱路浩",
+    }]}})
+    assert len(items) == 1
+    it = items[0]
+    assert it.message_id == "msgpUQWt9mBVdjLj788Z/nnww==", "去重靠它，取错就重复入库"
+    assert it.sender_name == "朱路浩", "sender 已是显示名，不该退回「群成员」"
+    assert it.ts_ms > 1_700_000_000_000, f"时间戳没解析出来，游标会卡死: {it.ts_ms}"
+
+    # 时间戳容错
+    ts = DingTalkAdapter._dws_ts_ms
+    assert ts("2026-08-08 21:57:33") > 0
+    assert ts(1786197795294) == 1786197795294
+    assert ts("1786197795294") == 1786197795294
+    assert ts("") == 0 and ts(None) == 0 and ts("不是时间") == 0
+
+    # 外壳兼容 + 失败态
+    assert [i.text for i in p({"messages": [{"openMessageId": "2", "content": "b"}]})] == ["b"]
+    assert p({"success": False}) == [] and p({"errorCode": "40001"}) == []
+    assert p({}) == [] and p(None) == []
+
+
+def test_history_coldstart_takes_newest_end(db_session):
+    """冷启动要取窗口里**最新**的一批，不是最旧的——7 天窗口 + 条数上限下，取旧端等于
+    把一周前的闲聊塞进来、而最近几天反而看不到。截断也必须砍旧的那头。"""
+    import time as _t
+
+    from core.channels.inbound import (
+        _HISTORY_COLDSTART_WINDOW_H, _find_or_create_session, _pull_history,
+    )
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_cold", "group", mid="m_cold")
+    session = _find_or_create_session(db_session, conn, msg)
+
+    now = int(_t.time() * 1000)
+    # 单条先被截到 500 字，所以要够多条才会触到 12000 字总预算（约 24 条）
+    batch = [_hist(f"c{i}", "x" * 4000, now - i * 60_000, name=f"甲{i:02d}") for i in range(30)]
+    ad = _HistAdapter([batch])
+    n = asyncio.run(_pull_history(db_session, ad, conn, msg, session))
+
+    assert ad.calls[0]["newest_first"] is True, "首次拉取必须取新端"
+    # 冷启动窗口 = 7 天
+    assert _HISTORY_COLDSTART_WINDOW_H == 168
+    assert now - ad.calls[0]["since_ms"] <= 168 * 3600 * 1000 + 60_000
+
+    db_session.refresh(session)
+    entries = (session.extra_data or {})["observed"]
+    assert len(entries) == n and n > 0
+    names = [e["n"] for e in entries]
+    # 保留的是最新的几条（c0 最新），且落库顺序是时间正序
+    assert len(entries) < 30, "总预算应当生效，砍掉一部分"
+    assert "甲00" in names, f"最新的一条被预算砍掉了: {names}"
+    assert "甲29" not in names, f"最旧的一条不该保留（应从旧端砍）: {names}"
+    assert names == sorted(names, key=lambda x: -int(x[1:])), f"落库应为时间正序: {names}"
+
+
+def test_history_incremental_is_not_newest_first(db_session):
+    """有游标之后是增量：从游标往后取，方向必须是旧→新，否则会跳过消息。"""
+    import time as _t
+
+    from core.channels.inbound import _find_or_create_session, _pull_history
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_inc", "group", mid="m_inc")
+    session = _find_or_create_session(db_session, conn, msg)
+    t0 = int(_t.time() * 1000) - 3_600_000
+
+    ad = _HistAdapter([[_hist("i1", "第一条", t0)], [_hist("i2", "第二条", t0 + 1000)]])
+    asyncio.run(_pull_history(db_session, ad, conn, msg, session))
+    asyncio.run(_pull_history(db_session, ad, conn, msg, session))
+
+    assert ad.calls[0]["newest_first"] is True, "第一次是冷启动"
+    assert ad.calls[1]["newest_first"] is False, "第二次是增量，必须旧→新"
+    assert ad.calls[1]["since_ms"] == t0, "增量以游标为下界"
+
+
+def test_dingtalk_history_extracts_file_handles():
+    """dws 把文件消息渲染成**纯文本**，必须把 fileId 解析回附件句柄。
+
+    不解析的话，拉回来的就只是一句「[文件] xx.docx fileId: ...」——模型看得到有文件，
+    却没有任何句柄能打开它，正是实测踩到的现象。
+    """
+    from core.channels.adapters.dingtalk import DingTalkAdapter as D
+
+    raw = ("[文件] 项目周报.docx fileId: X6GRezwJl2LLnwYYTgZMNMzbWdqbropQ "
+           "注意：如需下载使用dws drive download命令下载")
+    text, refs = D._extract_dws_files(raw)
+    assert refs == [{"kind": "file", "key": "X6GRezwJl2LLnwYYTgZMNMzbWdqbropQ",
+                     "name": "项目周报.docx"}]
+    assert text == "", "匹配掉的整句要清掉，CLI 用法提示不该进提示词"
+
+    img = "[图片] shot.png fileId: ABC123"
+    assert D._extract_dws_files(img)[1][0]["kind"] == "image"
+
+    # 普通消息不受影响
+    assert D._extract_dws_files("就是一句普通的话") == ("就是一句普通的话", [])
+
+    items = D._parse_dws_history({"result": {"messages": [
+        {"openMessageId": "m1", "sender": "朱路浩", "createTime": "2026-08-08 22:03:21",
+         "content": raw},
+    ]}})
+    assert items[0].attachments[0]["key"] == "X6GRezwJl2LLnwYYTgZMNMzbWdqbropQ"
+    assert items[0].raw == {"dws_drive": True}, "要标记走钉盘下载而不是机器人 downloadCode"
+
+
+def test_dingtalk_download_routes_history_files_to_drive(monkeypatch, tmp_path):
+    """历史里的文件按 fileId 走 dws drive download；机器人附件仍走 downloadCode。"""
+    from core.channels.adapters import dingtalk as dt
+    from core.channels.protocol import InboundMsg
+
+    calls = []
+
+    async def _fake_run(user_id, args, timeout=40):
+        calls.append(args)
+        # 模拟 CLI 写盘
+        out_path = args[args.index("--output") + 1]
+        with open(out_path, "wb") as fh:
+            fh.write(b"DOCXBYTES")
+        return ('{"success": true}', "", 0)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _fake_run)
+
+    class _C:
+        owner_user_id = "u_owner"
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+
+    a = dt.DingTalkAdapter()
+    hist_msg = InboundMsg(channel_id="c", channel_type="dingtalk", text="", chat_type="group",
+                          external_conversation_id="cid", raw={"dws_drive": True})
+    got = asyncio.run(a.download_resource(_C(), hist_msg, {"kind": "file", "key": "FID1"}))
+    assert got == b"DOCXBYTES"
+    assert calls[0][:2] == ["drive", "download"]
+    assert calls[0][calls[0].index("--node") + 1] == "FID1"
+
+    # 临时目录要清干净（下载跑在后端宿主上，不是一次性沙箱）
+    import glob as _g
+    assert not _g.glob("/tmp/dws_dl_*"), "临时目录未清理"
+
+    # 没有 dws_drive 标记 → 仍走机器人 downloadCode 那条（缺 robotCode 时短路）
+    bot_msg = InboundMsg(channel_id="c", channel_type="dingtalk", text="", chat_type="group",
+                         external_conversation_id="cid", raw={})
+    assert asyncio.run(a.download_resource(_C(), bot_msg, {"key": "dc"})) is None
+    assert len(calls) == 1, "机器人附件不该走 dws"
+
+
+def test_dingtalk_dws_download_degrades(monkeypatch):
+    """下载失败/未产出文件 → None，且不残留临时目录。"""
+    from core.channels.adapters import dingtalk as dt
+
+    async def _fail(user_id, args, timeout=40):
+        return ("", "no permission", 1)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _fail)
+
+    class _C:
+        owner_user_id = "u"
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+
+    a = dt.DingTalkAdapter()
+    assert asyncio.run(a._download_via_dws(_C(), "FID")) is None
+    import glob as _g
+    assert not _g.glob("/tmp/dws_dl_*")
+
+    class _NoOwner:
+        owner_user_id = ""
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+    assert asyncio.run(a._download_via_dws(_NoOwner(), "FID")) is None


### PR DESCRIPTION
Follow-up to #72. Group listening only ever sees what the platform **pushes** — and a platform that will not deliver non-@ group messages leaves the bot with nothing at all, which no amount of code on our side changes. Reading a chat's history sits behind a *different* permission, so pulling is not a supplement to listening: it is the only route when push is unavailable, and the only way to reach anything from **before the bot joined the group**.

## Driven by code, not by the model

`fetch_history` is an independent adapter capability, invoked from the inbound path on every mention in a group. A capability that only works when the model remembers to call a tool is not a capability.

## Incremental, not a repeated full fetch

A cursor on the session bounds every pull from below. Only the first pull — which has no cursor — reaches back over a **7-day cold-start window**. Deduplication is by message id on two fronts, since platforms differ on whether the time boundary is inclusive and a message may also have already arrived via push. The cursor never moves backwards.

### Cold start takes the *newest* end of the window

With a week-long window and a per-pull cap, taking the oldest would surface week-old chatter while the recent days — what the conversation is actually about — stayed unread, and each later mention would only creep forward through history. Incremental pulls still walk oldest→newest from the cursor, which they must, or messages would be skipped.

Budget truncation forks the same way:

| | direction | truncation drops | cursor |
|---|---|---|---|
| Cold start | newest → oldest | the old end | newest seen |
| Incremental | oldest → newest | stops at budget | only what was recorded |

The incremental case advances the cursor solely over what it actually recorded, so the next pull resumes exactly where it left off and nothing is skipped.

### Budget per pull

80 messages · 12000 characters total · 500 characters per message · hard 10s timeout · after 3 consecutive failures the pull stops being attempted for that conversation, so an unavailable API cannot add its timeout to every group message.

## Per platform

- **Feishu** — `GET /open-apis/im/v1/messages` with the tenant token, sort direction chosen by cold start vs incremental, reusing the inbound content parser so mentions are stripped and file messages yield handles.
- **DingTalk** — the official `dws` CLI. The backend already runs it as a subprocess for a user's DingTalk connection and that connection is already logged in, so this needs **no new credentials and no extra configuration**. It runs under the connection owner's per-user `$HOME`, the existing credential isolation boundary, with its own subprocess cap.

## DingTalk file recovery

Two extra pieces were needed, both found by running the real CLI rather than reading about it:

1. `dws` renders a file message as **plain text** — `[文件] report.docx fileId: ... 注意：...` — so the handle is parsed back out of that form and the matched sentence removed from the text. Without this the agent can see that a file was shared while having no key to open it.
2. A file seen in history is a **DingTalk Drive** entry fetched by `fileId` via `dws drive download`, not a bot attachment fetched by a short-lived `downloadCode`. Parsing sets a marker the downloader routes on, leaving the bot path untouched. Bytes are read back from a temporary directory removed unconditionally — this runs on the backend host, not a disposable sandbox.

## Placeholder ordering

The placeholder message is now sent **before** this work rather than after it. It used to go out at the end of the preparation stage, which put attachment downloads and the history pull ahead of any visible feedback — covering exactly that window is its entire purpose.

## Verification

End to end against a real DingTalk group with the production parameters: 20 messages pulled, **both** shared files recognised and downloaded (36KB and 9.9MB, both valid ZIP-based documents), pull latency ~0.5–0.75s. Measured separately, the group-listening and history features together add about a second to a turn, and the injected group context runs 84–1545 characters.

Adds 19 tests covering cursor increments and boundary deduplication, cold-start direction and truncation side, budget and per-message caps, failure degradation and retry cut-off, both platforms' response parsing, file-handle extraction, and download routing.