### PR TITLE
feat(channels): support DingTalk online documents; surface the platform's own reason

### DIFF
--- a/src/backend/core/channels/adapters/dingtalk.py
+++ b/src/backend/core/channels/adapters/dingtalk.py
@@ -62,6 +62,7 @@ from datetime import datetime, timezone
 from core.channels.markdown import derive_title, downgrade_for_dingtalk
 from core.channels.protocol import (
     ChannelCaps,
+    ChannelResourceError,
     HistoryItem,
     InboundMsg,
     SendResult,
@@ -237,6 +238,64 @@ class DingTalkAdapter:
 
     _DWS_DOWNLOAD_TIMEOUT_S = 45
 
+    @staticmethod
+    def _dws_business_error(raw_out: str) -> Optional[str]:
+        """Pull the human-readable reason out of a dws error envelope, if that's what this is.
+
+        Worth surfacing rather than collapsing to "download failed": the messages are
+        specific and actionable ("this data belongs to organization X while the tool is
+        configured for organization Y"), and reading that as an expiry sends the user
+        looking in entirely the wrong place.
+        """
+        try:
+            err = (json.loads(raw_out or "{}") or {}).get("error")
+        except Exception:  # noqa: BLE001
+            return None
+        if not isinstance(err, dict):
+            return None
+        msg = str(err.get("message") or "").strip()
+        return msg or None
+
+    async def _read_doc_via_dws(self, conn: Any, node_id: str) -> Optional[bytes]:
+        """`dws doc read --node <id> --content-format markdown` → markdown bytes.
+
+        A DingTalk online document has no file to download; it is read as content. Returning
+        markdown keeps it in the same artifact pipeline as everything else.
+        """
+        owner = getattr(conn, "owner_user_id", "") or ""
+        if not owner:
+            return None
+        from core.services.dingtalk_service import _run_dws
+
+        out, err, code = await _run_dws(
+            owner,
+            ["doc", "read", "--node", node_id, "--content-format", "markdown", "--format", "json"],
+            timeout=self._DWS_DOWNLOAD_TIMEOUT_S,
+        )
+        reason = self._dws_business_error(out) or self._dws_business_error(err)
+        if reason:
+            logger.warning("[dingtalk] 钉钉文档读取被拒 node=%s: %s", node_id[:16], reason[:200])
+            raise ChannelResourceError(reason)
+        if code != 0 or not out.strip():
+            logger.debug("[dingtalk] 钉钉文档读取失败 code=%s err=%s", code, (err or "")[:160])
+            return None
+        try:
+            payload = json.loads(out)
+        except Exception:  # noqa: BLE001
+            return out.encode("utf-8")
+        # Content sits under a few possible keys depending on CLI version; fall back to the
+        # whole payload rather than silently returning nothing.
+        for key in ("content", "markdown", "data", "result"):
+            val = payload.get(key) if isinstance(payload, dict) else None
+            if isinstance(val, str) and val.strip():
+                return val.encode("utf-8")
+            if isinstance(val, dict):
+                for sub in ("content", "markdown", "text"):
+                    inner = val.get(sub)
+                    if isinstance(inner, str) and inner.strip():
+                        return inner.encode("utf-8")
+        return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
     async def _download_via_dws(self, conn: Any, file_id: str) -> Optional[bytes]:
         """`dws drive download --node <fileId>` → bytes.
 
@@ -303,6 +362,33 @@ class DingTalkAdapter:
         r"(?:\s*注意[：:][^\n]*)?"
     )
 
+    # A DingTalk **online document** shared into a group arrives as a link card, not as a
+    # file: a title line, an icon, and an alidocs URL. It is a different resource from a Drive
+    # file — read with `dws doc read`, not downloaded by fileId — and without recognising it
+    # the agent sees only an unusable link.
+    _DWS_DOC_RE = re.compile(r"https?://alidocs\.dingtalk\.com/i/nodes/(?P<node>[A-Za-z0-9_\-]+)")
+
+    @classmethod
+    def _extract_dws_docs(cls, content: str) -> List[Dict[str, Any]]:
+        """DingTalk Docs link cards → attachment refs (deduped by node id)."""
+        nodes = {m.group("node") for m in cls._DWS_DOC_RE.finditer(content or "")}
+        if not nodes:
+            return []
+        # The card's first non-empty line is the document title; skip the markdown image line
+        # and the "创建者：" byline, neither of which names the document.
+        title = ""
+        for line in (content or "").splitlines():
+            line = line.strip()
+            if line and not line.startswith("![") and not line.startswith("[http"):
+                if line.startswith("创建者"):
+                    continue
+                title = line
+                break
+        return [
+            {"kind": "doc", "key": node, "name": title or "钉钉文档"}
+            for node in sorted(nodes)
+        ]
+
     @classmethod
     def _extract_dws_files(cls, content: str) -> tuple:
         """(cleaned_text, attachment_refs) for one history message body."""
@@ -313,6 +399,11 @@ class DingTalkAdapter:
                 "key": m.group("fid"),
                 "name": m.group("name").strip(),
             })
+        doc_refs = cls._extract_dws_docs(content)
+        if doc_refs:
+            # The card body is title + icon + a long URL repeated twice; the attachment entry
+            # carries title and handle, so keeping the raw card would just burn prompt space.
+            return "", refs + doc_refs
         if not refs:
             return (content or "").strip(), []
         # Drop the matched sentences: the attachment ref already renders name + handle, and
@@ -425,6 +516,8 @@ class DingTalkAdapter:
         # Files seen through *history* are DingTalk Drive entries addressed by fileId, not
         # bot-callback attachments addressed by a short-lived downloadCode — different
         # storage, different API. The marker is set when the history item is parsed.
+        if attachment.get("kind") == "doc":
+            return await self._read_doc_via_dws(conn, str(code))
         if (inbound.raw or {}).get("dws_drive"):
             return await self._download_via_dws(conn, str(code))
         robot_code = (inbound.raw or {}).get("dingtalk_robot_code") or ""

--- a/src/backend/core/channels/protocol.py
+++ b/src/backend/core/channels/protocol.py
@@ -87,6 +87,16 @@ class InboundMsg:
     raw: Dict[str, Any] = field(default_factory=dict)  # raw event, kept for reference
 
 
+class ChannelResourceError(RuntimeError):
+    """A resource fetch failed for a reason the user needs to hear verbatim.
+
+    ``download_resource`` normally returns None on failure, which the caller reports as a
+    generic "download failed, the link may have expired". That is actively misleading when
+    the platform refused for a specific, actionable reason — a cross-organization access
+    block reads nothing like an expiry. Adapters raise this to carry that reason up.
+    """
+
+
 @dataclass
 class HistoryItem:
     """One message pulled from a group's history (normalized across channels)."""

--- a/src/backend/core/llm/tools/channel_attachment_tool.py
+++ b/src/backend/core/llm/tools/channel_attachment_tool.py
@@ -18,6 +18,7 @@ Registered only for channel runs (see agent_factory's ``_is_channel_run``).
 import json
 import logging
 import mimetypes
+import os
 from typing import Any, Dict, Optional
 
 from agentscope.message import TextBlock
@@ -112,6 +113,7 @@ def register_channel_attachment(
             JSON: 成功返回 {file_id, filename, mime_type, size, next: 使用提示}；
                   失败返回 {error: 原因}。下载码可能过期，过旧的文件可能取不回。
         """
+        from core.channels.protocol import ChannelResourceError
         from core.channels.registry import get_adapter
         from core.db.engine import SessionLocal
         from core.services.artifact_service import store_bytes_as_artifact
@@ -141,6 +143,10 @@ def register_channel_attachment(
                     conn, _rebuild_inbound(conn, session, entry),
                     {"kind": entry.get("kind") or "file", "key": key, "name": name},
                 )
+            except ChannelResourceError as exc:
+                # 平台给了明确理由（如跨组织访问被拒），原样透出——把它说成“已过期”
+                # 会让用户往完全错误的方向排查。
+                return _err(str(exc) or "渠道拒绝了这次读取")
             except Exception:  # noqa: BLE001
                 logger.exception("[channels] 按需取回附件失败 key=%s", key[:16])
                 return _err("附件下载失败，可能下载码已过期")
@@ -149,6 +155,13 @@ def register_channel_attachment(
             if len(content) > _MAX_ATTACHMENT_BYTES:
                 return _err(f"文件过大（{len(content)} 字节），超出 50MB 上限")
 
+            # An online document is fetched as markdown *content*, and its name is a title
+            # with no extension. read_artifact dispatches its parser purely on the filename
+            # extension, so leaving it bare would mean the file downloads fine and then reads
+            # back as "unsupported format" — fetched but unusable. Give it the extension that
+            # matches what the bytes actually are.
+            if entry.get("kind") == "doc" and not os.path.splitext(name)[1]:
+                name = f"{name}.md"
             mime = mimetypes.guess_type(name)[0] or "application/octet-stream"
             art = store_bytes_as_artifact(
                 db, user_id=str(session.user_id), content=content, filename=name,

--- a/src/backend/tests/test_channel_bots.py
+++ b/src/backend/tests/test_channel_bots.py
@@ -1999,3 +1999,111 @@ def test_dingtalk_dws_download_degrades(monkeypatch):
         app_id = "k"
         channel_id = "c"
     assert asyncio.run(a._download_via_dws(_NoOwner(), "FID")) is None
+
+
+def test_dingtalk_history_extracts_online_doc_links():
+    """钉钉**在线文档**是链接卡片，不是文件——也要解析成句柄，否则模型只看到一条没用的链接。"""
+    from core.channels.adapters.dingtalk import DingTalkAdapter as D
+
+    card = (
+        "季度工作台账\n创建者：张三\n"
+        "![image](https://img.alicdn.com/x.png)\n"
+        "[https://alidocs.dingtalk.com/i/nodes/NODEabc123XYZ?corpId=d1]"
+        "(https://alidocs.dingtalk.com/i/nodes/NODEabc123XYZ?corpId=d1)"
+    )
+    text, refs = D._extract_dws_files(card)
+    assert refs == [{"kind": "doc", "key": "NODEabc123XYZ",
+                     "name": "季度工作台账"}]
+    assert text == "", "卡片正文是标题+图标+两遍长 URL，留着纯属浪费提示词"
+    # 同一 URL 在卡片里出现两次（显示文本 + 链接），不能记成两个附件
+    assert len(refs) == 1
+
+
+def test_dingtalk_doc_read_surfaces_real_reason(monkeypatch):
+    """平台给了明确理由（如跨组织被拒）时必须原样透出，不能笼统说“可能已过期”。
+
+    实测踩到的就是这个：文档属于另一个组织，dws 明确说明了原因，但用户看到的是
+    模糊的“统一身份认证”，往完全错误的方向排查。
+    """
+    from core.channels.adapters import dingtalk as dt
+    from core.channels.protocol import ChannelResourceError, InboundMsg
+
+    cross_org = json.dumps({"error": {
+        "category": "api",
+        "message": "出于安全考虑，不支持跨组织访问数据，该数据属于组织 A，而 MCP 工具配置的组织为 B",
+        "server_error_code": "forbidden.accessDenied",
+    }}, ensure_ascii=False)
+
+    async def _refused(user_id, args, timeout=40):
+        return (cross_org, "", 1)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _refused)
+
+    class _C:
+        owner_user_id = "u"
+        config = {}
+        app_id = "k"
+        channel_id = "c"
+
+    a = dt.DingTalkAdapter()
+    msg = InboundMsg(channel_id="c", channel_type="dingtalk", text="", chat_type="group",
+                     external_conversation_id="cid", raw={})
+    try:
+        asyncio.run(a.download_resource(_C(), msg, {"kind": "doc", "key": "NODE1"}))
+        raise AssertionError("应当抛出带原因的 ChannelResourceError")
+    except ChannelResourceError as exc:
+        assert "跨组织" in str(exc)
+
+    # 正常读取：返回 markdown 字节
+    async def _ok(user_id, args, timeout=40):
+        assert args[:2] == ["doc", "read"]
+        assert args[args.index("--content-format") + 1] == "markdown"
+        return (json.dumps({"content": "# 台账\n第一行"}, ensure_ascii=False), "", 0)
+
+    monkeypatch.setattr("core.services.dingtalk_service._run_dws", _ok)
+    got = asyncio.run(a.download_resource(_C(), msg, {"kind": "doc", "key": "NODE1"}))
+    assert got.decode("utf-8").startswith("# 台账")
+
+    # 业务错误判定不能误伤正常返回
+    assert dt.DingTalkAdapter._dws_business_error('{"result":{"a":1}}') is None
+    assert dt.DingTalkAdapter._dws_business_error("not json") is None
+
+
+def test_channel_read_attachment_names_docs_with_md_extension(db_session, monkeypatch):
+    """在线文档取回的是 markdown 正文，落库文件名必须带 .md。
+
+    read_artifact 的解析器是**纯按扩展名**分发的（file_parser.parse_file），标题类文件名
+    没有后缀就会被判成"不支持的格式"——文件下下来了却读不了，等于白取。
+    """
+    from core.channels.inbound import _find_or_create_session, _record_observed_batch
+
+    conn = _mk_conn(db_session)
+    msg = _inbound("oc_doc", "group", mid="m_doc")
+    session = _find_or_create_session(db_session, conn, msg)
+    _record_observed_batch(db_session, session, [], {
+        "NODE1": {"name": "季度工作台账", "kind": "doc",
+                  "message_id": "m1", "raw": {}},
+        "FID2": {"name": "报表.xlsx", "kind": "file", "message_id": "m2", "raw": {}},
+    })
+
+    monkeypatch.setattr("core.db.engine.SessionLocal", lambda: db_session)
+
+    class _Ad:
+        async def download_resource(self, conn, inbound, att):
+            return b"# tai zhang"
+
+    monkeypatch.setattr("core.channels.registry.get_adapter", lambda ct: _Ad())
+
+    tool = _reg_channel_tool(str(session.user_id), session.chat_id)
+    doc = _tool_json(asyncio.run(tool("NODE1")))
+    assert doc["filename"].endswith(".md"), doc
+    assert doc["mime_type"].startswith("text/"), doc
+
+    # 解析器确实认这个名字
+    from core.content.file_parser import parse_file
+    assert parse_file(b"# tai zhang", doc["filename"]) == "# tai zhang"
+    assert parse_file(b"# tai zhang", "季度工作台账") is None, "无后缀本会被判不支持"
+
+    # 普通文件名不受影响，不该被加后缀
+    f = _tool_json(asyncio.run(tool("FID2")))
+    assert f["filename"] == "报表.xlsx"


### PR DESCRIPTION
Follow-up to #74. Sharing a DingTalk **online document** into a group made the agent reply that it "needs DingTalk unified identity authentication". Three separate things were wrong.

## 1. Online documents were not recognised as attachments

A DingTalk online document shared into a group arrives as a **link card** — a title line, an icon, and an `alidocs` URL — not the `[文件] name fileId: …` form a Drive file uses. The parser saw only an unusable link, so the agent had no handle at all.

The alidocs node id is now parsed into a `doc` handle. The same URL appears twice in a card (as display text and as link target) and is recorded once. Reading goes through `dws doc read --content-format markdown`: an online document has no file to download, it is read as *content*, which then flows through the same artifact pipeline as everything else.

## 2. The error message sent the user looking in the wrong place

The CLI had in fact given a precise reason:

> 出于安全考虑，不支持跨组织访问数据，该数据属于组织 A，而 MCP 工具配置的组织为 B

But `download_resource` can only return `None` on failure, so the caller reported *"download failed, the code may have expired"*. An expiry and a cross-organization refusal are nothing alike — and the second cannot be resolved by retrying, which is exactly what the misleading message invites.

`ChannelResourceError` now carries a reason the platform stated verbatim up to the user. Ordinary failures still degrade to `None`, unchanged.

## 3. A document also needs a file extension to be readable

`read_artifact` dispatches its parser purely on the filename extension (`file_parser.parse_file` takes `splitext` and returns `None` for anything unrecognised). A document's name is a **title**, with no extension — so the content would download successfully, the artifact would be created, and `read_artifact` would then report "unsupported format". Fetched but unusable.

Documents are stored with a `.md` extension matching what the bytes actually are. Verified: `parse_file(b"...", "季度工作台账")` → `None`, `parse_file(b"...", "季度工作台账.md")` → the content.

## Scope note

The cross-organization case is a platform permission boundary and is not something to work around in code — the bot should not be able to read another organization's documents. What changed is that the user now sees the real reason instead of a misleading one. Same-organization nodes were verified not to hit that boundary.

## Tests

Adds coverage for link-card parsing including URL de-duplication, the cross-organization reason propagating as `ChannelResourceError`, a successful markdown read, business-error detection not misfiring on normal responses, and the `.md` naming (including that a bare title would otherwise be unparseable, and that ordinary filenames are left alone).