### PR TITLE
docs: use the English-narrated demo video in the English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A 60-second tour: the same task run twice, with audited self-evolution in betwee
 memory, skills and orchestration each settled, and each taking effect only after you
 approve it.
 
-https://github.com/user-attachments/assets/a268e371-a11f-488b-98d4-08598e2fdf89
+https://github.com/user-attachments/assets/635c5b35-10c0-47b9-a6f1-c73df9510e90
 
 ## Quick start
 


### PR DESCRIPTION
The Demo section of `README.md` embedded the Chinese-narrated tour, the same clip used by `README_CN.md`.

This swaps it for the English-narrated version, so each README carries the demo in its own language.

Only `README.md` changes; `README_CN.md` keeps the Chinese clip.