### PR TITLE
feat(plugin): progressive plugin loading — activate plugin components on demand

### DIFF
--- a/document/en/modules/agent-skills.md
+++ b/document/en/modules/agent-skills.md
@@ -84,6 +84,19 @@ All skills — built-in and DB/admin-imported — are exposed inside the sandbox
 - DB skills are materialized into the same directory on demand (`loader._materialize_skill_files`);
 - the remote cube sandbox has no host mounts, so skill files matching `/workspace/skills` are pushed into the sandbox at runtime instead (`CUBE_SKILL_PREPUSH*` settings).
 
+### Progressive Plugin Loading
+
+Installed plugins' components (skills + MCP tools) **no longer enter every request wholesale**: during main-chat assembly the plugin's skill lines and tool JSON Schemas are removed from the context, the system prompt keeps only a one-line "plugin directory" entry (slug + description), and a `load_plugin` tool is registered. When the model decides a user request matches a plugin's description it calls `load_plugin` to activate it — only then are its MCP servers connected and its skills registered, becoming usable from the next step. This flattens the TTFT growth that installing many plugins used to cause.
+
+Key points:
+
+- **Sticky per chat**: activation is persisted in the session metadata (`chat_sessions.metadata.activated_plugins`); subsequent turns of the same chat assemble the plugin normally with no re-activation. Explicitly invoking a plugin (`/` slash, `+` menu) counts as activation.
+- **Byte-stable directory**: the directory is sorted by slug and independent of activation state; with provider-side prefix caching an activation pays for a cache rebuild only on the activation turn and the following one, after which the prefix is stable again.
+- **Scope**: main-chat assembly and sub-agents. A sub-agent's bound plugins are deferred the same way, but activation lives only within that run and is never persisted (sub-agent runs are short-lived and isolated; writing under the parent chat's key would leak the activation into the main agent's assembly). Plugins pinned by a restricted chat mode stay eagerly loaded (a deliberate admin narrowing); plugins with stdio-transport MCP components are not deferred.
+- **Kill switch**: set `PLUGIN_PROGRESSIVE_LOADING=false` to revert to eager assembly.
+
+Implementation: `core/llm/plugin_loader.py` (deferral resolution / directory rendering / activation tool) plus the assembly hook in `core/llm/agent_factory.py`.
+
 ## The Skill Marketplace
 
 The marketplace is an installable skill library with two sources — curated presets and community submissions — implemented in `core/services/marketplace_service.py`.

--- a/document/zh-CN/modules/agent-skills.md
+++ b/document/zh-CN/modules/agent-skills.md
@@ -84,6 +84,19 @@
 - DB 技能按需物化到同一目录（`loader._materialize_skill_files`）；
 - 远端 cube 沙箱无 host mount，改为运行时把命中 `/workspace/skills` 的技能文件推送进沙箱（`CUBE_SKILL_PREPUSH` 系列配置）。
 
+### 插件的渐进式加载（Progressive Plugin Loading）
+
+已安装插件的组件（技能 + MCP 工具）默认**不再全量进入每轮请求**：主对话装配时，插件的技能行与工具 JSON Schema 从上下文中剔除，系统提示词只保留一行「插件目录」条目（插件标识 + 描述），并注册 `load_plugin` 工具。模型判断用户请求匹配某插件的描述时调用 `load_plugin` 激活它——此时才连接其 MCP server、注册其技能，下一步即可使用。这把安装大量插件带来的首字延迟（TTFT）膨胀压回常数级。
+
+要点：
+
+- **会话粘滞**：激活写入会话元数据（`chat_sessions.metadata.activated_plugins`），同一会话后续轮次该插件直接常规装配，无需重复激活；显式呼唤插件（`/` 斜杠、`+` 菜单）视同激活。
+- **目录字节稳定**：插件目录按标识排序、不随激活状态变化，配合模型侧前缀缓存（prefix caching），激活行为只在激活当轮与下一轮各付一次缓存重建，之后前缀重新稳定。
+- **范围**：主对话链路 + 子智能体。子智能体绑定的插件同样延迟加载，但激活只在该次运行内生效、不落库（子智能体运行短暂且相互隔离，落到父会话的键上会把激活泄漏进主智能体装配）；收窄模式（对话模式）圈定的插件保持全量装配（那是管理员的显式圈定）；组件含 stdio 形态 MCP 的插件不延迟。
+- **开关**：环境变量 `PLUGIN_PROGRESSIVE_LOADING=false` 可整体回退到全量装配。
+
+实现：`core/llm/plugin_loader.py`（延迟解析 / 目录渲染 / 激活工具）+ `core/llm/agent_factory.py` 装配接入。
+
 ## 技能市场（Skill Marketplace）
 
 技能市场是"预置 + 社区"双来源的可安装技能库，核心服务在 `core/services/marketplace_service.py`。

