### PR TITLE
fix(db): strip NUL (U+0000) from chat messages before persistence

### DIFF
--- a/src/backend/core/db/repository/chat.py
+++ b/src/backend/core/db/repository/chat.py
@@ -15,6 +15,25 @@ from sqlalchemy import and_, desc, func, or_, select
 from sqlalchemy.orm import Session
 
 
+def _strip_nul(value: Any) -> Any:
+    """递归剥离 ``\\u0000``——PostgreSQL 的 text/JSONB 不接受 NUL 字符。
+
+    工具结果里混入字面 NUL 并不罕见（PDF 提取文本、二进制味的网页正文），
+    一旦原样进入 content / tool_calls 等字段，INSERT 会被
+    ``UntranslatableCharacter`` 整条拒绝、消息丢失。这里是消息落库的唯一
+    收口，普通对话 / 定时任务 / 自主循环全部经过。
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "") if "\x00" in value else value
+    if isinstance(value, list):
+        return [_strip_nul(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_nul(v) for v in value)
+    if isinstance(value, dict):
+        return {_strip_nul(k): _strip_nul(v) for k, v in value.items()}
+    return value
+
+
 def _visible_message_text(content: str) -> str:
     """assistant 消息 content 的可见正文（剥离 <think> 思考段）。
 
@@ -348,7 +367,7 @@ class ChatMessageRepository:
 
     def create(self, message_data: Dict[str, Any]) -> ChatMessage:
         """Create a new chat message."""
-        message = ChatMessage(**message_data)
+        message = ChatMessage(**_strip_nul(message_data))
         message.created_at = datetime.utcnow()
         self.db.add(message)
         self.db.commit()
@@ -366,7 +385,7 @@ class ChatMessageRepository:
         if not message:
             return None
         for key, value in update_data.items():
-            setattr(message, key, value)
+            setattr(message, key, _strip_nul(value))
         self.db.commit()
         self.db.refresh(message)
         return message
@@ -377,7 +396,7 @@ class ChatMessageRepository:
         if not message:
             return None
         merged = dict(message.extra_data or {})
-        merged.update(patch)
+        merged.update(_strip_nul(patch))
         message.extra_data = merged
         self.db.commit()
         self.db.refresh(message)

--- a/src/backend/tests/chat/test_message_nul_sanitize.py
+++ b/src/backend/tests/chat/test_message_nul_sanitize.py
@@ -1,0 +1,57 @@
+"""消息落库收口的 NUL 清洗（ChatMessageRepository）。
+
+PostgreSQL 的 text/JSONB 不接受 NUL：工具结果（PDF 提取文本等）带字面 NUL
+时，整条 INSERT 会被 UntranslatableCharacter 拒绝、消息丢失（定时任务
+「arXiv 雷达」2026-07-03 实际翻车过）。repository 的 create/update/
+update_extra_data 是消息写库唯一收口，须在此剥离。SQLite 测试库本身不
+拒绝 NUL，所以断言的是「存进去的值已被清洗」。
+"""
+
+from core.db.repository.chat import ChatMessageRepository, _strip_nul
+
+
+def test_strip_nul_recurses_and_preserves_clean_values():
+    assert _strip_nul("a\x00b") == "ab"
+    nested = {"k\x00ey": ["x\x00", {"n": "y\x00z"}, 1, None, 3.5]}
+    assert _strip_nul(nested) == {"key": ["x", {"n": "yz"}, 1, None, 3.5]}
+    clean = "clean"
+    assert _strip_nul(clean) is clean  # 无 NUL 时不复制
+
+
+def test_create_sanitizes_content_and_json_fields(db_session):
+    repo = ChatMessageRepository(db_session)
+    msg = repo.create(
+        {
+            "message_id": "msg_nul_create",
+            "chat_id": "chat_nul",
+            "role": "assistant",
+            "content": "Ψ(HA) ≡ β\x00…",
+            "tool_calls": [{"tool_name": "search", "result": "pdf\x00text"}],
+            "usage": {"prompt_tokens": 1},
+            "extra_data": {"note": "a\x00b"},
+        }
+    )
+    assert msg.content == "Ψ(HA) ≡ β…"
+    assert msg.tool_calls == [{"tool_name": "search", "result": "pdftext"}]
+    assert msg.extra_data == {"note": "ab"}
+
+
+def test_update_and_extra_data_merge_sanitize(db_session):
+    repo = ChatMessageRepository(db_session)
+    repo.create(
+        {
+            "message_id": "msg_nul_update",
+            "chat_id": "chat_nul",
+            "role": "assistant",
+            "content": "初始",
+        }
+    )
+    updated = repo.update(
+        "msg_nul_update",
+        {"content": "新\x00正文", "tool_calls": [{"r": "v\x00"}]},
+    )
+    assert updated.content == "新正文"
+    assert updated.tool_calls == [{"r": "v"}]
+
+    patched = repo.update_extra_data("msg_nul_update", {"follow_up": ["q\x001"]})
+    assert patched.extra_data["follow_up"] == ["q1"]


### PR DESCRIPTION
## Problem

PostgreSQL rejects NUL characters (`\u0000`) in `text`/`JSONB` columns. When a tool result carried a literal NUL — e.g. text extracted from a PDF or a binary-ish web page — the whole assistant-message INSERT into `chat_messages` failed with `UntranslatableCharacter` and the message (including all tool cards) was lost. For scheduled tasks this surfaced as a failed run.

## Fix

Recursively strip `\x00` from strings at the single write choke point — `ChatMessageRepository.create` / `update` / `update_extra_data` — so regular chats, scheduled tasks and autonomous loops are all covered by one sanitizer. Clean values pass through without copying.

## Tests

- `src/backend/tests/chat/test_message_nul_sanitize.py`: helper recursion/pass-through, sanitization on create, on in-place update and on `extra_data` merge (3 new tests).
- Existing `tests/chat` + `tests/services` suites pass (219 tests).