--- a/src/backend/core/llm/agent_factory.py
+++ b/src/backend/core/llm/agent_factory.py
@@ -521,6 +521,15 @@ async def create_agent_executor(
     turbo_mode: bool = False,
     turbo_explicit_skill_ids: Optional[List[str]] = None,
     turbo_explicit_mcp_ids: Optional[List[str]] = None,
+    # invoked_skill_ids / invoked_mcp_ids: capabilities the user explicitly
+    # summoned THIS turn（斜杠技能 / 插件 chip 展开的 skill_ids/mcp_ids），mode
+    # 无关。Consumed by progressive plugin loading: an explicitly invoked
+    # plugin must not be deferred (its user-message injection promises the
+    # capability is active), and the invocation is persisted as a sticky
+    # activation for the chat. turbo_explicit_* remain the turbo-only narrowing
+    # pass-throughs.
+    invoked_skill_ids: Optional[List[str]] = None,
+    invoked_mcp_ids: Optional[List[str]] = None,
     # mode_spec: 对话模式的装配契约（core/services/chat_mode_service.ChatModeSpec）。
     # 「模式」把原来写死的极速模式泛化成一张表：工具面 / 技能 / 插件 / 提示词 kind /
     # 迭代上限都由它给。turbo_mode 现在的含义是"这个模式要收窄工具面"，收窄成什么
@@ -562,6 +571,12 @@ async def create_agent_executor(
         )
 
     # ── Sub-agent overrides ──────────────────────────────────────────
+    # _subagent_progressive: the sub-agent's bound plugins, progressively
+    # loaded — deferred here, directory + load_plugin injected in the subagent
+    # prompt branch below. Activation is in-run only (no sticky persistence:
+    # sub-agent runs are short-lived and isolated, and writing under the parent
+    # chat's key would leak the activation into the main agent's assembly).
+    _subagent_progressive = None
     if user_agent is not None:
         # Override capability bindings from user_agent config
         enabled_mcp_ids = list(user_agent.mcp_server_ids or [])
@@ -570,7 +585,38 @@ async def create_agent_executor(
         # Expand bound plugins into their component skills + MCPs (a plugin = a detachable capability bundle). Merge with the loose bindings, deduplicated.
         plugin_ids = user_agent.plugin_ids or []
         if plugin_ids:
+            from core.llm import plugin_loader as _plug_sub
+
+            if not disable_tools and _plug_sub.progressive_plugin_loading_enabled():
+                try:
+
+                    def _resolve_bound():
+                        # Same ownership/release narrowing the eager expansion
+                        # would have received via _filter_skill_ids_for_user.
+                        return _plug_sub.resolve_bound_progressive_plugins(
+                            list(plugin_ids),
+                            skill_filter=lambda sids: _filter_skill_ids_for_user(
+                                sids, current_user_id
+                            ),
+                        )
+
+                    _subagent_progressive = await asyncio.to_thread(_resolve_bound)
+                    if not _subagent_progressive.directory:
+                        _subagent_progressive = None
+                except Exception as exc:  # noqa: BLE001
+                    _log.warning(
+                        "[factory] subagent progressive plugin resolve failed（回退全量装配）: %s",
+                        exc,
+                    )
+                    _subagent_progressive = None
             p_skills, p_mcp = _expand_plugin_bindings(plugin_ids)
+            if _subagent_progressive is not None:
+                # Deferred components stay out of the assembly; stdio-transport
+                # plugins (absent from deferred_*) still expand eagerly.
+                p_skills = [
+                    s for s in p_skills if s not in _subagent_progressive.deferred_skill_ids
+                ]
+                p_mcp = [m for m in p_mcp if m not in _subagent_progressive.deferred_mcp_ids]
             enabled_skill_ids = list(dict.fromkeys(enabled_skill_ids + p_skills))
             enabled_mcp_ids = list(dict.fromkeys(enabled_mcp_ids + p_mcp))
 
@@ -658,6 +704,59 @@ async def create_agent_executor(
     # Security: strip out other users' private skills, preventing unauthorized skill_ids passed in from the frontend
     if enabled_skill_ids:
         enabled_skill_ids = _filter_skill_ids_for_user(enabled_skill_ids, current_user_id)
+
+    # ── Progressive plugin loading（渐进式插件加载）────────────────────────
+    # Main-path only: a sub-agent's plugin binding is the owner's deliberate
+    # configuration and a restricted mode's plugin set is the admin's deliberate
+    # narrowing — both stay eager. Here, installed plugins' components are
+    # removed from this run's enabled sets and replaced by a one-line directory
+    # entry + a `load_plugin` activation tool (see core/llm/plugin_loader.py).
+    # Deferral happens BEFORE the skill-bound-MCP merge below so a deferred
+    # skill doesn't pull its bound MCP servers into the assembly either.
+    _progressive = None
+    if (
+        not disable_tools
+        and not turbo_mode
+        and user_agent is None
+        and current_user_id
+    ):
+        from core.llm import plugin_loader as _plug
+
+        if _plug.progressive_plugin_loading_enabled():
+            try:
+                # Normalize the None fallbacks to their concrete resolutions
+                # (identical sources to the later phases) so the subtraction
+                # below has explicit lists to operate on.
+                if enabled_skill_ids is None:
+                    enabled_skill_ids = _filter_skill_ids_for_user(
+                        _effective_main_available_skills(), current_user_id
+                    )
+                if not isinstance(enabled_mcp_ids, list):
+                    enabled_mcp_ids = [
+                        x for x in get_enabled_ids("mcp") if isinstance(x, str) and x.strip()
+                    ]
+                _progressive = await asyncio.to_thread(
+                    _plug.resolve_progressive_plugins,
+                    user_id=str(current_user_id),
+                    chat_id=chat_id,
+                    enabled_skill_ids=enabled_skill_ids,
+                    enabled_mcp_ids=enabled_mcp_ids,
+                    invoked_skill_ids=invoked_skill_ids,
+                    invoked_mcp_ids=invoked_mcp_ids,
+                )
+                if _progressive.deferred_skill_ids:
+                    enabled_skill_ids = [
+                        s for s in enabled_skill_ids if s not in _progressive.deferred_skill_ids
+                    ]
+                if _progressive.deferred_mcp_ids:
+                    enabled_mcp_ids = [
+                        m for m in enabled_mcp_ids if m not in _progressive.deferred_mcp_ids
+                    ]
+                if not _progressive.directory:
+                    _progressive = None
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("[factory] progressive plugin resolve failed（回退全量装配）: %s", exc)
+                _progressive = None
 
     # A skill's MCP binding is an explicit capability grant, just like a sub-agent binding.
     # Merge only the MCPs declared by enabled skills; unrelated disabled MCPs remain disabled.
@@ -1323,6 +1422,10 @@ async def create_agent_executor(
     # ── Phase 4: Build system prompt (DB parts pre-fetched) ──
     _log.info("[factory] +%s tools registered", _elapsed())
     _agent_ref: Optional[Dict] = None
+    # Progressive plugin runtime holder — filled in stages: registered with the
+    # collector below, then completed after the real Toolkit / AgentRuntimeState
+    # exist (the load_plugin closure mutates both at activation time).
+    _plugin_runtime: Optional[Dict[str, Any]] = None
 
     _ontology_runtime = ontology_runtime if isinstance(ontology_runtime, dict) else {}
     skill_metadata = loader.load_all_metadata()
@@ -1354,12 +1457,21 @@ async def create_agent_executor(
 
     def _build_toolkit() -> Toolkit:
         # ``toolkit`` here is still the ToolCollector; construct the real Toolkit from the current collection state.
+        #
+        # "Skill" (AgentScope's builtin SkillViewer) is hidden unconditionally —
+        # distinct from the ontology forbidden_tools above. The Toolkit injects
+        # its schema on every request whenever any skill is registered, but this
+        # stack loads skills exclusively through view_text_file (sandbox↔backend
+        # path mapping, {baseDir} substitution, runtime hint, skill_call
+        # observability). A model that called Skill instead would bypass all of
+        # that and receive backend-path content unusable in the sandbox — so the
+        # schema is pure per-round prefill waste plus a wrong door.
         return OntologyFilteredToolkit(
             tools=toolkit.function_tools,
             mcps=[*mcp_clients, *http_clients],
             skills_or_loaders=toolkit.skill_loaders or None,
             skill_instruction_template=_SKILL_INSTRUCTION_TEMPLATE,
-            hidden_tools=_ontology_hidden_tools,
+            hidden_tools={*_ontology_hidden_tools, "Skill"},
         )
 
     # Compute schemas first in the "subagent tools not yet registered" state
@@ -1384,6 +1496,44 @@ async def create_agent_executor(
                 "[factory] +%s subagent ontology contract injected (%d chars)",
                 _elapsed(),
                 len(_ontology_prompt),
+            )
+
+        # ── Progressive plugin directory + load_plugin tool (sub-agent) ──
+        # Bound plugins deferred in the override block above; in-run activation
+        # only (persist=False — see the note there).
+        if _subagent_progressive is not None:
+            from core.llm import plugin_loader as _plug
+
+            _plugin_dir_section = _plug.build_plugin_directory_section(
+                _subagent_progressive.directory
+            )
+            if _plugin_dir_section:
+                system_prompt += "\n\n" + _plugin_dir_section
+            _plugin_runtime = {
+                "activated_slugs": set(),
+                "connected_keys": set(enabled_mcp_keys),
+                "toolkit": None,
+                "permission_context": None,
+                "close_list": None,
+                "persist": False,
+                "loader": loader,
+                "chat_id": chat_id,
+                "user_id": current_user_id,
+                "enabled_kb_ids": enabled_kb_ids,
+                "channel_origin": channel_origin,
+                "reranker_enabled": reranker_enabled,
+                "confirm_gate": _mcp_confirm_should_gate,
+                "ontology_runtime": _ontology_runtime,
+            }
+            _plug.register_load_plugin(
+                toolkit, _subagent_progressive.deferred_by_slug(), _plugin_runtime
+            )
+            _log.info(
+                "[factory] +%s subagent progressive plugins: %d deferred (skills=%d, mcp=%d)",
+                _elapsed(),
+                len(_subagent_progressive.deferred),
+                len(_subagent_progressive.deferred_skill_ids),
+                len(_subagent_progressive.deferred_mcp_ids),
             )
     else:
         # ── 模式自带的专属提示词 ──
@@ -1469,6 +1619,44 @@ async def create_agent_executor(
                     _elapsed(),
                     len(_code_exec_text),
                 )
+
+        # ── Progressive plugin directory + load_plugin tool ──
+        # The directory section is byte-stable per user (sorted by slug,
+        # independent of activation state) so an activation never perturbs this
+        # part of the prefix; only the tools/skills it adds do, once.
+        if _progressive is not None:
+            from core.llm import plugin_loader as _plug
+
+            _plugin_dir_section = _plug.build_plugin_directory_section(_progressive.directory)
+            if _plugin_dir_section:
+                system_prompt += "\n\n" + _plugin_dir_section
+            _plugin_runtime = {
+                "activated_slugs": set(_progressive.activated_slugs),
+                "connected_keys": set(enabled_mcp_keys),
+                "toolkit": None,  # the real Toolkit, filled after construction
+                "permission_context": None,  # filled after AgentRuntimeState exists
+                "close_list": None,  # filled right before return
+                "loader": loader,
+                "chat_id": chat_id,
+                "user_id": current_user_id,
+                "enabled_kb_ids": enabled_kb_ids,
+                "channel_origin": channel_origin,
+                "reranker_enabled": reranker_enabled,
+                "confirm_gate": _mcp_confirm_should_gate,
+                "ontology_runtime": _ontology_runtime,
+            }
+            _plug.register_load_plugin(
+                toolkit, _progressive.deferred_by_slug(), _plugin_runtime
+            )
+            _log.info(
+                "[factory] +%s progressive plugins: %d in directory, %d deferred "
+                "(skills=%d, mcp=%d)",
+                _elapsed(),
+                len(_progressive.directory),
+                len(_progressive.deferred),
+                len(_progressive.deferred_skill_ids),
+                len(_progressive.deferred_mcp_ids),
+            )
 
         # ── Inject batch execution hint (App Center batch-execution sessions only) ──
         if batch_mode:
@@ -1981,6 +2169,12 @@ async def create_agent_executor(
         for n in _all_tool_names
     }
 
+    # Complete the progressive-plugin runtime holder now that the real Toolkit
+    # and the permission context exist (load_plugin mutates both mid-run).
+    if _plugin_runtime is not None:
+        _plugin_runtime["toolkit"] = toolkit
+        _plugin_runtime["permission_context"] = _state.permission_context
+
     # Offloader: when compressing/truncating overlong tool results, spill the
     # overflow to the sandbox at /workspace/.offload/ (rather than silently
     # discarding it); the model can read it back on demand via Read/bash. Only
@@ -2049,4 +2243,8 @@ async def create_agent_executor(
     # pooled stable clients stay open for reuse (closing them would defeat the
     # pool and hand dead clients to the next request).
     all_transient = [*transient_mcp_clients, *http_clients]
+    # Clients connected by a mid-run load_plugin activation are appended to this
+    # same list object, so the caller's close_clients() teardown covers them.
+    if _plugin_runtime is not None:
+        _plugin_runtime["close_list"] = all_transient
     return agent, all_transient

--- a/src/backend/core/llm/plugin_loader.py
+++ b/src/backend/core/llm/plugin_loader.py
@@ -1,0 +1,598 @@
+"""Progressive plugin loading（渐进式插件加载）.
+
+安装后的插件默认把 N 个技能的 yaml 头 + M 个 MCP 工具的完整 JSON Schema 全量
+注入每一轮请求（技能进系统提示词末尾的技能清单，工具进 tools 参数），插件越装
+越多，首字延迟（TTFT）随之线性膨胀。本模块把「插件」这个聚合单位带回运行时：
+
+- **装配期**：插件的组件（技能 / MCP server）从本轮的 enabled 集合中剔除，系统
+  提示词只保留一行「插件目录」条目（插件名 + 描述），并注册一个 ``load_plugin``
+  工具。
+- **激活期**：模型判断需要某插件时调用 ``load_plugin``，此时才连接该插件的 MCP
+  server（追加进 Toolkit basic 组的 mcps）、注册其技能（追加 LocalSkillLoader），
+  下一轮 ReAct 请求里工具 schema 与技能清单即出现（AS2 的
+  ``_prepare_model_input`` 每轮重算，无缓存）。
+- **粘滞性**：激活写入 ``ChatSession.extra_data["activated_plugins"]``——同一会话
+  后续轮次装配期直接不再延迟该插件（其组件回到常规装配位置）。显式呼唤插件
+  （``/`` 斜杠、``+`` 菜单展开的 skill_ids/mcp_ids）视同激活并同样落库。
+
+与前缀缓存（prefix caching）的关系：插件目录段内容与顺序对同一用户稳定（按
+slug 排序、不随激活状态变化），激活行为本身会在「激活那一轮」与「激活后的下一
+轮」（组件回到常规装配位）各击穿一次前缀缓存，之后前缀重新稳定。未被引用的
+插件则永远不再为每轮 prefill 付费。
+
+关闭开关：环境变量 ``PLUGIN_PROGRESSIVE_LOADING=false`` 回到全量 eager 装配。
+
+范围：主链路装配（``resolve_progressive_plugins``，可见插件 ∩ enabled 集合，
+会话粘滞）+ 子智能体装配（``resolve_bound_progressive_plugins``，按绑定的
+install_id 解析；子智能体运行短暂且相互隔离，激活只在本次运行内生效、不落库）。
+收窄模式（对话模式）圈定的插件面是管理员的显式圈定，保持 eager；组件含 stdio
+transport MCP 的插件不延迟（激活期进程内起子进程的生命周期管理复杂度不值得）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Set
+
+logger = logging.getLogger(__name__)
+
+
+def progressive_plugin_loading_enabled() -> bool:
+    """Env-driven kill switch (default on)."""
+    return os.getenv("PLUGIN_PROGRESSIVE_LOADING", "true").strip().lower() == "true"
+
+
+@dataclass
+class DeferredPlugin:
+    """One deferral-eligible plugin and its in-play components."""
+
+    slug: str
+    name: str
+    description: str
+    # Component ids intersected with this run's enabled sets — only what the
+    # run would actually have carried is deferred / later activated.
+    skill_ids: List[str] = field(default_factory=list)
+    mcp_ids: List[str] = field(default_factory=list)
+    # MCP servers declared by the plugin's skills via SKILL.md frontmatter
+    # (mcp_server_ids). Connected at activation when not already connected —
+    # NOT subtracted from the base assembly, since they may be shared with
+    # non-plugin skills.
+    bound_mcp_ids: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ProgressiveResolution:
+    """Outcome of the assembly-time deferral decision."""
+
+    # Plugins actually deferred this run (not activated, not invoked).
+    deferred: List[DeferredPlugin] = field(default_factory=list)
+    # All deferral-eligible plugins regardless of activation state, sorted by
+    # slug. The directory section renders THIS list so the prompt bytes stay
+    # identical before and after an activation (prefix-cache friendly).
+    directory: List[DeferredPlugin] = field(default_factory=list)
+    activated_slugs: List[str] = field(default_factory=list)
+    deferred_skill_ids: Set[str] = field(default_factory=set)
+    deferred_mcp_ids: Set[str] = field(default_factory=set)
+
+    def deferred_by_slug(self) -> Dict[str, DeferredPlugin]:
+        return {p.slug: p for p in self.deferred}
+
+
+# ── Activation persistence (ChatSession.extra_data) ──────────────────────────
+
+_ACTIVATED_KEY = "activated_plugins"
+
+
+def load_activated_plugin_slugs(chat_id: Optional[str]) -> List[str]:
+    """Read the chat's sticky activation list (activation order preserved)."""
+    if not chat_id:
+        return []
+    try:
+        from core.db.engine import SessionLocal
+        from core.db.models import ChatSession
+
+        with SessionLocal() as db:
+            row = db.query(ChatSession.extra_data).filter(ChatSession.chat_id == chat_id).first()
+            if not row:
+                return []
+            data = row[0] or {}
+            slugs = data.get(_ACTIVATED_KEY) or []
+            return [str(s) for s in slugs if isinstance(s, str) and s.strip()]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[plugin-loader] activated list read failed: %s", exc)
+        return []
+
+
+def record_plugin_activation(chat_id: Optional[str], slugs: Sequence[str]) -> None:
+    """Append slugs to the chat's sticky activation list (idempotent)."""
+    if not chat_id or not slugs:
+        return
+    try:
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from core.db.engine import SessionLocal
+        from core.db.models import ChatSession
+
+        with SessionLocal() as db:
+            row = db.query(ChatSession).filter(ChatSession.chat_id == chat_id).first()
+            if row is None:
+                return
+            data = dict(row.extra_data or {})
+            current = [s for s in (data.get(_ACTIVATED_KEY) or []) if isinstance(s, str)]
+            added = False
+            for slug in slugs:
+                if slug and slug not in current:
+                    current.append(slug)
+                    added = True
+            if not added:
+                return
+            data[_ACTIVATED_KEY] = current
+            row.extra_data = data
+            flag_modified(row, "extra_data")
+            db.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[plugin-loader] activation persist failed: %s", exc)
+
+
+# ── Assembly-time resolution ─────────────────────────────────────────────────
+
+
+def _http_transport(cfg: Any) -> bool:
+    if not isinstance(cfg, dict):
+        return False
+    return bool(cfg.get("url")) or cfg.get("transport") in ("streamable_http", "sse")
+
+
+def resolve_progressive_plugins(
+    *,
+    user_id: str,
+    chat_id: Optional[str],
+    enabled_skill_ids: Sequence[str],
+    enabled_mcp_ids: Sequence[str],
+    invoked_skill_ids: Optional[Sequence[str]] = None,
+    invoked_mcp_ids: Optional[Sequence[str]] = None,
+) -> ProgressiveResolution:
+    """Decide which installed plugins this run defers.
+
+    Runs in a worker thread (sync DB access). A plugin is deferral-eligible
+    when it is visible to the user, has at least one component in this run's
+    enabled sets, and none of its in-play MCP servers use stdio transport.
+    Eligible plugins already activated for this chat — or explicitly invoked
+    this turn — stay eager; explicit invocation is persisted as activation so
+    the plugin stays loaded on subsequent turns.
+    """
+    from sqlalchemy import or_
+
+    from core.db.engine import SessionLocal
+    from core.db.models import InstalledPlugin
+
+    enabled_skills = {s for s in enabled_skill_ids if isinstance(s, str) and s.strip()}
+    enabled_mcps = {m for m in enabled_mcp_ids if isinstance(m, str) and m.strip()}
+    invoked = {x for x in (invoked_skill_ids or []) if isinstance(x, str) and x.strip()}
+    invoked |= {x for x in (invoked_mcp_ids or []) if isinstance(x, str) and x.strip()}
+
+    # Server transport lookup (global + the user's private servers).
+    try:
+        from core.services.mcp_service import McpServerConfigService
+
+        svc = McpServerConfigService.get_instance()
+        server_cfgs = dict(svc.get_all_servers(enabled_only=True))
+        try:
+            server_cfgs.update(svc.get_owned_servers(str(user_id), enabled_only=False))
+        except Exception:  # noqa: BLE001
+            pass
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[plugin-loader] server config lookup failed: %s", exc)
+        server_cfgs = {}
+
+    # Skill → bound MCP metadata (SKILL.md frontmatter mcp_server_ids).
+    skill_meta: Dict[str, Any] = {}
+    try:
+        from core.agent_skills.loader import get_skill_loader
+
+        skill_meta = get_skill_loader().load_all_metadata() or {}
+    except Exception:  # noqa: BLE001
+        skill_meta = {}
+
+    activated = load_activated_plugin_slugs(chat_id)
+    activated_set = set(activated)
+
+    res = ProgressiveResolution(activated_slugs=list(activated))
+    eligible: List[DeferredPlugin] = []
+    newly_pinned: List[str] = []
+    try:
+        with SessionLocal() as db:
+            rows = (
+                db.query(InstalledPlugin)
+                .filter(
+                    or_(
+                        InstalledPlugin.owner_user_id == user_id,
+                        InstalledPlugin.owner_user_id.is_(None),
+                    )
+                )
+                .all()
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[plugin-loader] installed plugin load failed: %s", exc)
+        return res
+
+    for r in rows:
+        cids = r.component_ids or {}
+        in_play_skills = [s for s in (cids.get("skills") or []) if s in enabled_skills]
+        in_play_mcps = [m for m in (cids.get("mcp") or []) if m in enabled_mcps]
+        if not in_play_skills and not in_play_mcps:
+            continue
+        # stdio-transport components keep the whole plugin eager: spawning
+        # per-request subprocesses mid-run has lifecycle costs this v1 skips.
+        if any(not _http_transport(server_cfgs.get(m)) for m in in_play_mcps):
+            continue
+        bound: List[str] = []
+        for sid in in_play_skills:
+            item = skill_meta.get(sid)
+            for server_id in getattr(item, "mcp_server_ids", None) or []:
+                if server_id and server_id not in bound and server_id not in in_play_mcps:
+                    bound.append(server_id)
+        plugin = DeferredPlugin(
+            slug=str(r.slug),
+            name=str(r.name or r.slug),
+            description=str(r.description or ""),
+            skill_ids=in_play_skills,
+            mcp_ids=in_play_mcps,
+            bound_mcp_ids=bound,
+        )
+        eligible.append(plugin)
+
+        components = set(in_play_skills) | set(in_play_mcps)
+        if plugin.slug in activated_set:
+            continue
+        if invoked & components:
+            # Explicit invocation this turn = activation; persist below so the
+            # next turn keeps the plugin eager without re-invocation.
+            newly_pinned.append(plugin.slug)
+            continue
+        res.deferred.append(plugin)
+        res.deferred_skill_ids.update(in_play_skills)
+        res.deferred_mcp_ids.update(in_play_mcps)
+
+    if newly_pinned:
+        record_plugin_activation(chat_id, newly_pinned)
+        res.activated_slugs.extend(newly_pinned)
+
+    res.directory = sorted(eligible, key=lambda p: p.slug)
+    return res
+
+
+def resolve_bound_progressive_plugins(
+    install_ids: Sequence[str],
+    *,
+    skill_filter: Optional[Any] = None,
+) -> ProgressiveResolution:
+    """Deferral resolution for a sub-agent's explicitly bound plugins.
+
+    Differences from the main-path resolver: plugins are looked up by
+    ``install_id`` (the binding is the grant — no visibility or catalog
+    intersection), every eligible plugin is deferred (sub-agent runs are
+    short-lived and isolated, so there is no sticky activation state to
+    consult), and ``skill_filter`` lets the caller apply the same ownership /
+    release-exposure narrowing the eager path would have applied to the
+    expanded skill ids. Plugins with stdio-transport MCP components are
+    returned via ``directory``-absence: the caller expands them eagerly as
+    before (their component ids are simply not in ``deferred_*``).
+    """
+    from core.db.engine import SessionLocal
+    from core.db.models import InstalledPlugin
+
+    res = ProgressiveResolution()
+    ids = [i for i in install_ids if isinstance(i, str) and i.strip()]
+    if not ids:
+        return res
+
+    try:
+        from core.services.mcp_service import McpServerConfigService
+
+        svc = McpServerConfigService.get_instance()
+        server_cfgs = dict(svc.get_all_servers(enabled_only=True))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[plugin-loader] server config lookup failed: %s", exc)
+        server_cfgs = {}
+
+    skill_meta: Dict[str, Any] = {}
+    try:
+        from core.agent_skills.loader import get_skill_loader
+
+        skill_meta = get_skill_loader().load_all_metadata() or {}
+    except Exception:  # noqa: BLE001
+        skill_meta = {}
+
+    try:
+        with SessionLocal() as db:
+            rows = db.query(InstalledPlugin).filter(InstalledPlugin.install_id.in_(ids)).all()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[plugin-loader] bound plugin load failed: %s", exc)
+        return res
+
+    eligible: List[DeferredPlugin] = []
+    for r in rows:
+        cids = r.component_ids or {}
+        skills = [s for s in (cids.get("skills") or []) if isinstance(s, str) and s.strip()]
+        if skill_filter is not None:
+            try:
+                skills = list(skill_filter(skills))
+            except Exception:  # noqa: BLE001
+                pass
+        mcps = [m for m in (cids.get("mcp") or []) if isinstance(m, str) and m.strip()]
+        if not skills and not mcps:
+            continue
+        if any(not _http_transport(server_cfgs.get(m)) for m in mcps):
+            continue
+        bound: List[str] = []
+        for sid in skills:
+            item = skill_meta.get(sid)
+            for server_id in getattr(item, "mcp_server_ids", None) or []:
+                if server_id and server_id not in bound and server_id not in mcps:
+                    bound.append(server_id)
+        plugin = DeferredPlugin(
+            slug=str(r.slug),
+            name=str(r.name or r.slug),
+            description=str(r.description or ""),
+            skill_ids=skills,
+            mcp_ids=mcps,
+            bound_mcp_ids=bound,
+        )
+        eligible.append(plugin)
+        res.deferred.append(plugin)
+        res.deferred_skill_ids.update(skills)
+        res.deferred_mcp_ids.update(mcps)
+
+    res.directory = sorted(eligible, key=lambda p: p.slug)
+    return res
+
+
+# ── Prompt section ───────────────────────────────────────────────────────────
+
+
+def build_plugin_directory_section(directory: Sequence[DeferredPlugin]) -> str:
+    """Render the stable plugin directory prompt section.
+
+    Deliberately independent of activation state: the same user sees the same
+    bytes in every chat and on every turn, so activating a plugin does not
+    perturb this part of the prefix.
+    """
+    if not directory:
+        return ""
+    lines = [
+        "## 插件目录（Progressive Plugins）",
+        "以下插件为按需加载：**未加载时其技能与工具不在当前列表中**。"
+        "当用户请求匹配某插件的描述、且所需能力不在当前工具/技能列表里时，先调用 "
+        "`load_plugin` 工具（参数为插件标识）加载它，加载后的下一步即可使用其"
+        "工具与技能。已加载过的插件无需重复调用。",
+        "",
+        "可用插件（`插件标识`：适用场景）：",
+    ]
+    for p in directory:
+        desc = " ".join((p.description or "").split()) or p.name
+        label = f"`{p.slug}`" if p.name == p.slug else f"`{p.slug}`（{p.name}）"
+        lines.append(f"- {label}：{desc}")
+    return "\n".join(lines)
+
+
+# ── Runtime activation tool ──────────────────────────────────────────────────
+
+
+def register_load_plugin(
+    toolkit: Any,
+    deferred_by_slug: Dict[str, DeferredPlugin],
+    runtime: Dict[str, Any],
+) -> None:
+    """Register the ``load_plugin`` activation tool onto the collector.
+
+    ``runtime`` is a mutable holder the factory fills in after the real
+    Toolkit / AgentRuntimeState exist:
+
+    - ``toolkit``: the live agentscope Toolkit (basic group is mutated in place;
+      AS2 recomputes schemas and skill instructions every ReAct round, so the
+      appended clients/loaders take effect on the next round).
+    - ``permission_context``: allow_rules are appended for new tool names —
+      without this every freshly activated MCP tool would fall back to ASK.
+    - ``close_list``: the transient-client list returned to the caller; clients
+      connected here are appended so the normal ``close_clients()`` teardown
+      covers them.
+    - ``connected_keys`` / ``activated_slugs``: dedup state.
+    - ``persist`` (default True): False for sub-agent runs — activation stays
+      in-run only (isolated short-lived contexts have no sticky state, and
+      writing under the parent chat's key would leak the activation into the
+      main agent's assembly).
+    - ``loader`` / ``chat_id`` / ``user_id`` / ``enabled_kb_ids`` /
+      ``channel_origin`` / ``reranker_enabled`` / ``confirm_gate`` /
+      ``ontology_runtime``: assembly context replayed at activation.
+    """
+    from agentscope.message import TextBlock
+    from agentscope.tool._response import ToolChunk as ToolResponse
+
+    def _text(msg: str) -> Any:
+        return ToolResponse(content=[TextBlock(type="text", text=msg)])
+
+    async def load_plugin(plugin: str) -> Any:
+        """加载插件目录中列出的插件，激活其包含的全部工具与技能。
+
+        Args:
+            plugin: 插件目录里列出的插件标识（反引号内的 slug），也接受插件名称。
+        """
+        wanted = (plugin or "").strip().strip("`")
+        target: Optional[DeferredPlugin] = None
+        for slug, item in deferred_by_slug.items():
+            if wanted == slug or wanted == item.name or wanted.lower() == slug.lower():
+                target = item
+                break
+        activated: Set[str] = runtime.setdefault("activated_slugs", set())
+        if target is None:
+            known = "、".join(f"`{s}`" for s in sorted(deferred_by_slug)) or "（无）"
+            if wanted in activated:
+                return _text(f"插件「{wanted}」本会话已加载，无需重复调用。")
+            return _text(f"未找到插件「{wanted}」。可加载的插件：{known}。")
+        if target.slug in activated:
+            return _text(f"插件「{target.name}」本会话已加载，无需重复调用。")
+
+        tk = runtime.get("toolkit")
+        if tk is None or not getattr(tk, "tool_groups", None):
+            return _text("插件加载器尚未就绪，请稍后重试。")
+        basic = tk.tool_groups[0]
+
+        connected: Set[str] = runtime.setdefault("connected_keys", set())
+        new_tool_names: List[str] = []
+        failed_servers: List[str] = []
+
+        # ── MCP servers: connect stateless HTTP clients and append in place ──
+        mcp_ids = [m for m in [*target.mcp_ids, *target.bound_mcp_ids] if m not in connected]
+        if mcp_ids:
+            from core.llm.agent_factory import _inject_runtime_headers
+            from core.llm.mcp_confirm import CONFIRM_MCP_SERVERS
+            from core.llm.mcp_pool import make_client
+            from core.services.mcp_service import McpServerConfigService
+
+            svc = McpServerConfigService.get_instance()
+            cfgs = dict(svc.get_all_servers(enabled_only=True))
+            try:
+                cfgs.update(svc.get_owned_servers(str(runtime.get("user_id") or ""), enabled_only=False))
+            except Exception:  # noqa: BLE001
+                pass
+            wanted_cfgs = {k: v for k, v in cfgs.items() if k in set(mcp_ids)}
+            wanted_cfgs = _inject_runtime_headers(
+                wanted_cfgs,
+                current_user_id=runtime.get("user_id"),
+                chat_id=runtime.get("chat_id"),
+                enabled_kb_ids=runtime.get("enabled_kb_ids"),
+                channel_origin=runtime.get("channel_origin"),
+                reranker_enabled=bool(runtime.get("reranker_enabled")),
+            )
+
+            async def _connect(key: str, cfg: dict) -> None:
+                if not _http_transport(cfg):
+                    failed_servers.append(key)
+                    return
+                try:
+                    if runtime.get("confirm_gate") and key in CONFIRM_MCP_SERVERS:
+                        from core.llm.mcp_confirm import (
+                            confirm_specs_for,
+                            make_confirm_gated_client,
+                        )
+
+                        client = make_confirm_gated_client(
+                            key,
+                            cfg,
+                            chat_id=runtime.get("chat_id"),
+                            specs=confirm_specs_for(key),
+                        )
+                    else:
+                        client = make_client(key, cfg, is_stateful=False)
+                    tools = await client.list_tools()
+                except BaseException as exc:  # noqa: BLE001 — SSE cleanup may raise CancelledError
+                    if isinstance(exc, asyncio.CancelledError):
+                        current = asyncio.current_task()
+                        if current is not None and getattr(current, "cancelling", lambda: 0)() > 0:
+                            raise
+                    logger.warning("[plugin-loader] MCP '%s' connect failed: %s", key, exc)
+                    failed_servers.append(key)
+                    return
+                basic.mcps.append(client)
+                connected.add(key)
+                close_list = runtime.get("close_list")
+                if isinstance(close_list, list):
+                    close_list.append(client)
+                new_tool_names.extend(t.name for t in tools if getattr(t, "name", None))
+
+            for key, cfg in wanted_cfgs.items():
+                await _connect(key, cfg)
+            for key in mcp_ids:
+                if key not in wanted_cfgs and key not in failed_servers:
+                    failed_servers.append(key)
+
+        # ── Skills: materialize and append loaders in place ──
+        loader = runtime.get("loader")
+        skill_lines: List[str] = []
+        if loader is not None and target.skill_ids:
+            from agentscope.skill import LocalSkillLoader
+
+            try:
+                meta = loader.load_all_metadata() or {}
+            except Exception:  # noqa: BLE001
+                meta = {}
+            for sid in target.skill_ids:
+                try:
+                    d = loader.get_skill_dir(sid)
+                except Exception:  # noqa: BLE001
+                    d = None
+                if not d:
+                    continue
+                basic.skills_or_loaders.append(LocalSkillLoader(directory=d))
+                item = meta.get(sid)
+                desc = str(getattr(item, "description", "") or "")
+                skill_lines.append(f"- `{sid}`：{desc}" if desc else f"- `{sid}`")
+                # Ontology gate sees the activated skill's trusted tags too.
+                try:
+                    from core.ontology.validator import register_runtime_asset_tags
+
+                    register_runtime_asset_tags(
+                        runtime.get("ontology_runtime") or {},
+                        kind="skill",
+                        asset_id=sid,
+                        tags=list(getattr(item, "tags", []) or []),
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+
+        # ── Permissions: newly activated MCP tools must be pre-allowed ──
+        pc = runtime.get("permission_context")
+        if pc is not None and new_tool_names:
+            try:
+                from agentscope.permission import PermissionBehavior, PermissionRule
+
+                for n in new_tool_names:
+                    pc.allow_rules.setdefault(n, []).append(
+                        PermissionRule(
+                            tool_name=n,
+                            rule_content="",
+                            behavior=PermissionBehavior.ALLOW,
+                            source="jx_trusted",
+                        )
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[plugin-loader] allow_rules append failed: %s", exc)
+
+        activated.add(target.slug)
+        if runtime.get("persist", True):
+            await asyncio.to_thread(
+                record_plugin_activation, runtime.get("chat_id"), [target.slug]
+            )
+
+        parts = [f"插件「{target.name}」已加载。"]
+        if new_tool_names:
+            parts.append("新增工具（下一步即可直接调用）：" + "、".join(f"`{n}`" for n in new_tool_names))
+        if skill_lines:
+            parts.append(
+                "新增技能（使用前必须先用 `view_text_file` 读取 "
+                "`/workspace/skills/<技能名>/SKILL.md`）：\n" + "\n".join(skill_lines)
+            )
+        if failed_servers:
+            parts.append("以下 MCP 服务连接失败，其工具本轮不可用：" + "、".join(failed_servers))
+        if not new_tool_names and not skill_lines:
+            parts.append("该插件本轮没有可加载的组件（可能均已被禁用）。")
+        return _text("\n".join(parts))
+
+    toolkit.register_tool_function(load_plugin, namesake_strategy="override")
+
+
+__all__ = [
+    "DeferredPlugin",
+    "ProgressiveResolution",
+    "build_plugin_directory_section",
+    "load_activated_plugin_slugs",
+    "progressive_plugin_loading_enabled",
+    "record_plugin_activation",
+    "register_load_plugin",
+    "resolve_bound_progressive_plugins",
+    "resolve_progressive_plugins",
+]

--- a/src/backend/orchestration/workflow.py
+++ b/src/backend/orchestration/workflow.py
@@ -1257,6 +1257,10 @@ def run_chat_workflow(
                 if _workflow_turbo
                 else None
             ),
+            # 渐进式插件加载：本轮显式呼唤的能力不得被延迟（用户消息注入已承诺
+            # 其可用），并作为会话级激活落库。
+            invoked_skill_ids=_explicit_skill_ids_from_context(context),
+            invoked_mcp_ids=[m for m in (context.get("mcp_ids") or []) if isinstance(m, str)],
             memory_enabled=_workflow_mem_enabled,
             batch_mode=_workflow_batch_chat if _direct_user_agent is None else False,
             user_agent=_direct_user_agent,
@@ -2464,6 +2468,10 @@ async def astream_chat_workflow(
                 if _turbo_chat
                 else None
             ),
+            # 渐进式插件加载：本轮显式呼唤的能力不得被延迟（用户消息注入已承诺
+            # 其可用），并作为会话级激活落库。
+            invoked_skill_ids=_explicit_skill_ids_from_context(context),
+            invoked_mcp_ids=[m for m in (context.get("mcp_ids") or []) if isinstance(m, str)],
             memory_enabled=_mem0_enabled,
             visible_subagents=_visible_subagents if _visible_subagents else None,
             plan_mode=_plan_chat,

--- a/src/backend/tests/test_plugin_progressive_loading.py
+++ b/src/backend/tests/test_plugin_progressive_loading.py
@@ -1,0 +1,286 @@
+"""Progressive plugin loading（渐进式插件加载）单元测试。
+
+覆盖三块：装配期延迟解析（可见性 / enabled 交集 / stdio 排除 / 激活与显式呼唤
+排除 + 落库）、插件目录 prompt 段的稳定渲染、``load_plugin`` 激活工具的运行时
+副作用（Toolkit basic 组追加 / allow_rules / close_list / 会话粘滞落库）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import core.db.engine as dbe
+from core.db.models import ChatSession, InstalledPlugin, UserShadow
+from core.llm import plugin_loader
+from core.llm.tool_collector import ToolCollector
+
+USER = "ppl_user"
+CHAT = "ppl_chat_1"
+
+
+@pytest.fixture()
+def ppl_env(tmp_path, monkeypatch):
+    """Isolated sqlite DB bound to SessionLocal + stubbed MCP/skill services."""
+    url = f"sqlite:///{tmp_path}/ppl.db"
+    engine = create_engine(url)
+    dbe.Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, expire_on_commit=False)
+    monkeypatch.setattr(dbe, "SessionLocal", TestSession)
+
+    with TestSession() as db:
+        db.add(UserShadow(user_id=USER, username=USER))
+        db.add(ChatSession(chat_id=CHAT, user_id=USER, title="t"))
+        db.add(
+            InstalledPlugin(
+                install_id="crawler@global",
+                slug="crawler",
+                name="爬虫插件",
+                description="抓取网页并结构化。",
+                component_ids={"skills": ["crawler-scrape-a1"], "mcp": ["crawler_mcp"]},
+            )
+        )
+        db.add(
+            InstalledPlugin(
+                install_id="localtool@global",
+                slug="localtool",
+                name="本地工具",
+                description="stdio 形态的本地插件。",
+                component_ids={"skills": [], "mcp": ["local_stdio_mcp"]},
+            )
+        )
+        db.add(
+            InstalledPlugin(
+                install_id="secret@other",
+                slug="secret",
+                name="别人的私有插件",
+                description="不可见。",
+                owner_user_id="someone_else",
+                component_ids={"skills": [], "mcp": ["crawler_mcp"]},
+            )
+        )
+        db.commit()
+
+    # MCP server configs: crawler_mcp is HTTP, local_stdio_mcp is stdio.
+    server_cfgs = {
+        "crawler_mcp": {"transport": "streamable_http", "url": "http://mcp:9999/mcp"},
+        "local_stdio_mcp": {"transport": "stdio", "command": "python"},
+    }
+    svc = SimpleNamespace(
+        get_all_servers=lambda enabled_only=True: dict(server_cfgs),
+        get_owned_servers=lambda uid, enabled_only=False: {},
+    )
+    from core.services.mcp_service import McpServerConfigService
+
+    monkeypatch.setattr(McpServerConfigService, "get_instance", classmethod(lambda cls: svc))
+
+    # Skill metadata: crawler skill binds no extra MCP.
+    meta = {
+        "crawler-scrape-a1": SimpleNamespace(
+            description="抓取单页", tags=[], mcp_server_ids=[]
+        )
+    }
+    loader_stub = SimpleNamespace(
+        load_all_metadata=lambda: dict(meta),
+        get_skill_dir=lambda sid: None,
+    )
+    import core.agent_skills.loader as skills_loader_mod
+
+    monkeypatch.setattr(skills_loader_mod, "get_skill_loader", lambda: loader_stub)
+
+    return SimpleNamespace(Session=TestSession, loader=loader_stub, server_cfgs=server_cfgs)
+
+
+def _resolve(env, **overrides):
+    kwargs = dict(
+        user_id=USER,
+        chat_id=CHAT,
+        enabled_skill_ids=["crawler-scrape-a1", "plain-skill"],
+        enabled_mcp_ids=["crawler_mcp", "local_stdio_mcp", "internet_search"],
+        invoked_skill_ids=None,
+        invoked_mcp_ids=None,
+    )
+    kwargs.update(overrides)
+    return plugin_loader.resolve_progressive_plugins(**kwargs)
+
+
+def test_defers_visible_http_plugin_and_keeps_stdio_eager(ppl_env):
+    res = _resolve(ppl_env)
+    assert [p.slug for p in res.deferred] == ["crawler"]
+    assert res.deferred_skill_ids == {"crawler-scrape-a1"}
+    assert res.deferred_mcp_ids == {"crawler_mcp"}
+    # stdio 插件不延迟也不进目录；他人私有插件不可见。
+    assert [p.slug for p in res.directory] == ["crawler"]
+    # 非插件组件不受影响（调用方只做差集，这里不应出现）。
+    assert "plain-skill" not in res.deferred_skill_ids
+    assert "internet_search" not in res.deferred_mcp_ids
+
+
+def test_disabled_components_make_plugin_ineligible(ppl_env):
+    res = _resolve(ppl_env, enabled_skill_ids=[], enabled_mcp_ids=["internet_search"])
+    assert res.deferred == []
+    assert res.directory == []
+
+
+def test_activated_plugin_stays_eager_but_remains_in_directory(ppl_env):
+    with ppl_env.Session() as db:
+        row = db.query(ChatSession).filter(ChatSession.chat_id == CHAT).first()
+        row.extra_data = {"activated_plugins": ["crawler"]}
+        db.commit()
+    res = _resolve(ppl_env)
+    assert res.deferred == []
+    assert [p.slug for p in res.directory] == ["crawler"]
+    assert res.activated_slugs == ["crawler"]
+
+
+def test_explicit_invocation_pins_activation(ppl_env):
+    res = _resolve(ppl_env, invoked_skill_ids=["crawler-scrape-a1"])
+    assert res.deferred == []
+    assert "crawler" in res.activated_slugs
+    # 落库粘滞：下一轮装配读到激活态。
+    assert plugin_loader.load_activated_plugin_slugs(CHAT) == ["crawler"]
+
+
+def test_directory_section_stable_and_empty_safe(ppl_env):
+    res = _resolve(ppl_env)
+    section = plugin_loader.build_plugin_directory_section(res.directory)
+    assert "`crawler`" in section and "爬虫插件" in section and "load_plugin" in section
+    assert plugin_loader.build_plugin_directory_section([]) == ""
+    # 激活状态不改变目录字节（前缀缓存友好）。
+    with ppl_env.Session() as db:
+        row = db.query(ChatSession).filter(ChatSession.chat_id == CHAT).first()
+        row.extra_data = {"activated_plugins": ["crawler"]}
+        db.commit()
+    res2 = _resolve(ppl_env)
+    assert plugin_loader.build_plugin_directory_section(res2.directory) == section
+
+
+class _FakeMCPClient:
+    def __init__(self, name, cfg):
+        self.name = name
+
+    async def list_tools(self):
+        return [SimpleNamespace(name="crawl_url"), SimpleNamespace(name="crawl_site")]
+
+
+def test_load_plugin_tool_activates_in_place(ppl_env, tmp_path, monkeypatch):
+    from agentscope.tool import Toolkit
+
+    import core.llm.mcp_pool as mcp_pool
+
+    monkeypatch.setattr(
+        mcp_pool, "make_client", lambda key, cfg, is_stateful=True, **kw: _FakeMCPClient(key, cfg)
+    )
+
+    # 技能目录物化桩：含 SKILL.md 的临时目录。
+    skill_dir = tmp_path / "crawler-scrape-a1"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: crawler-scrape-a1\ndescription: 抓取单页\n---\nbody", encoding="utf-8"
+    )
+    ppl_env.loader.get_skill_dir = lambda sid: str(skill_dir)
+
+    res = _resolve(ppl_env)
+    collector = ToolCollector()
+    tk = Toolkit(tools=[], mcps=[])
+    close_list: list = []
+    permission_context = SimpleNamespace(allow_rules={})
+    runtime = {
+        "activated_slugs": set(),
+        "connected_keys": {"internet_search"},
+        "toolkit": tk,
+        "permission_context": permission_context,
+        "close_list": close_list,
+        "loader": ppl_env.loader,
+        "chat_id": CHAT,
+        "user_id": USER,
+        "enabled_kb_ids": [],
+        "channel_origin": None,
+        "reranker_enabled": False,
+        "confirm_gate": False,
+        "ontology_runtime": {},
+    }
+    plugin_loader.register_load_plugin(collector, res.deferred_by_slug(), runtime)
+    tool = collector.get_tool("load_plugin")
+    assert tool is not None
+
+    resp = asyncio.run(tool._func(plugin="crawler"))
+    text = "".join(getattr(b, "text", "") for b in resp.content)
+    assert "已加载" in text and "crawl_url" in text and "crawler-scrape-a1" in text
+
+    basic = tk.tool_groups[0]
+    assert len(basic.mcps) == 1 and len(close_list) == 1
+    assert {r for r in permission_context.allow_rules} == {"crawl_url", "crawl_site"}
+    assert len(basic.skills_or_loaders) == 1
+    assert "crawler" in runtime["activated_slugs"]
+    assert plugin_loader.load_activated_plugin_slugs(CHAT) == ["crawler"]
+
+    # 重复加载幂等，未知插件报错并列出可用项。
+    resp2 = asyncio.run(tool._func(plugin="crawler"))
+    text2 = "".join(getattr(b, "text", "") for b in resp2.content)
+    assert "无需重复调用" in text2
+    assert len(basic.mcps) == 1
+
+    resp3 = asyncio.run(tool._func(plugin="nope"))
+    text3 = "".join(getattr(b, "text", "") for b in resp3.content)
+    assert "未找到插件" in text3 and "`crawler`" in text3
+
+
+def test_resolve_bound_defers_http_plugins_and_applies_skill_filter(ppl_env):
+    res = plugin_loader.resolve_bound_progressive_plugins(
+        ["crawler@global", "localtool@global", "missing@global"],
+        skill_filter=lambda sids: [s for s in sids if s != "crawler-scrape-a1"],
+    )
+    # crawler 仍有 MCP 组件 → 延迟；skill_filter 生效（技能被属主过滤掉）。
+    assert [p.slug for p in res.deferred] == ["crawler"]
+    assert res.deferred_skill_ids == set()
+    assert res.deferred_mcp_ids == {"crawler_mcp"}
+    # stdio 插件不进延迟集（调用方按老路径 eager 展开）。
+    assert all(p.slug != "localtool" for p in res.directory)
+
+
+def test_load_plugin_no_persist_for_subagent_runtime(ppl_env, tmp_path, monkeypatch):
+    from agentscope.tool import Toolkit
+
+    import core.llm.mcp_pool as mcp_pool
+
+    monkeypatch.setattr(
+        mcp_pool, "make_client", lambda key, cfg, is_stateful=True, **kw: _FakeMCPClient(key, cfg)
+    )
+    res = plugin_loader.resolve_bound_progressive_plugins(["crawler@global"])
+    collector = ToolCollector()
+    runtime = {
+        "activated_slugs": set(),
+        "connected_keys": set(),
+        "toolkit": Toolkit(tools=[], mcps=[]),
+        "permission_context": SimpleNamespace(allow_rules={}),
+        "close_list": [],
+        "persist": False,
+        "loader": ppl_env.loader,
+        "chat_id": CHAT,
+        "user_id": USER,
+        "enabled_kb_ids": [],
+        "channel_origin": None,
+        "reranker_enabled": False,
+        "confirm_gate": False,
+        "ontology_runtime": {},
+    }
+    plugin_loader.register_load_plugin(collector, res.deferred_by_slug(), runtime)
+    tool = collector.get_tool("load_plugin")
+    resp = asyncio.run(tool._func(plugin="crawler"))
+    text = "".join(getattr(b, "text", "") for b in resp.content)
+    assert "已加载" in text
+    assert "crawler" in runtime["activated_slugs"]
+    # 子智能体激活不落库——父会话的激活列表保持为空。
+    assert plugin_loader.load_activated_plugin_slugs(CHAT) == []
+
+
+def test_env_kill_switch(monkeypatch):
+    monkeypatch.setenv("PLUGIN_PROGRESSIVE_LOADING", "false")
+    assert plugin_loader.progressive_plugin_loading_enabled() is False
+    monkeypatch.delenv("PLUGIN_PROGRESSIVE_LOADING", raising=False)
+    assert plugin_loader.progressive_plugin_loading_enabled() is True

--- a/src/frontend/src/components/tool/ToolCallRow.tsx
+++ b/src/frontend/src/components/tool/ToolCallRow.tsx
@@ -71,6 +71,10 @@ function getRowLabel(
         const sn = (tool.input as any)?.skill_name || (tool.input as any)?.name || '';
         return { prefix: t('激活技能：'), value: sn || '' };
       }
+      case 'load_plugin': {
+        const pn = (tool.input as any)?.plugin || '';
+        return { prefix: t('加载插件：'), value: String(pn) };
+      }
       case 'view_text_file': {
         const fp = (tool.input as any)?.file_name || (tool.input as any)?.path || '';
         const fn = fp ? String(fp).split('/').pop() || '' : '';
@@ -166,6 +170,7 @@ function StepIcon({ name }: { name: string }) {
     list_datasets: DatabaseOutlined,
     query_database: DatabaseOutlined,
     load_skill: ThunderboltOutlined,
+    load_plugin: ThunderboltOutlined,
     get_skills: ThunderboltOutlined,
     get_mcp_tools: ThunderboltOutlined,
     call_subagent: RobotOutlined,

--- a/src/frontend/src/components/tool/ToolOutputRenderer.tsx
+++ b/src/frontend/src/components/tool/ToolOutputRenderer.tsx
@@ -219,6 +219,25 @@ export function renderToolOutputBody(toolName: string, out: unknown, setDetailMo
   // Load skill: render the same detail as the capability center, avoiding stuffing the full SKILL.md into the card
   if (toolName === 'load_skill') return renderLoadSkill(out);
 
+  // Load plugin: the activation summary is human-readable markdown-ish text
+  // (新增工具/技能列表) — render it as formatted content, never as a JSON dump
+  if (toolName === 'load_plugin') {
+    const raw = typeof out === 'string'
+      ? out
+      : (out && typeof out === 'object' && typeof (out as any).result === 'string')
+        ? (out as any).result
+        : (out && typeof out === 'object' && typeof (out as any).text === 'string')
+          ? (out as any).text
+          : String(out ?? '');
+    if (!raw.trim()) return empty(t('暂无详情'));
+    return (
+      <div className="jx-tr-db">
+        <div className="jx-tr-dbHeader success">{t('插件已加载')}</div>
+        <div className="jx-md jx-tr-skillBody" dangerouslySetInnerHTML={{ __html: mdToHtml(raw) }} />
+      </div>
+    );
+  }
+
   // Load/read file: compact metadata card + short preview, avoiding stuffing the whole file into the card
   if (toolName === 'view_text_file' || toolName === 'read_artifact' || toolName === 'Read') {
     return renderFilePreview(out);

--- a/src/frontend/src/i18n/en/stores.ts
+++ b/src/frontend/src/i18n/en/stores.ts
@@ -47,6 +47,7 @@ export const STORES_DICT: Record<string, string> = {
   // constants — tool name overrides
   '读取文件': 'Read File',
   '加载技能': 'Load Skill',
+  '加载插件': 'Load Plugin',
   '浏览我的空间': 'Browse My Space',
   '导入文件到工作区': 'Import File to Workspace',
   '浏览收藏会话': 'Browse Favorite Chats',

--- a/src/frontend/src/i18n/en/tool.ts
+++ b/src/frontend/src/i18n/en/tool.ts
@@ -56,6 +56,8 @@ export const TOOL_DICT: Record<string, string> = {
   '本地知识库': 'Local KB',
   '知识库列表': 'KB List',
   '激活技能：': 'Skill: ',
+  '加载插件：': 'Plugin: ',
+  '插件已加载': 'Plugin loaded',
   '读取文件：': 'Read file: ',
   '生成图表': 'Generate Chart',
   '生成 Word 文档': 'Generate Word',

--- a/src/frontend/src/utils/constants.ts
+++ b/src/frontend/src/utils/constants.ts
@@ -39,6 +39,7 @@ export const TOOL_NAME_OVERRIDES: Record<string, string> = {
   view_text_file: t('读取文件'),
   call_subagent: t('调用子智能体'),
   load_skill: t('加载技能'),
+  load_plugin: t('加载插件'),
   // MySpace tools
   list_myspace_files: t('浏览我的空间'),
   stage_myspace_file: t('导入文件到工作区'),


### PR DESCRIPTION
## Summary

Installed plugins used to inject **all** of their bundled capabilities into every request — one skill-list line per skill in the system prompt, plus the full JSON schema of every MCP tool in the `tools` parameter, re-sent on every ReAct round. TTFT therefore grew linearly with the number of installed plugins.

This PR introduces **progressive plugin loading**: the plugin becomes a runtime aggregation unit again.

- **Assembly time**: plugin components are subtracted from the run's enabled sets. The system prompt carries only a one-line directory entry per plugin (`slug` + description) and a single `load_plugin` tool is registered.
- **Activation time**: when the model decides a request matches a plugin's description, it calls `load_plugin`. Only then are the plugin's MCP servers connected (stateless HTTP clients appended to the live toolkit) and its skills registered. Schemas and skill instructions are recomputed each round, so everything is usable from the next step.
- **Stickiness**: activation is persisted per chat (`chat_sessions.metadata.activated_plugins`), so subsequent turns assemble the plugin eagerly with no repeated activation. Explicitly invoking a plugin (slash / `+` menu) counts as activation.
- **Sub-agents**: plugins bound to a sub-agent are deferred the same way, with run-scoped activation only (no persistence, to avoid leaking into the parent chat's assembly).

The plugin directory is sorted by slug and byte-stable regardless of activation state, so provider-side prefix caching pays for an activation only on the activation turn and the one after it.

## Boundaries

- Plugins pinned by a restricted chat mode stay eagerly loaded (deliberate admin narrowing).
- Plugins with stdio-transport MCP components are not deferred.
- `PLUGIN_PROGRESSIVE_LOADING=false` reverts to eager assembly.

## Also included

- Hide AgentScope's builtin `Skill` viewer schema: skills load exclusively through `view_text_file` in this stack, so the schema was pure per-round prefill waste and a wrong entry point bypassing path mapping / runtime hints / observability.
- Chat UI polish for the `load_plugin` tool call: localized label, inline plugin slug, and a formatted activation-summary card instead of a raw JSON dump.

## Testing

- `tests/test_plugin_progressive_loading.py` (9 cases): deferral resolution (visibility / enabled intersection / stdio exclusion / activation & invocation exemption with persistence), directory rendering stability, `load_plugin` runtime side effects (toolkit mutation, allow rules, close-list, chat persistence, sub-agent no-persist), env kill switch.
- Existing plugin / chat-mode / citation regression suites pass.
