### PR TITLE
feat(ui): dark mode with system-follow and manual toggle

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -5,6 +5,28 @@
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HugAgentOS</title>
+    <script>
+      // 防闪烁：在任何 CSS/JS 加载前同步落主题，避免深色用户首屏闪白。
+      // key 与解析规则和 src/theme.ts 保持一致（非 light/dark 的值一律按 system）；
+      // 分享预览页锁定浅色。主树 src/frontend/index.html 有逐字相同的一份，三处同步改。
+      ;(function () {
+        try {
+          var mode = localStorage.getItem('hugagent_theme_mode')
+          var dark =
+            mode === 'dark' ||
+            (mode !== 'light' &&
+              typeof matchMedia === 'function' &&
+              matchMedia('(prefers-color-scheme: dark)').matches)
+          if (new URLSearchParams(location.search).has('share')) dark = false
+          if (dark) {
+            document.documentElement.setAttribute('data-theme', 'dark')
+            document.documentElement.style.colorScheme = 'dark'
+          }
+        } catch (e) {
+          /* 存储被禁等异常时保持浅色 */
+        }
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -707,7 +707,7 @@ export default function App() {
         onSelectSearchResult={handleSelectSearchResult}
       />
 
-      <Layout className={`jx-appMainLayout${canvasFullscreen ? ' is-canvasFullscreen' : ''}`} style={{ overflow: 'hidden', background: '#ffffff' }}>
+      <Layout className={`jx-appMainLayout${canvasFullscreen ? ' is-canvasFullscreen' : ''}`} style={{ overflow: 'hidden', background: 'var(--color-bg-base)' }}>
         <div className={`jx-primaryPane${canvasOpen ? ' is-canvasOpen' : ''}`}>
         {!showChatHeader && (
           <header className="jx-mobileHeader">

--- a/src/frontend/src/AppThemeProvider.tsx
+++ b/src/frontend/src/AppThemeProvider.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useSyncExternalStore, type ReactNode } from 'react';
+import { ConfigProvider } from 'antd';
+import zhCN from 'antd/locale/zh_CN';
+import enUS from 'antd/locale/en_US';
+import { getLang } from './i18n';
+import { getAppTheme } from './appTheme';
+import { useUIStore } from './stores/uiStore';
+import { applyThemeToDom, systemPrefersDark, watchSystemTheme } from './theme';
+
+interface AppThemeProviderProps {
+  children: ReactNode;
+  /** 分享预览等对外页面锁定浅色：观看者常不是本机账号，内容外观应与作者所见一致 */
+  forceLight?: boolean;
+}
+
+/**
+ * 主题根：统一包掉 antd ConfigProvider（含 locale），按 uiStore 的档位 + 系统外观
+ * 解析当前深浅，切换 light/dark algorithm 并把 data-theme 落 DOM。
+ * 「跟随系统」经 useSyncExternalStore 订阅 matchMedia，系统翻转即时生效。
+ * 主入口与 CE overlay 入口共用，入口文件各自只包一层。
+ */
+export function AppThemeProvider({ children, forceLight = false }: AppThemeProviderProps) {
+  const themeMode = useUIStore((s) => s.themeMode);
+  const sysDark = useSyncExternalStore(watchSystemTheme, systemPrefersDark);
+  const isDark = !forceLight && (themeMode === 'dark' || (themeMode === 'system' && sysDark));
+
+  useEffect(() => {
+    applyThemeToDom(isDark);
+  }, [isDark]);
+
+  return (
+    <ConfigProvider theme={getAppTheme(isDark)} locale={getLang() === 'en' ? enUS : zhCN}>
+      {children}
+    </ConfigProvider>
+  );
+}

--- a/src/frontend/src/appTheme.ts
+++ b/src/frontend/src/appTheme.ts
@@ -1,25 +1,63 @@
-/** Ant Design theme tokens aligned with UI design spec — a single shared point for main.tsx (including the CE overlay version). */
-export const appTheme = {
-  token: {
-    colorPrimary: '#126DFF',
-    colorSuccess: '#02B589',
-    colorWarning: '#F8AB42',
-    colorError: '#FC5D5D',
-    colorInfo: '#126DFF',
-    colorText: '#101828',
-    colorTextSecondary: '#475467',
-    colorTextTertiary: '#667085',
-    colorTextQuaternary: '#98A2B3',
-    colorBorder: '#DDE3EC',
-    colorBorderSecondary: '#E9EDF3',
-    colorBgContainer: '#FFFFFF',
-    colorBgLayout: '#F5F7FB',
-    borderRadius: 10,
-    borderRadiusLG: 16,
-    borderRadiusSM: 6,
-    fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", sans-serif',
-    fontSize: 14,
-    fontSizeSM: 12,
-    fontSizeLG: 16,
-  },
+/**
+ * Ant Design theme tokens aligned with UI design spec — a single shared point for main.tsx (including the CE overlay version).
+ * 深浅两套 token 的取值与 styles/variables.css 的 :root / :root[data-theme="dark"] 覆盖块一一对应，两边同步改。
+ */
+import { theme as antdTheme } from 'antd';
+import type { ThemeConfig } from 'antd';
+
+const sharedToken = {
+  colorWarning: '#F8AB42',
+  borderRadius: 10,
+  borderRadiusLG: 16,
+  borderRadiusSM: 6,
+  fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", sans-serif',
+  fontSize: 14,
+  fontSizeSM: 12,
+  fontSizeLG: 16,
 };
+
+const lightToken = {
+  colorPrimary: '#126DFF',
+  colorSuccess: '#02B589',
+  colorError: '#FC5D5D',
+  colorInfo: '#126DFF',
+  colorText: '#101828',
+  colorTextSecondary: '#475467',
+  colorTextTertiary: '#667085',
+  colorTextQuaternary: '#98A2B3',
+  colorBorder: '#DDE3EC',
+  colorBorderSecondary: '#E9EDF3',
+  colorBgContainer: '#FFFFFF',
+  colorBgLayout: '#F5F7FB',
+};
+
+const darkToken = {
+  colorPrimary: '#3E8BFF',
+  colorSuccess: '#22C79D',
+  colorError: '#FF6B6B',
+  colorInfo: '#3E8BFF',
+  colorText: '#E8ECF4',
+  colorTextSecondary: '#B3BDCD',
+  colorTextTertiary: '#8792A4',
+  colorTextQuaternary: '#5F6B7D',
+  colorBorder: '#2B3442',
+  colorBorderSecondary: '#242C38',
+  colorBgContainer: '#161C25',
+  colorBgElevated: '#1C2330',
+  colorBgLayout: '#12171F',
+  colorBgSpotlight: '#1C2330',
+};
+
+// 模块级预建常量：同主题下引用稳定，ConfigProvider 无需重算派生 token
+const LIGHT_THEME: ThemeConfig = {
+  algorithm: antdTheme.defaultAlgorithm,
+  token: { ...sharedToken, ...lightToken },
+};
+const DARK_THEME: ThemeConfig = {
+  algorithm: antdTheme.darkAlgorithm,
+  token: { ...sharedToken, ...darkToken },
+};
+
+export function getAppTheme(isDark: boolean): ThemeConfig {
+  return isDark ? DARK_THEME : LIGHT_THEME;
+}

--- a/src/frontend/src/components/loop/loop.css
+++ b/src/frontend/src/components/loop/loop.css
@@ -18,28 +18,30 @@
   min-height: 0;
   height: calc(100vh - 150px);
   font-size: 14px;
-  color: var(--text-primary, #1f2328);
-  background: var(--bg-primary, #fff);
-  border: 1px solid var(--border-color, #e1e4e8);
+  color: var(--color-text);
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   overflow: hidden;
 }
 .loop-sidebar {
   width: 340px;
-  border-right: 1px solid var(--border-color, #e1e4e8);
+  border-right: 1px solid var(--color-border);
   padding: 16px;
   overflow-y: auto;
   flex-shrink: 0;
 }
 .loop-sidebar h3 { margin: 8px 0; font-size: 15px; }
-.loop-sidebar label { display: block; margin: 8px 0 3px; font-size: 12px; color: #666; }
+.loop-sidebar label { display: block; margin: 8px 0 3px; font-size: 12px; color: var(--color-text-secondary); }
 .loop-sidebar textarea,
 .loop-sidebar input {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid var(--border-color, #d0d7de);
+  border: 1px solid var(--color-fill);
   border-radius: 6px;
   padding: 6px 8px;
+  background: var(--color-bg-container);
+  color: var(--color-text);
   font-family: inherit;
   font-size: 13px;
 }
@@ -49,28 +51,28 @@
   border: none; border-radius: 6px; padding: 7px 14px; cursor: pointer;
   font-size: 13px; margin-top: 10px;
 }
-.loop-btn.primary { background: #2563eb; color: #fff; }
-.loop-btn.danger { background: #dc2626; color: #fff; }
+.loop-btn.primary { background: var(--color-primary); color: var(--color-text-white); }
+.loop-btn.danger { background: var(--color-error); color: var(--color-text-white); }
 .loop-list { margin-top: 8px; }
 .loop-list-item {
-  border: 1px solid var(--border-color, #e1e4e8); border-radius: 8px;
+  border: 1px solid var(--color-border); border-radius: 8px;
   padding: 8px 10px; margin-bottom: 6px; cursor: pointer;
 }
-.loop-list-item.active { border-color: #2563eb; background: rgba(37,99,235,0.06); }
+.loop-list-item.active { border-color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 6%, transparent); }
 .loop-title { font-weight: 600; font-size: 13px; }
-.loop-status { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 10px; margin: 3px 0; background: #eee; }
+.loop-status { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 10px; margin: 3px 0; background: var(--color-fill-hover); }
 .loop-status.s-completed { background: #dcfce7; color: #166534; }
 .loop-status.s-running { background: #dbeafe; color: #1e40af; }
 .loop-status.s-budget_exhausted { background: #fef9c3; color: #854d0e; }
 .loop-status.s-failed { background: #fee2e2; color: #991b1b; }
 .loop-status.s-awaiting_human { background: #fae8ff; color: #86198f; }
-.loop-meta { font-size: 11px; color: #888; }
+.loop-meta { font-size: 11px; color: var(--color-text-tertiary); }
 
 .loop-main { flex: 1; padding: 20px; overflow-y: auto; }
-.loop-empty, .loop-dim { color: #999; }
+.loop-empty, .loop-dim { color: var(--color-text-placeholder); }
 .loop-header { display: flex; justify-content: space-between; align-items: center; }
-.loop-goal { background: #f6f8fa; border-radius: 8px; padding: 10px 12px; margin: 10px 0; }
-.loop-budget { font-size: 12px; color: #666; margin-top: 4px; }
+.loop-goal { background: var(--color-bg-layout); border-radius: 8px; padding: 10px 12px; margin: 10px 0; }
+.loop-budget { font-size: 12px; color: var(--color-text-secondary); margin-top: 4px; }
 .loop-stream {
   background: #0d1117; color: #c9d1d9; border-radius: 8px; padding: 12px;
   font-family: ui-monospace, monospace; font-size: 12.5px; max-height: 300px; overflow-y: auto;
@@ -81,9 +83,9 @@
 .loop-done { color: #3fb950; font-weight: 600; }
 .loop-err { color: #f85149; }
 .loop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 12.5px; }
-.loop-table th, .loop-table td { border: 1px solid var(--border-color, #e1e4e8); padding: 5px 8px; text-align: left; }
-.loop-table th { background: #f6f8fa; }
-.loop-reason-cell { max-width: 320px; white-space: pre-wrap; color: #555; }
+.loop-table th, .loop-table td { border: 1px solid var(--color-border); padding: 5px 8px; text-align: left; }
+.loop-table th { background: var(--color-bg-layout); }
+.loop-reason-cell { max-width: 320px; white-space: pre-wrap; color: var(--color-text-secondary); }
 .loop-tableWrap { max-width: 100%; overflow-x: auto; }
 
 @media (max-width: 768px) {
@@ -120,7 +122,7 @@
     width: 100%;
     padding: 14px;
     border-right: 0;
-    border-bottom: 1px solid var(--border-color, #e1e4e8);
+    border-bottom: 1px solid var(--color-border);
     overflow: visible;
     box-sizing: border-box;
   }
@@ -166,24 +168,18 @@
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .loop-panel { background: #0d1117; color: #c9d1d9; }
-  .loop-sidebar, .loop-table th, .loop-goal { background: #161b22; }
-  .loop-sidebar textarea, .loop-sidebar input { background: #0d1117; color: #c9d1d9; border-color: #30363d; }
-}
-
 /* ── 对话内「计划条」（输入框上方，取代第 N 轮表格）───────────────────── */
 .loop-planbar {
-  border: 1px solid var(--border-color, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: var(--card-bg, #fafbfc);
+  background: var(--color-bg-layout);
   margin: 0 0 8px;
   overflow: hidden;
   font-size: 13px;
 }
 .loop-planbar-running {
-  border-color: var(--primary-color, #4f46e5);
-  box-shadow: 0 0 0 1px var(--primary-color, #4f46e5) inset;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary) inset;
 }
 .loop-planbar-head {
   display: flex; align-items: center; gap: 8px;
@@ -193,34 +189,34 @@
 .loop-planbar-title {
   flex: 1; min-width: 0; font-weight: 600;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  color: var(--text-color, #1f2328);
+  color: var(--color-text);
 }
 .loop-planbar-status {
   flex-shrink: 0; font-size: 12px; font-weight: 600;
   padding: 1px 8px; border-radius: 20px;
-  background: var(--tag-bg, #eef2ff); color: var(--primary-color, #4f46e5);
+  background: var(--color-primary-light); color: var(--color-primary);
 }
 .loop-status-completed { background: #dcfce7; color: #16a34a; }
 .loop-status-budget_exhausted { background: #fef3c7; color: #b45309; }
 .loop-status-cancelled, .loop-status-failed { background: #fee2e2; color: #dc2626; }
-.loop-planbar-caret { flex-shrink: 0; color: var(--text-muted, #8a94a6); font-size: 11px; }
+.loop-planbar-caret { flex-shrink: 0; color: var(--color-text-placeholder); font-size: 11px; }
 .loop-planbar-continue {
   flex-shrink: 0; border: none; cursor: pointer; white-space: nowrap;
   font-size: 12px; font-weight: 600; line-height: 1;
   padding: 3px 10px; border-radius: 20px;
-  background: var(--primary-color, #4f46e5); color: #fff;
+  background: var(--color-primary); color: var(--color-text-white);
 }
 .loop-planbar-continue:hover { filter: brightness(1.08); }
 .loop-planbar-close {
   flex-shrink: 0; border: none; background: transparent; cursor: pointer;
-  color: var(--text-muted, #8a94a6); font-size: 16px; line-height: 1; padding: 0 2px;
+  color: var(--color-text-placeholder); font-size: 16px; line-height: 1; padding: 0 2px;
 }
-.loop-planbar-close:hover { color: var(--text-color, #1f2328); }
+.loop-planbar-close:hover { color: var(--color-text); }
 .loop-planbar-progress {
-  height: 3px; background: var(--border-color, #e5e7eb); overflow: hidden;
+  height: 3px; background: var(--color-border); overflow: hidden;
 }
 .loop-planbar-progress-fill {
-  height: 100%; background: var(--primary-color, #4f46e5);
+  height: 100%; background: var(--color-primary);
   transition: width .4s ease;
 }
 .loop-planbar-list { list-style: none; margin: 0; padding: 6px 12px 10px; }
@@ -228,19 +224,19 @@
   display: flex; align-items: flex-start; gap: 8px; padding: 3px 0; line-height: 1.5;
 }
 .loop-planbar-mark { flex-shrink: 0; width: 14px; text-align: center; font-size: 12px; }
-.loop-planbar-desc { color: var(--text-color, #1f2328); }
+.loop-planbar-desc { color: var(--color-text); }
 .loop-item-done .loop-planbar-mark { color: #16a34a; }
-.loop-item-done .loop-planbar-desc { color: var(--text-muted, #8a94a6); text-decoration: line-through; }
-.loop-item-active .loop-planbar-mark { color: var(--primary-color, #4f46e5); }
+.loop-item-done .loop-planbar-desc { color: var(--color-text-placeholder); text-decoration: line-through; }
+.loop-item-active .loop-planbar-mark { color: var(--color-primary); }
 .loop-item-active .loop-planbar-desc { font-weight: 600; }
-.loop-item-todo .loop-planbar-mark { color: var(--text-muted, #b6bdc9); }
+.loop-item-todo .loop-planbar-mark { color: var(--color-text-placeholder); }
 .loop-planbar-reviewing {
   flex-shrink: 0; margin-left: 6px; font-size: 11px; font-weight: 600;
-  color: var(--primary-color, #4f46e5); white-space: nowrap;
+  color: var(--color-primary); white-space: nowrap;
   animation: loop-review-pulse 1.2s ease-in-out infinite;
 }
 @keyframes loop-review-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
-.loop-planbar-hint { padding: 4px 12px 10px; color: var(--text-muted, #8a94a6); }
+.loop-planbar-hint { padding: 4px 12px 10px; color: var(--color-text-placeholder); }
 .loop-status-interrupted { background: #fef3c7; color: #b45309; }
 .loop-planbar-steer {
   display: flex; align-items: center; gap: 6px; padding: 4px 12px 10px;
@@ -248,16 +244,16 @@
 .loop-planbar-steer-input {
   flex: 1; min-width: 0; font-size: 12px; line-height: 1.4;
   padding: 5px 10px; border-radius: 16px;
-  border: 1px solid var(--border-color, #e5e7eb);
-  background: var(--bg-color, #fff); color: var(--text-color, #1f2328);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-container); color: var(--color-text);
   outline: none;
 }
-.loop-planbar-steer-input:focus { border-color: var(--primary-color, #4f46e5); }
+.loop-planbar-steer-input:focus { border-color: var(--color-primary); }
 .loop-planbar-steer-send {
   flex-shrink: 0; border: none; cursor: pointer; white-space: nowrap;
   font-size: 12px; font-weight: 600; line-height: 1;
   padding: 6px 12px; border-radius: 16px;
-  background: var(--primary-color, #4f46e5); color: #fff;
+  background: var(--color-primary); color: var(--color-text-white);
 }
 .loop-planbar-steer-send:disabled { opacity: .45; cursor: default; }
 
@@ -271,9 +267,9 @@
 
   .loop-sidebar,
   .loop-main {
-    border: 1px solid rgba(15,23,42,.065);
+    border: 1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius: 20px;
-    background: rgba(255,255,255,.94);
+    background: color-mix(in srgb, var(--color-bg-container) 94%, transparent);
     box-shadow: 0 12px 34px rgba(42,61,94,.075), 0 1px 2px rgba(15,23,42,.035);
   }
 
@@ -287,7 +283,7 @@
 
   .loop-sidebar h3,
   .loop-header h2 {
-    color: #101828;
+    color: var(--color-text);
     font-weight: 700;
     letter-spacing: -.025em;
   }
@@ -296,16 +292,16 @@
   .loop-budget,
   .loop-meta,
   .loop-dim {
-    color: #667085;
+    color: var(--color-text-tertiary);
   }
 
   .loop-sidebar textarea,
   .loop-sidebar input {
     min-height: 44px;
-    border-color: rgba(15,23,42,.1);
+    border-color: color-mix(in srgb, var(--color-text) 10%, transparent);
     border-radius: 12px;
-    background: #F7F8FA;
-    color: #101828;
+    background: var(--color-bg-layout);
+    color: var(--color-text);
     font-size: 14px;
   }
 
@@ -320,14 +316,14 @@
   }
 
   .loop-btn.primary {
-    background: #126DFF;
+    background: var(--color-primary);
   }
 
   .loop-list {
     overflow: hidden;
-    border: 1px solid rgba(15,23,42,.065);
+    border: 1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius: 14px;
-    background: #F7F8FA;
+    background: var(--color-bg-layout);
   }
 
   .loop-list-item {
@@ -338,7 +334,7 @@
   }
 
   .loop-list-item + .loop-list-item {
-    border-top: 1px solid rgba(15,23,42,.075);
+    border-top: 1px solid color-mix(in srgb, var(--color-text) 7.5%, transparent);
   }
 
   .loop-list-item.active {
@@ -348,8 +344,8 @@
 
   .loop-goal {
     border-radius: 14px;
-    background: #F7F8FA;
-    color: #344054;
+    background: var(--color-bg-layout);
+    color: var(--color-text-secondary);
   }
 
   .loop-stream {

--- a/src/frontend/src/components/settings/SettingsModal.tsx
+++ b/src/frontend/src/components/settings/SettingsModal.tsx
@@ -43,6 +43,7 @@ import { ChatModesPanel } from './ChatModesPanel';
 import { FactsList } from '../memory/FactsList';
 import { OntologyManager } from '../ontology';
 import { getLang, setLang, t, type Lang } from '../../i18n';
+import type { ThemeMode } from '../../theme';
 
 interface SectionDef {
   id: string;
@@ -99,7 +100,7 @@ function getCropBounds(imageWidth: number, imageHeight: number, zoom: number) {
 }
 
 export default function SettingsPage() {
-  const { dispatchProcessVisible, setDispatchProcessVisible } = useUIStore();
+  const { dispatchProcessVisible, setDispatchProcessVisible, themeMode, setThemeMode } = useUIStore();
   const {
     memoryEnabled,
     memoryWriteEnabled,
@@ -670,6 +671,27 @@ export default function SettingsPage() {
                 { value: 'en', label: 'English' },
               ]}
               onChange={(v) => setLang(v as Lang)}
+            />
+          </div>
+
+          <div className="jx-settings-divider" />
+
+          <div className="jx-settings-row">
+            <div className="jx-settings-rowLeft">
+              <span className="jx-settings-rowLabel">{t('外观')}</span>
+              <span className="jx-settings-rowDesc">
+                {t('切换界面深浅配色，选择跟随系统时自动匹配系统外观')}
+              </span>
+            </div>
+            <Select
+              value={themeMode}
+              style={{ width: 140 }}
+              options={[
+                { value: 'system', label: t('跟随系统') },
+                { value: 'light', label: t('浅色') },
+                { value: 'dark', label: t('深色') },
+              ]}
+              onChange={(v) => setThemeMode(v as ThemeMode)}
             />
           </div>
         </div>

--- a/src/frontend/src/i18n/en/settings.ts
+++ b/src/frontend/src/i18n/en/settings.ts
@@ -789,4 +789,11 @@ export const SETTINGS_DICT: Record<string, string> = {
   '删除模式「{name}」？': 'Delete mode "{name}"?',
   '保存失败：{msg}': 'Save failed: {msg}',
   '删除失败：{msg}': 'Delete failed: {msg}',
+
+  // ── 外观 / 深色模式 ──
+  '外观': 'Appearance',
+  '切换界面深浅配色，选择跟随系统时自动匹配系统外观': 'Switch between light and dark color schemes; "Follow system" matches your OS appearance automatically',
+  '跟随系统': 'Follow system',
+  '浅色': 'Light',
+  '深色': 'Dark',
 };

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -14,6 +14,7 @@ body {
   min-height: 100vh;
 }
 
+/* 错误边界页可能在主样式加载失败时渲染，颜色用 var(fallback) 双保险 */
 .jx-appError {
   min-height: 100vh;
   display: grid;
@@ -22,22 +23,22 @@ body {
   padding: 32px;
   background:
     radial-gradient(circle at 15% 12%, rgba(69, 112, 255, 0.12), transparent 32%),
-    #f6f8fc;
-  color: #182033;
+    var(--color-bg-layout, #f6f8fc);
+  color: var(--color-text, #182033);
 }
 
 .jx-appError-card {
   width: min(460px, 100%);
   box-sizing: border-box;
   padding: 36px;
-  border: 1px solid rgba(24, 32, 51, 0.08);
+  border: 1px solid var(--color-border, rgba(24, 32, 51, 0.08));
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 18px 60px rgba(31, 47, 82, 0.12);
+  background: var(--color-bg-container, rgba(255, 255, 255, 0.96));
+  box-shadow: var(--shadow-card, 0 18px 60px rgba(31, 47, 82, 0.12));
 }
 
 .jx-appError-code {
-  color: #5570c9;
+  color: var(--color-primary, #5570c9);
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.16em;
@@ -51,7 +52,7 @@ body {
 
 .jx-appError-card p {
   margin: 0;
-  color: #5d6577;
+  color: var(--color-text-secondary, #5d6577);
   line-height: 1.7;
 }
 
@@ -60,13 +61,13 @@ body {
   padding: 10px 20px;
   border: 0;
   border-radius: 10px;
-  background: #3157d5;
-  color: #fff;
+  background: var(--color-primary, #3157d5);
+  color: var(--color-text-white, #fff);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
 }
 
 .jx-appError-card button:hover {
-  background: #2748b7;
+  background: var(--color-primary-hover, #2748b7);
 }

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,16 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { ConfigProvider } from 'antd'
-import zhCN from 'antd/locale/zh_CN'
-import enUS from 'antd/locale/en_US'
-import { getLang } from './i18n'
 import 'antd/dist/reset.css'
 import './index.css'
 import './styles'
 import App from './App.tsx'
 import ApiDocApp from './ApiDocApp.tsx'
 import SharePreviewApp from './SharePreviewApp.tsx'
-import { appTheme } from './appTheme'
+import { AppThemeProvider } from './AppThemeProvider'
 import { installPreloadErrorReload } from './preloadReload'
 
 // 社区版入口：只挂主应用 / API 文档 / 分享预览。
@@ -23,8 +19,9 @@ const isSharePreview = new URLSearchParams(window.location.search).has('share')
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ConfigProvider theme={appTheme} locale={getLang() === 'en' ? enUS : zhCN}>
+    {/* 分享预览是对外页面，锁定浅色（与 index.html 防闪烁脚本的 share 判断保持一致） */}
+    <AppThemeProvider forceLight={isSharePreview}>
       {isSharePreview ? <SharePreviewApp /> : isApiDocs ? <ApiDocApp /> : <App />}
-    </ConfigProvider>
+    </AppThemeProvider>
   </StrictMode>,
 )

--- a/src/frontend/src/stores/uiStore.ts
+++ b/src/frontend/src/stores/uiStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import type { UpdateEntry, UpdateCategory, FileConfirmInfo, DesignPickInfo } from '../types';
 import type { SearchResultItem } from '../api';
 import { IS_COMMUNITY_EDITION_BUILD } from '../edition';
+import { loadThemeMode, saveThemeMode, type ThemeMode } from '../theme';
 
 export type HistoryTimeFilter = 'all' | 'today' | '7d' | '30d';
 export type UpdateFilter = '全部' | UpdateCategory;
@@ -52,6 +53,11 @@ interface UIState {
   promptHubOpen: boolean;
   dispatchProcessVisible: boolean;
 
+  // ── 主题（深色模式）──
+  // 只存用户档位（system/light/dark）；实际深浅由 AppThemeProvider 结合系统外观解析，
+  // DOM 落地与「跟随系统」监听也在那里，这里只管状态与持久化。
+  themeMode: ThemeMode;
+
   // ── §13 My Space write confirmation ──
   // Stores one **FIFO queue** per chatId: a single round of parallel tool calls can concurrently register N distinct
   // pending confirmations, which must all be queued and popped one by one — click one, the next appears — never overwritten
@@ -87,6 +93,8 @@ interface UIState {
 
   setPromptHubOpen: (v: boolean) => void;
   setDispatchProcessVisible: (v: boolean) => void;
+
+  setThemeMode: (mode: ThemeMode) => void;
 
   // Enqueue an item (deduped by confirmId; ignored if already in the queue).
   enqueuePendingConfirm: (chatId: string, info: FileConfirmInfo) => void;
@@ -126,6 +134,8 @@ export const useUIStore = create<UIState>((set) => ({
 
   promptHubOpen: false,
   dispatchProcessVisible: loadDispatchProcessVisible(),
+
+  themeMode: loadThemeMode(),
 
   pendingConfirm: {},
   pendingDesignPick: {},
@@ -236,5 +246,10 @@ export const useUIStore = create<UIState>((set) => ({
       }
     }
     set({ dispatchProcessVisible: v });
+  },
+
+  setThemeMode: (mode) => {
+    saveThemeMode(mode);
+    set({ themeMode: mode });
   },
 }));

--- a/src/frontend/src/styles/admin.css
+++ b/src/frontend/src/styles/admin.css
@@ -7,8 +7,8 @@
 
 /* 校验失败：红色系一次性高亮（卡片背景为白，结束色回到白） */
 @keyframes admin-flash-error {
-  0%   { background-color: #FFF1F0; }
-  100% { background-color: #fff; }
+  0%   { background-color: var(--color-error-light); }
+  100% { background-color: var(--color-bg-container); }
 }
 
 /* 计数徽标 0→n 的一次性脉冲 */
@@ -27,7 +27,7 @@
 
 /* 上移/下移落点闪烁，600ms 后由组件清除类 */
 .row-just-moved > td {
-  --flash-color: #E6F0FF;
+  --flash-color: var(--color-primary-light);
   animation: jx-kf-flash 0.6s ease-out;
 }
 
@@ -42,7 +42,7 @@
 
 /* 非表格容器（抽屉里的片段卡等）的同语义落点闪烁 */
 .admin-flash-once {
-  --flash-color: #E6F0FF;
+  --flash-color: var(--color-primary-light);
   animation: jx-kf-flash 0.6s ease-out;
 }
 
@@ -97,9 +97,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #f0f0f0;
+  border: 1px solid var(--color-border);
   border-radius: 10px;
-  background: #fff;
+  background: var(--color-bg-container);
   transition:
     border-color 0.15s var(--motion-ease-standard),
     transform 0.12s var(--motion-ease-standard);
@@ -110,8 +110,8 @@
 }
 .admin-icon-cell--active,
 .admin-icon-cell--active:hover {
-  border-color: #126DFF;
-  box-shadow: inset 0 0 0 1px #126DFF;
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
 }
 
 /* ── 长任务日志：run 进行中底部呼吸光标 ─────────────────────── */
@@ -122,7 +122,7 @@
   height: 14px;
   margin-left: 2px;
   vertical-align: -2px;
-  background: #dcdcdc;
+  background: var(--color-fill);
   animation: admin-caret 1s ease-in-out infinite;
 }
 
@@ -155,4 +155,10 @@
 .jx-modal-scrollhide::-webkit-scrollbar {
   width: 0;
   height: 0;
+}
+
+/* ── 深色模式覆盖 ── */
+/* IconPicker 图标格 hover 边（基础值 #bfbfbf 非令牌）在暗底上过亮，换语义色 */
+:root[data-theme='dark'] .admin-icon-cell:hover {
+  border-color: var(--color-fill-deep);
 }

--- a/src/frontend/src/styles/apidoc.css
+++ b/src/frontend/src/styles/apidoc.css
@@ -23,7 +23,7 @@
 }
 .jx-apidoc-groupItem.active,
 .jx-apidoc-groupItem.active:hover {
-  background: #E6F0FF;
+  background: var(--color-primary-light);
   border-left-color: var(--color-primary);
   color: var(--color-primary);
 }
@@ -31,7 +31,7 @@
 /* 中栏：接口条目 */
 .jx-apidoc-epItem {
   padding: 10px 12px;
-  border-bottom: 1px solid #F0F0F0;
+  border-bottom: 1px solid var(--color-border);
 }
 .jx-apidoc-epItem.active,
 .jx-apidoc-epItem.active:hover {

--- a/src/frontend/src/styles/automation-timeline.css
+++ b/src/frontend/src/styles/automation-timeline.css
@@ -13,7 +13,7 @@
   position: relative;
   overflow: hidden;
   color: var(--color-text);
-  background: #ffffff;
+  background: var(--color-bg-container);
   border-left: 1px solid var(--color-border);
   /* 入场/退场由 App.tsx 的 AnimatePresence + motion.div 接管，CSS 不再做 slideIn（避免双播） */
   font-family: var(--font-family);
@@ -30,7 +30,7 @@
   padding: 0 20px;
   height: 56px;
   border-bottom: 1px solid var(--color-border);
-  background: #ffffff;
+  background: var(--color-bg-container);
 }
 
 .jx-runTimeline-crumb {
@@ -296,7 +296,7 @@
   border-radius: var(--radius-md);
   border: 1px dashed var(--color-border);
   color: var(--color-text-tertiary);
-  background: #ffffff;
+  background: var(--color-bg-container);
 }
 
 .jx-runTimeline-emptyTitle {
@@ -397,7 +397,7 @@
   gap: 8px;
   padding: 12px;
   border-radius: var(--radius-sm);
-  background: #ffffff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
@@ -476,7 +476,7 @@
   justify-content: center;
   padding: 1px 6px;
   border-radius: var(--radius-xs);
-  background: #ffffff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   color: var(--color-text-tertiary);
   font-size: var(--font-size-xs);

--- a/src/frontend/src/styles/automation.css
+++ b/src/frontend/src/styles/automation.css
@@ -20,7 +20,7 @@
 .jx-automation-sectionTitle {
   font-size: 13px;
   font-weight: 500;
-  color: var(--color-text-secondary, #666);
+  color: var(--color-text-secondary, var(--color-text-secondary));
   margin-bottom: 8px;
   padding-left: 4px;
 }
@@ -33,8 +33,8 @@
   gap: 12px;
   padding: 14px 16px;
   border-radius: 10px;
-  background: var(--color-bg-card, #fff);
-  border: 1px solid var(--color-border-light, #f0f0f0);
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
   margin-bottom: 8px;
   cursor: pointer;
   transition: box-shadow 0.2s, border-color 0.2s;
@@ -60,7 +60,7 @@
 .jx-automation-card-name {
   font-size: 14px;
   font-weight: 500;
-  color: var(--color-text-primary, #1a1a1a);
+  color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -72,19 +72,19 @@
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: var(--color-text-tertiary, #999);
+  color: var(--color-text-tertiary, var(--color-text-placeholder));
   flex-wrap: wrap;
 }
 
 .jx-automation-card-sep {
   width: 1px;
   height: 12px;
-  background: var(--color-border-light, #e5e5e5);
+  background: var(--color-border);
   flex-shrink: 0;
 }
 
 .jx-automation-card-type {
-  background: var(--color-fill-light, #f5f5f5);
+  background: var(--color-fill-light, var(--color-bg-gray));
   padding: 1px 6px;
   border-radius: 4px;
   font-size: 11px;
@@ -106,8 +106,8 @@
 
 .jx-automation-cronPreview {
   font-size: 12px;
-  color: var(--color-text-secondary, #666);
-  background: var(--color-fill-light, #f5f5f5);
+  color: var(--color-text-secondary, var(--color-text-secondary));
+  background: var(--color-fill-light, var(--color-bg-gray));
   padding: 6px 12px;
   border-radius: 6px;
   margin-top: 4px;
@@ -138,11 +138,11 @@
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   font-size: 14px;
   transition: color .12s;
 }
-.jx-automation-detail-backBtn:hover { color: #1a1a1a; }
+.jx-automation-detail-backBtn:hover { color: var(--color-text); }
 
 .jx-automation-detail-content {
   flex: 1;
@@ -162,13 +162,13 @@
   padding: 10px 14px;
   margin-bottom: 16px;
   border-radius: 10px;
-  background: rgba(235, 242, 255, 0.96);
-  border: 1px solid #D7E3F4;
+  background: color-mix(in srgb, var(--color-primary-light) 96%, transparent);
+  border: 1px solid var(--color-border);
   backdrop-filter: blur(8px);
 }
 .jx-automation-detail-editBar-text {
   font-size: 13px;
-  color: #3F536E;
+  color: var(--color-text-secondary);
   font-weight: 500;
 }
 .jx-automation-detail-editBar-actions {
@@ -187,13 +187,13 @@
   width: 44px;
   height: 44px;
   border-radius: 8px;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  background: #FFFFFF;
+  background: var(--color-bg-container);
 }
 .jx-automation-detail-iconWrap img {
   width: 28px;
@@ -203,7 +203,7 @@
 .jx-automation-detail-name {
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   max-width: 480px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -215,24 +215,24 @@
   padding: 1px 6px;
   border-radius: 4px;
   flex-shrink: 0;
-  color: #808080;
-  background: #F5F6F7;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-gray);
   line-height: 1.5;
   transition: color .25s var(--motion-ease-standard), background-color .25s var(--motion-ease-standard);
 }
 .jx-automation-detail-badge.is-active {
-  color: #02B589;
-  background: #E0F7EF;
+  color: var(--color-success);
+  background: var(--color-success-bg);
 }
 .jx-automation-detail-badge.is-paused {
-  color: #F8AB42;
-  background: #FFF3E0;
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
 }
 .jx-automation-detail-badge.is-disabled,
 .jx-automation-detail-badge.is-completed,
 .jx-automation-detail-badge.is-expired {
-  color: #808080;
-  background: #F5F6F7;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-gray);
 }
 
 .jx-automation-detail-runSwitch {
@@ -244,7 +244,7 @@
 }
 .jx-automation-detail-runSwitch-label {
   font-size: 13px;
-  color: #4D4D4D;
+  color: var(--color-text-secondary);
 }
 
 /* ── Meta row ────────────────────────────────────────── */
@@ -255,11 +255,11 @@
   margin-top: 10px;
   margin-bottom: 18px;
   font-size: 12px;
-  color: #808080;
+  color: var(--color-text-tertiary);
   flex-wrap: wrap;
 }
 .jx-automation-detail-metaRow-sep {
-  color: #D8DBE2;
+  color: var(--color-fill);
 }
 
 /* ── Error alert ────────────────────────────────────────── */
@@ -270,7 +270,7 @@
 /* ── Divider ────────────────────────────────────────── */
 .jx-automation-detail-divider {
   border: none;
-  border-top: 1px solid #E3E6EA;
+  border-top: 1px solid var(--color-border);
   margin: 0 0 20px;
 }
 
@@ -283,9 +283,9 @@
 }
 
 .jx-automation-detail-section {
-  border: 1px solid #E5EAF0;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #FFFFFF;
+  background: var(--color-bg-container);
   padding: 18px 20px 20px;
 }
 
@@ -301,7 +301,7 @@
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: #1F2937;
+  color: var(--color-text);
 }
 
 .jx-automation-detail-grid {
@@ -314,8 +314,8 @@
   min-width: 0;
   padding: 14px 16px;
   border-radius: 10px;
-  background: #FAFBFC;
-  border: 1px solid #ECEFF3;
+  background: var(--color-bg-layout);
+  border: 1px solid var(--color-border);
 }
 
 .jx-automation-detail-field.is-multiline {
@@ -327,19 +327,19 @@
   font-size: 12px;
   font-weight: 600;
   letter-spacing: .2px;
-  color: #7B8794;
+  color: var(--color-text-tertiary);
 }
 
 .jx-automation-detail-fieldValue {
   font-size: 14px;
   line-height: 1.75;
-  color: #374151;
+  color: var(--color-text);
   word-break: break-word;
   white-space: pre-wrap;
 }
 
 .jx-automation-detail-fieldValue.is-muted {
-  color: #9CA3AF;
+  color: var(--color-text-placeholder);
 }
 
 /* ── Run list ────────────────────────────────────────── */
@@ -355,10 +355,10 @@
   padding: 10px 4px;
   border-bottom: 1px solid #F1F3F6;
   font-size: 13px;
-  color: #374151;
+  color: var(--color-text);
 }
 .jx-automation-detail-runRow:last-child { border-bottom: none; }
-.jx-automation-detail-runRow:hover { background: #F7F9FC; }
+.jx-automation-detail-runRow:hover { background: var(--color-bg-layout); }
 
 .jx-automation-runDot {
   width: 8px;
@@ -369,22 +369,22 @@
 /* 运行中扩散涟漪：组件层挂 .jx-anim-ripple（motion.css 原语，compositor-only），
    这里只调色与扩散倍数（8px 圆点 ×2.5 ≈ 原 6px box-shadow 扩散幅度） */
 .jx-automation-runDot.is-running {
-  background: #126DFF;
+  background: var(--color-primary);
   --ripple-color: var(--color-primary);
   --ripple-scale: 2.5;
 }
-.jx-automation-runDot.is-success { background: #02B589; }
-.jx-automation-runDot.is-failed  { background: #FC5D5D; }
+.jx-automation-runDot.is-success { background: var(--color-success); }
+.jx-automation-runDot.is-failed  { background: var(--color-error); }
 
 .jx-automation-detail-runRow-time {
   flex-shrink: 0;
-  color: #4D4D4D;
+  color: var(--color-text-secondary);
   width: 150px;
 }
 
 .jx-automation-detail-runRow-duration {
   flex-shrink: 0;
-  color: #808080;
+  color: var(--color-text-tertiary);
   width: 60px;
 }
 
@@ -394,12 +394,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: #4D4D4D;
+  color: var(--color-text-secondary);
 }
 
 .jx-automation-detail-runRow-error {
   flex-basis: 100%;
-  color: #FC5D5D;
+  color: var(--color-error);
   font-size: 12px;
   padding-left: 20px;
   line-height: 1.6;
@@ -408,7 +408,7 @@
 
 .jx-automation-detail-runEmpty {
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--color-text-placeholder);
   padding: 20px 4px;
   text-align: center;
 }
@@ -432,7 +432,7 @@
   padding: 12px;
   border: 1px solid rgba(229, 234, 240, 0.96);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.92);
+  background: color-mix(in srgb, var(--color-bg-container) 92%, transparent);
   backdrop-filter: blur(12px);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
   pointer-events: auto;
@@ -456,8 +456,8 @@
   flex-direction: column;
   gap: 10px;
   padding: 12px 14px;
-  background: #FAFBFC;
-  border: 1px solid #ECEFF3;
+  background: var(--color-bg-layout);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
 }
 
@@ -469,16 +469,16 @@
 
 .jx-schedule-selector-label {
   font-size: 13px;
-  color: #4D4D4D;
+  color: var(--color-text-secondary);
   min-width: 64px;
   flex-shrink: 0;
 }
 
 .jx-schedule-selector-preview {
   font-size: 12px;
-  color: #3F536E;
-  background: #F3F7FC;
-  border: 1px solid #D7E3F4;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-layout);
+  border: 1px solid var(--color-border);
   padding: 6px 10px;
   border-radius: 6px;
 }
@@ -499,13 +499,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--color-text, #262626);
+  color: var(--color-text, var(--color-text));
 }
 
 .jx-automation-planOption-steps {
   flex-shrink: 0;
   font-size: 12px;
-  color: var(--color-text-tertiary, #808080);
+  color: var(--color-text-tertiary, var(--color-text-tertiary));
   font-variant-numeric: tabular-nums;
 }
 
@@ -520,10 +520,10 @@
     rgba(18, 109, 255, 0.045) 0%,
     rgba(18, 109, 255, 0.00) 72%
   );
-  border: 1px solid var(--color-border, #E3E6EA);
+  border: 1px solid var(--color-border);
   border-radius: 14px;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    inset 0 1px 0 color-mix(in srgb, var(--color-bg-container) 90%, transparent),
     0 1px 2px rgba(15, 23, 42, 0.04);
   --fadeInUp-distance: 6px;
   animation: jx-kf-fadeInUp 280ms var(--motion-ease-brand-out) backwards;
@@ -536,7 +536,7 @@
   gap: 10px;
   padding: 32px 16px;
   font-size: 13px;
-  color: var(--color-text-tertiary, #808080);
+  color: var(--color-text-tertiary, var(--color-text-tertiary));
 }
 
 .jx-automation-planFrame-label {
@@ -544,13 +544,13 @@
   top: -9px;
   left: 18px;
   padding: 2px 10px;
-  background: #fff;
-  color: var(--color-primary, #126DFF);
+  background: var(--color-bg-container);
+  color: var(--color-primary, var(--color-primary));
   font-size: 10.5px;
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  border: 1px solid var(--color-primary-light, #EBF2FF);
+  border: 1px solid var(--color-primary-light, var(--color-primary-light));
   border-radius: 999px;
   line-height: 1.6;
 }
@@ -580,7 +580,7 @@
   width: 4px;
 }
 .jx-automation-planFrame-scroll::-webkit-scrollbar-thumb {
-  background: var(--color-fill, #D8DBE2);
+  background: var(--color-fill, var(--color-fill));
   border-radius: 2px;
 }
 .jx-automation-planFrame-scroll::-webkit-scrollbar-thumb:hover {
@@ -592,8 +592,8 @@
   align-items: center;
   gap: 8px;
   font-size: 12.5px;
-  color: var(--color-primary, #126DFF);
-  background: var(--color-primary-light, #EBF2FF);
+  color: var(--color-primary, var(--color-primary));
+  background: var(--color-primary-light, var(--color-primary-light));
   padding: 6px 12px;
   border-radius: 999px;
   line-height: 1.6;
@@ -617,7 +617,7 @@
 /* ── Automation Skeleton ─────────────────────────────────── */
 .jx-automation-card--skeleton {
   pointer-events: none;
-  border-color: var(--color-border-light, #f0f0f0) !important;
+  border-color: var(--color-border) !important;
   box-shadow: none !important;
 }
 .jx-automation-skSectionTitle {
@@ -731,7 +731,7 @@
   height: 28px;
   border-radius: 50%;
   border: 1px solid var(--color-border);
-  background: #fff;
+  background: var(--color-bg-container);
   color: var(--color-text-tertiary);
   font-size: 12px;
   display: inline-flex;
@@ -775,7 +775,7 @@
   padding: 18px 20px;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  background: #fff;
+  background: var(--color-bg-container);
   cursor: pointer;
   /* 位移/时长交给 motion.css 的 .jx-card-lift 原语（含 reduced-motion 降级），这里只管配色 */
 }
@@ -896,7 +896,7 @@
   padding: 14px 16px;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  background: #fff;
+  background: var(--color-bg-container);
   margin-bottom: 8px;
   cursor: pointer;
 }

--- a/src/frontend/src/styles/canvas.css
+++ b/src/frontend/src/styles/canvas.css
@@ -8,8 +8,8 @@
 
 .jx-canvasPanelSlot {
   min-width: 0;
-  border-left: 1px solid rgba(15, 23, 42, .08);
-  background: #fff;
+  border-left: 1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
+  background: var(--color-bg-container);
 }
 
 /* 全屏：面板脱离文档流盖住整个主区，而不是把主区挤成 0 宽。
@@ -67,8 +67,8 @@
   gap: 4px;
   flex-shrink: 0;
   overflow: hidden;
-  border-bottom: 1px solid rgba(15, 23, 42, .08);
-  background: rgba(255, 255, 255, .98);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
+  background: color-mix(in srgb, var(--color-bg-container) 98%, transparent);
 }
 
 /* 页签条：多页签时横向滚动，滚动条隐藏（活动页签由 JS 滚进可视区） */
@@ -357,7 +357,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #fff;
+  background: var(--color-bg-container);
   border-left: 0;
   box-shadow: -4px 0 24px rgba(18, 109, 255, .05);
   overflow: hidden;
@@ -441,8 +441,8 @@
   gap: 12px;
   padding: 6px 14px;
   flex-shrink: 0;
-  border-bottom: 1px solid rgba(15, 23, 42, .06);
-  background: rgba(255, 255, 255, .92);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
+  background: color-mix(in srgb, var(--color-bg-container) 92%, transparent);
   backdrop-filter: blur(10px);
 }
 
@@ -517,7 +517,7 @@
   flex: 1;
   min-height: 0;
   overflow: auto;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 
@@ -610,7 +610,7 @@
 /* ══ DOCX Renderer ══ */
 .jx-canvas-docx {
   padding: 0;
-  background: #fff;
+  background: var(--color-bg-container);
   min-height: 100%;
 }
 .jx-canvas-docx .docx-wrapper,
@@ -633,7 +633,7 @@
   border-radius: 0;
   box-shadow: none !important;
   margin-bottom: 0 !important;
-  color: rgba(15, 23, 42, .88);
+  color: color-mix(in srgb, var(--color-text) 88%, transparent);
   font-family: var(--font-family) !important;
   line-height: 1.84;
   overflow: hidden;
@@ -650,7 +650,7 @@
 .jx-canvas-docx section.jx-canvas-docx-wrapper p,
 .jx-canvas-docx section.jx-canvas-docx-wrapper li,
 .jx-canvas-docx section.jx-canvas-docx-wrapper td {
-  color: rgba(30, 41, 59, .86);
+  color: color-mix(in srgb, var(--color-text-secondary) 86%, transparent);
   font-size: 15.5px !important;
   font-weight: 400 !important;
   line-height: 1.84 !important;
@@ -678,7 +678,7 @@
 .jx-canvas-docx section.docx p[style*="font-size:24"],
 .jx-canvas-docx section.docx p[style*="font-size: 22"],
 .jx-canvas-docx section.docx p[style*="font-size:22"] {
-  color: rgba(15, 23, 42, .96) !important;
+  color: color-mix(in srgb, var(--color-text) 96%, transparent) !important;
   font-weight: 600 !important;
   line-height: 1.5 !important;
   letter-spacing: 0 !important;
@@ -710,7 +710,7 @@
 .jx-canvas-docx section.jx-canvas-docx-wrapper p.jx-docx-subtitle {
   margin: 26px 0 10px !important;
   font-size: 18px !important;
-  color: rgba(15, 23, 42, .92) !important;
+  color: color-mix(in srgb, var(--color-text) 92%, transparent) !important;
   font-weight: 600 !important;
   line-height: 1.5 !important;
 }
@@ -743,7 +743,7 @@
 .jx-canvas-docx section.jx-canvas-docx-wrapper strong,
 .jx-canvas-docx section.jx-canvas-docx-wrapper b {
   font-weight: 600 !important;
-  color: rgba(15, 23, 42, .94) !important;
+  color: color-mix(in srgb, var(--color-text) 94%, transparent) !important;
 }
 
 .jx-canvas-docx section.docx p.jx-docx-meta,
@@ -754,7 +754,7 @@
 .jx-canvas-docx section.jx-canvas-docx-wrapper p.jx-docx-meta strong {
   font-size: 15px !important;
   line-height: 1.72 !important;
-  color: rgba(51, 65, 85, .82) !important;
+  color: color-mix(in srgb, var(--color-text-secondary) 82%, transparent) !important;
 }
 
 .jx-canvas-docx section.docx p.jx-docx-meta,
@@ -791,7 +791,7 @@
 .jx-canvas-docx section.docx th,
 .jx-canvas-docx section.jx-canvas-docx-wrapper th {
   background: rgba(248, 250, 252, .9) !important;
-  color: rgba(15, 23, 42, .9) !important;
+  color: rgba(15, 23, 42, .9) !important; /* 纸面浅底固定，文字不随主题翻转 */
   font-weight: 600 !important;
 }
 
@@ -799,8 +799,8 @@
 .jx-canvas-docx section.jx-canvas-docx-wrapper blockquote {
   margin: 16px 0 !important;
   padding: 8px 0 8px 14px !important;
-  border-left: 2px solid rgba(148, 163, 184, .45) !important;
-  color: rgba(71, 85, 105, .92) !important;
+  border-left: 2px solid color-mix(in srgb, var(--color-text-placeholder) 45%, transparent) !important;
+  color: color-mix(in srgb, var(--color-text-secondary) 92%, transparent) !important;
 }
 
 .jx-canvas-docx section.docx p:last-child,
@@ -827,7 +827,7 @@
   display: flex;
   gap: 0;
   padding: 0 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
   overflow-x: auto;
@@ -865,7 +865,7 @@
   border-collapse: collapse;
   font-size: 12px;
   font-family: var(--font-family-number);
-  background: #fff;
+  background: var(--color-bg-container);
   border-radius: var(--radius-xs);
   overflow: hidden;
   width: max-content;
@@ -920,7 +920,7 @@
 .jx-canvas-text {
   padding: 16px;
   min-height: 100%;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 .jx-canvas-text-pre {
   margin: 0;
@@ -937,7 +937,7 @@
 .jx-canvas-markdown {
   min-height: 100%;
   padding: 28px clamp(24px, 5vw, 56px) 48px;
-  background: #fff;
+  background: var(--color-bg-container);
   overflow-wrap: anywhere;
 }
 
@@ -947,7 +947,7 @@
   width: 100%;
   height: 100%;
   border: none;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 /* ══ Artifact card preview button (in MessageBubble) ══ */
@@ -959,18 +959,18 @@
   padding: 0 14px;
   border: 1px solid rgba(203,213,225,.9);
   border-radius: 10px;
-  background: #fff;
+  background: var(--color-bg-container);
   font-size: 14px;
   font-weight: 500;
-  color: #475569;
+  color: var(--color-text-secondary);
   cursor: pointer;
   transition: background .15s, border-color .15s, color .15s;
   white-space: nowrap;
 }
 .jx-dlCard-previewBtn:hover {
-  background: #f8fafc;
-  border-color: rgba(148,163,184,.95);
-  color: #0f172a;
+  background: var(--color-bg-layout);
+  border-color: color-mix(in srgb, var(--color-text-placeholder) 95%, transparent);
+  color: var(--color-text);
 }
 
 /* ══ Univer Spreadsheet Container ══ */

--- a/src/frontend/src/styles/catalog.css
+++ b/src/frontend/src/styles/catalog.css
@@ -27,14 +27,14 @@
   padding:6px 22px;
   font-size:13px;
   font-weight:600;
-  color:rgba(15,23,42,.60);
+  color:color-mix(in srgb, var(--color-text) 60%, transparent);
   cursor:pointer;
   transition:all .18s ease;
 }
-.jx-docsNewTab:hover{ color:rgba(15,23,42,.80); }
+.jx-docsNewTab:hover{ color:color-mix(in srgb, var(--color-text) 80%, transparent); }
 .jx-docsNewTab.active{
-  background:#fff;
-  color:rgba(15,23,42,.90);
+  background:var(--color-bg-container);
+  color:color-mix(in srgb, var(--color-text) 90%, transparent);
   box-shadow:0 1px 6px rgba(15,23,42,.10);
 }
 
@@ -42,7 +42,7 @@
 .jx-docsHeader {
   padding: 28px 20px 18px;
   flex-shrink: 0;
-  border-bottom: 1px solid rgba(15,23,42,.06);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   margin-bottom: 0;
 }
 
@@ -66,19 +66,19 @@
 .jx-updateFilterBtn{
   appearance:none;
   position:relative;
-  border:1px solid rgba(15,23,42,.14);
-  background:#fff;
+  border:1px solid color-mix(in srgb, var(--color-text) 14%, transparent);
+  background:var(--color-bg-container);
   border-radius:999px;
   padding:4px 14px;
   font-size:12px;
   font-weight:500;
-  color:rgba(15,23,42,.62);
+  color:color-mix(in srgb, var(--color-text) 62%, transparent);
   cursor:pointer;
   transition:all .16s ease;
 }
 .jx-updateFilterBtn:hover{
-  border-color:rgba(15,23,42,.28);
-  color:rgba(15,23,42,.80);
+  border-color:color-mix(in srgb, var(--color-text) 28%, transparent);
+  color:color-mix(in srgb, var(--color-text) 80%, transparent);
 }
 /* active 底色由 layoutId="updateFilterPill" 的滑动背景块提供（DocsPanel） */
 .jx-updateFilterBtn.active{
@@ -119,12 +119,12 @@
 .jx-tlDateMain{
   font-size:15px;
   font-weight:700;
-  color:rgba(15,23,42,.80);
+  color:color-mix(in srgb, var(--color-text) 80%, transparent);
   letter-spacing:.5px;
 }
 .jx-tlDateYear{
   font-size:11px;
-  color:rgba(15,23,42,.44);
+  color:color-mix(in srgb, var(--color-text) 44%, transparent);
 }
 .jx-tlTrack{
   display:flex;
@@ -136,7 +136,7 @@
   width:10px;
   height:10px;
   border-radius:50%;
-  background:#fff;
+  background:var(--color-bg-container);
   border:2px solid rgba(18,109,255,.55);
   flex-shrink:0;
   position:relative;
@@ -162,7 +162,7 @@
 .jx-tlTitle{
   font-size:14px;
   font-weight:700;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   flex:1;
   min-width:0;
   line-height:1.4;
@@ -178,11 +178,11 @@
 }
 .jx-cat-模型迭代,.jx-cat-信息处理,.jx-cat-应用上新,.jx-cat-体验优化{
   background:rgba(15,23,42,.07);
-  color:rgba(15,23,42,.55);
+  color:color-mix(in srgb, var(--color-text) 55%, transparent);
 }
 .jx-tlDesc{
   font-size:13px;
-  color:rgba(15,23,42,.66);
+  color:color-mix(in srgb, var(--color-text) 66%, transparent);
   line-height:1.6;
   margin:0;
 }
@@ -329,8 +329,8 @@
   display:grid;
   grid-template-columns:28px 1fr;
   gap:10px;
-  background:#fff;
-  border:1px solid rgba(15,23,42,.08);
+  background:var(--color-bg-container);
+  border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   border-radius:14px;
   padding:16px 18px;
   box-shadow:0 2px 8px rgba(15,23,42,.04);
@@ -350,12 +350,12 @@
 .jx-capTitle{
   font-size:14px;
   font-weight:700;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   line-height:1.35;
 }
 .jx-capDesc{
   font-size:13px;
-  color:rgba(15,23,42,.66);
+  color:color-mix(in srgb, var(--color-text) 66%, transparent);
   line-height:1.6;
   margin:0;
 }
@@ -368,7 +368,7 @@
 }
 .jx-capBullets li{
   font-size:12px;
-  color:rgba(15,23,42,.60);
+  color:color-mix(in srgb, var(--color-text) 60%, transparent);
   line-height:1.5;
 }
 
@@ -396,14 +396,14 @@
   gap:14px;
   align-items:flex-start;
   padding:20px;
-  border:1px solid var(--color-border, #E3E6EA);
+  border:1px solid var(--color-border, var(--color-border));
   border-radius:12px;
-  background:#fff;
+  background:var(--color-bg-container);
   cursor:pointer;
   transition:border-color .18s, box-shadow .18s;
 }
 .jx-appCenterCard:hover{
-  border-color:var(--color-primary, #126DFF);
+  border-color:var(--color-primary, var(--color-primary));
   box-shadow:0 2px 12px rgba(18,109,255,.10);
 }
 .jx-appCenterCard--disabled{
@@ -424,11 +424,11 @@
 .jx-appCenterCardTitle{
   font-size:15px;
   font-weight:600;
-  color:var(--color-text, #262626);
+  color:var(--color-text, var(--color-text));
 }
 .jx-appCenterCardDesc{
   font-size:13px;
-  color:var(--color-text-tertiary, #808080);
+  color:var(--color-text-tertiary, var(--color-text-tertiary));
   line-height:1.5;
 }
 
@@ -448,7 +448,7 @@
   font-size:18px;
   line-height:1.6;
   font-weight:500;
-  color:rgba(15,23,42,.56);
+  color:color-mix(in srgb, var(--color-text) 56%, transparent);
   letter-spacing:.08em;
 }
 
@@ -456,7 +456,7 @@
   margin:0;
   font-size:13px;
   line-height:1.9;
-  color:rgba(15,23,42,.38);
+  color:color-mix(in srgb, var(--color-text) 38%, transparent);
 }
 
 @keyframes jx-appCenterFadeIn{
@@ -515,7 +515,7 @@
 .jx-skillMetaValue{
   font-size:14px;
   font-weight:600;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   font-family:'Consolas', 'Monaco', 'Courier New', monospace;
   background:rgba(18,109,255,.10);
   padding:5px 10px;
@@ -527,9 +527,9 @@
 .jx-skillMetaDesc{
   font-size:14px;
   line-height:1.78;
-  color:rgba(31,35,40,.85);
+  color:color-mix(in srgb, var(--color-text) 85%, transparent);
   padding:14px 16px;
-  background:rgba(255,255,255,.6);
+  background:color-mix(in srgb, var(--color-bg-container) 60%, transparent);
   border-radius:8px;
   border-left:3px solid var(--color-primary);
   margin-bottom:14px;
@@ -579,7 +579,7 @@
   display:inline-flex;
   align-items:center;
   padding:6px 10px;
-  background:rgba(255,255,255,.8);
+  background:color-mix(in srgb, var(--color-bg-container) 80%, transparent);
   border:1px solid rgba(18,109,255,.20);
   border-radius:8px;
   font-size:13px;
@@ -591,7 +591,7 @@
 }
 
 .jx-skillTool:hover{
-  background:#fff;
+  background:var(--color-bg-container);
   border-color:var(--color-primary);
   box-shadow:0 3px 8px rgba(18,109,255,.12);
   transform:translateY(-1px);
@@ -608,7 +608,7 @@
 }
 
 .jx-manageDetailHeader{
-  background:linear-gradient(180deg, #ffffff 0%, rgba(18, 109, 255, 0.03) 100%);
+  background:linear-gradient(180deg, var(--color-bg-container) 0%, rgba(18, 109, 255, 0.03) 100%);
   padding:18px 20px;
   align-items:flex-start;
 }
@@ -617,7 +617,7 @@
   font-size:20px;
   font-weight:1000;
   line-height:1.35;
-  color:rgba(15,23,42,.95);
+  color:color-mix(in srgb, var(--color-text) 95%, transparent);
 }
 
 .jx-manageDetailMetaText.ant-typography{
@@ -626,7 +626,7 @@
   max-width:80ch;
   font-size:14px;
   line-height:1.78;
-  color:rgba(31,35,40,.68);
+  color:color-mix(in srgb, var(--color-text) 68%, transparent);
 }
 
 .jx-manageDetailStatusTag{
@@ -641,7 +641,7 @@
   padding:22px 24px;
   font-size:14px;
   line-height:1.78;
-  color:rgba(31,35,40,.90);
+  color:color-mix(in srgb, var(--color-text) 90%, transparent);
   display:flex;
   flex-direction:column;
   gap:16px;
@@ -656,7 +656,7 @@
 .jx-manageDetailBody .jx-md{
   font-size:14px;
   line-height:1.78;
-  color:rgba(31,35,40,.90);
+  color:color-mix(in srgb, var(--color-text) 90%, transparent);
 }
 .jx-manageDetailBody .jx-md h1{font-size:22px}
 .jx-manageDetailBody .jx-md h2{font-size:18px}
@@ -683,7 +683,7 @@
 .jx-manageDetailEmpty.ant-typography{
   font-size:14px;
   line-height:1.8;
-  color:rgba(31,35,40,.60);
+  color:color-mix(in srgb, var(--color-text) 60%, transparent);
 }
 .jx-mcpExplain{
   padding:18px 20px;
@@ -692,7 +692,7 @@
   background:linear-gradient(135deg, rgba(18,109,255,.08) 0%, rgba(18,109,255,.04) 100%);
   box-shadow:0 2px 8px rgba(18,109,255,.06);
   font-size:14px;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   display:flex;
   flex-direction:column;
   gap:12px;
@@ -719,7 +719,7 @@
   padding:18px 20px;
   border-radius:12px;
   border:1px solid rgba(18,109,255,.12);
-  background:linear-gradient(135deg, rgba(248,250,252,.8) 0%, rgba(255,255,255,.9) 100%);
+  background:linear-gradient(135deg, rgba(248,250,252,.8) 0%, color-mix(in srgb, var(--color-bg-container) 90%, transparent) 100%);
   box-shadow:0 2px 6px rgba(17,24,39,.04);
   max-width:80ch;
 }
@@ -734,7 +734,7 @@
 }
 .jx-kv .v{
   font-size:14px;
-  color:rgba(31,35,40,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   word-break:break-word;
   line-height:1.75;
 }
@@ -744,7 +744,7 @@
   margin-top:2px;
   font-size:16px;
   font-weight:1000;
-  color:rgba(15,23,42,.92);
+  color:color-mix(in srgb, var(--color-text) 92%, transparent);
 }
 .jx-kbDocItem{
   display:flex;
@@ -754,7 +754,7 @@
   padding:14px;
   border-radius:14px;
   border:1px solid rgba(17,24,39,.10);
-  background:#fff;
+  background:var(--color-bg-container);
   transition:border-color .16s ease, box-shadow .16s ease, transform .16s ease;
 }
 .jx-kbDocItem:hover{
@@ -775,7 +775,7 @@
 }
 .jx-kbDocItem .info .desc{
   font-size:13px;
-  color:rgba(31,35,40,.62);
+  color:color-mix(in srgb, var(--color-text) 62%, transparent);
   line-height:1.65;
 }
 .jx-kbDocTypeTag{
@@ -821,11 +821,11 @@
   font-weight:900;
   font-size:13px;
   margin-bottom:6px;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
 }
 .jx-kbSearchResultSnippet{
   font-size:13px;
-  color:rgba(31,35,40,.78);
+  color:color-mix(in srgb, var(--color-text) 78%, transparent);
   line-height:1.72;
 }
 .jx-kbDocModalBody{
@@ -843,7 +843,7 @@
 /* Document detail modal */
 .jx-kbDocDesc{
   font-size:14px;
-  color:rgba(31,35,40,.65);
+  color:color-mix(in srgb, var(--color-text) 65%, transparent);
   line-height:1.7;
   margin-bottom:16px;
   padding:10px 14px;
@@ -861,7 +861,7 @@
   padding:8px 18px;
   font-size:14px;
   font-weight:500;
-  color:rgba(31,35,40,.55);
+  color:color-mix(in srgb, var(--color-text) 55%, transparent);
   background:none;
   border:none;
   cursor:pointer;
@@ -873,9 +873,9 @@
   color:rgba(18,109,255,.85);
 }
 .jx-kbDocTab.active{
-  color:#0e59ef;
+  color:var(--color-primary-active);
   font-weight:600;
-  border-bottom-color:#0e59ef;
+  border-bottom-color:var(--color-primary-active);
 }
 
 /* Chunk list */
@@ -887,7 +887,7 @@
 .jx-chunkCard{
   border-radius:14px;
   border:1px solid rgba(17,24,39,.08);
-  background:#fff;
+  background:var(--color-bg-container);
   overflow:hidden;
   transition:border-color .18s, box-shadow .18s;
 }
@@ -916,7 +916,7 @@
   height:28px;
   border-radius:8px;
   background:rgba(31,35,40,.72);
-  color:#fff;
+  color:var(--color-text-white);
   font-size:13px;
   font-weight:700;
 }
@@ -927,12 +927,12 @@
 }
 .jx-chunkContentLen{
   font-size:12px;
-  color:rgba(31,35,40,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
 }
 .jx-chunkContent{
   padding:14px 16px;
   font-size:13px;
-  color:rgba(31,35,40,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   line-height:1.75;
   white-space:pre-wrap;
   word-break:break-word;
@@ -953,7 +953,7 @@
 .jx-chunkSectionLabel{
   font-size:12px;
   font-weight:600;
-  color:rgba(31,35,40,.50);
+  color:color-mix(in srgb, var(--color-text) 50%, transparent);
   display:flex;
   align-items:center;
   gap:4px;
@@ -1007,7 +1007,7 @@
 .jx-chunkQuestionText{
   flex:1;
   font-size:13px;
-  color:rgba(31,35,40,.82);
+  color:color-mix(in srgb, var(--color-text) 82%, transparent);
   line-height:1.5;
 }
 .jx-chunkQuestionDel{
@@ -1058,14 +1058,14 @@
   gap: 8px;
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0 0 6px;
 }
 
 .jx-sectionTitleCount {
   display: inline-flex;
   align-items: baseline;
-  color: #98a1ae;
+  color: var(--color-text-tertiary);
   font-size: 15px;
   font-weight: 400;
   line-height: 1;
@@ -1076,7 +1076,7 @@
 
 .jx-sk-subtitle {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-weight: 400;
   margin: 0;
 }
@@ -1094,13 +1094,13 @@
   gap: 8px;
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0 0 6px;
 }
 
 .jx-mcp-subtitle {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-weight: 400;
   margin: 0;
 }
@@ -1127,14 +1127,14 @@
   background: transparent;
   cursor: pointer;
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   padding: 6px;
   border-radius: 6px;
   transition: color .15s, background .15s;
 }
 
 .jx-sk-iconBtn:hover {
-  color: #1a1a1a;
+  color: var(--color-text);
   background: rgba(0,0,0,.04);
 }
 
@@ -1147,21 +1147,21 @@
 .jx-sk-uploadBtn.ant-btn {
   border-radius: 6px;
   font-size: 13px;
-  border-color: #d0daf0;
-  color: #4e7af5;
+  border-color: var(--color-border);
+  color: var(--color-primary);
 }
 
 .jx-sk-uploadBtn.ant-btn:hover {
-  border-color: #4e7af5;
-  color: #4e7af5;
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 /* ── List section ───────────────────────────────────────────────── */
 
 .jx-sk-list {
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   overflow: hidden;
   margin-bottom: 20px;
 }
@@ -1173,11 +1173,11 @@
 }
 
 .jx-sk-item:not(:last-child) {
-  border-bottom: 1px solid #f0f1f3;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .jx-sk-item:hover {
-  background: #f8f9fb;
+  background: var(--color-bg-layout);
 }
 
 .jx-sk-itemNameRow {
@@ -1190,7 +1190,7 @@
 .jx-sk-itemName {
   font-size: 16px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   line-height: 1.4;
 }
 
@@ -1206,7 +1206,7 @@
 
 .jx-sk-itemDesc {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   line-height: 1.72;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -1231,9 +1231,9 @@
 /* hover 抬升/按压由 .jx-card-lift（motion.css）提供 */
 .jx-sk-card {
   padding: 16px 20px;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -1242,7 +1242,7 @@
 }
 
 .jx-sk-card:hover {
-  border-color: #c0cadb;
+  border-color: var(--color-fill);
   box-shadow: 0 2px 8px rgba(0,0,0,.04);
 }
 
@@ -1256,15 +1256,15 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  border: 1px solid #E3E6EA;
-  background: #f0f2f5;
+  border: 1px solid var(--color-border);
+  background: var(--color-fill-hover);
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   font-size: 12px;
   font-weight: 600;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .jx-sk-cardNameGroup {
@@ -1277,7 +1277,7 @@
 .jx-sk-cardName {
   font-size: 16px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1290,7 +1290,7 @@
 
 .jx-sk-cardDesc {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   line-height: 1.6;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -1321,7 +1321,7 @@
   padding: 4px 0;
   margin-right: 16px;
   margin-top: 5px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-size: 14px;
   display: inline-flex;
   align-items: center;
@@ -1330,7 +1330,7 @@
 }
 
 .jx-sk-backBtn:hover {
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-sk-detailContent {
@@ -1355,7 +1355,7 @@
 .jx-sk-detailName {
   font-size: 19px;
   font-weight: 520;
-  color: #0f172a;
+  color: var(--color-text);
   line-height: 1.28;
   letter-spacing: -.012em;
 }
@@ -1367,13 +1367,13 @@
 .jx-sk-detailSubtitle {
   font-size: 18px;
   font-weight: 700;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0 0 8px;
 }
 
 .jx-sk-detailDesc {
   font-size: 15px;
-  color: #555;
+  color: var(--color-text-secondary);
   line-height: 1.82;
   margin: 0 0 20px;
 }
@@ -1385,7 +1385,7 @@
 .jx-sk-detailBody .jx-md {
   font-size: 13.5px;
   line-height: 1.92;
-  color: rgba(51,65,85,.88);
+  color: color-mix(in srgb, var(--color-text-secondary) 88%, transparent);
   letter-spacing: .002em;
 }
 
@@ -1395,7 +1395,7 @@
 .jx-sk-detailBody .jx-md h4 {
   font-weight: 560;
   letter-spacing: -.008em;
-  color: rgba(15,23,42,.9);
+  color: color-mix(in srgb, var(--color-text) 90%, transparent);
 }
 
 .jx-sk-detailBody .jx-md h1 {
@@ -1417,14 +1417,14 @@
 .jx-sk-detailBody .jx-md h3 {
   font-size: 14px;
   margin: 16px 0 8px;
-  color: rgba(30,41,59,.84);
+  color: color-mix(in srgb, var(--color-text-secondary) 84%, transparent);
 }
 
 .jx-sk-detailBody .jx-md h4 {
   font-size: 13px;
   margin: 12px 0 8px;
   font-weight: 540;
-  color: rgba(71,85,105,.82);
+  color: color-mix(in srgb, var(--color-text-secondary) 82%, transparent);
   text-transform: uppercase;
   letter-spacing: .04em;
 }
@@ -1441,7 +1441,7 @@
 
 .jx-sk-detailBody .jx-md li {
   line-height: 1.86;
-  color: rgba(51,65,85,.9);
+  color: color-mix(in srgb, var(--color-text-secondary) 90%, transparent);
 }
 
 .jx-sk-detailBody .jx-md li + li {
@@ -1450,7 +1450,7 @@
 
 .jx-sk-detailBody .jx-md strong {
   font-weight: 580;
-  color: rgba(15,23,42,.94);
+  color: color-mix(in srgb, var(--color-text) 94%, transparent);
 }
 
 .jx-sk-detailBody .jx-md code {
@@ -1458,13 +1458,13 @@
   font-weight: 500;
   border-radius: 5px;
   background: rgba(148,163,184,.12);
-  color: rgba(51,65,85,.9);
+  color: color-mix(in srgb, var(--color-text-secondary) 90%, transparent);
 }
 
 .jx-sk-detailBody .jx-md blockquote {
-  color: rgba(71,85,105,.82);
+  color: color-mix(in srgb, var(--color-text-secondary) 82%, transparent);
   background: rgba(248,250,252,.92);
-  border-left-color: rgba(148,163,184,.7);
+  border-left-color: color-mix(in srgb, var(--color-text-placeholder) 70%, transparent);
 }
 
 /* ── Header right (启用 + switch) ───────────────────────────────── */
@@ -1515,7 +1515,7 @@
 
 .jx-sk-enableLabel {
   font-size: 15px;
-  color: #555;
+  color: var(--color-text-secondary);
 }
 
 /* ── Version + divider ──────────────────────────────────────────── */
@@ -1524,21 +1524,21 @@
   font-family: 'PingFang SC', -apple-system, sans-serif;
   font-weight: 400;
   font-size: 13px;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   margin-top: 6px;
   margin-bottom: 20px;
 }
 
 .jx-sk-divider {
   border: none;
-  border-top: 1px solid #E3E6EA;
+  border-top: 1px solid var(--color-border);
   margin: 0 0 20px;
 }
 
 /* ── Metadata card ──────────────────────────────────────────────── */
 
 .jx-sk-metaCard {
-  background: #F7F7F7;
+  background: var(--color-bg-gray);
   border-radius: 12px;
   padding: 20px 24px;
   margin-bottom: 24px;
@@ -1548,13 +1548,13 @@
 .jx-sk-metaName {
   font-size: 15px;
   font-weight: 700;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0 0 8px;
 }
 
 .jx-sk-metaDesc {
   font-size: 13px;
-  color: #555;
+  color: var(--color-text-secondary);
   line-height: 1.7;
   margin: 0 0 12px;
 }
@@ -1570,9 +1570,9 @@
   border-radius: 4px;
   font-size: 12px;
   padding: 2px 10px;
-  border: 1px solid #dde1e6;
-  background: #fff;
-  color: #444;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-container);
+  color: var(--color-text-secondary);
 }
 
 /* ── Skills detail page: sticky header + scrollable body ──────── */
@@ -1591,12 +1591,12 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: #fff;
+  background: var(--color-bg-container);
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 16px 0 14px;
-  border-bottom: 1px solid #E3E6EA;
+  border-bottom: 1px solid var(--color-border);
   box-shadow: 0 2px 6px rgba(15,23,42,.04);
 }
 
@@ -1639,13 +1639,13 @@
   font-family: 'PingFang SC', -apple-system, sans-serif;
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0 0 6px;
 }
 .jx-agentPage-subtitle {
   font-family: 'PingFang SC', -apple-system, sans-serif;
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-weight: 400;
   margin: 0;
 }
@@ -1667,7 +1667,7 @@
 .jx-agentPage-empty {
   text-align: center;
   padding: 64px 0;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   font-size: 14px;
 }
 
@@ -1686,14 +1686,14 @@
 /* hover 抬升/按压由 .jx-card-lift（motion.css）提供 */
 .jx-agentCard {
   padding: 16px 20px;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   cursor: pointer;
   min-width: 0;
 }
 .jx-agentCard:hover {
-  border-color: #c0cadb;
+  border-color: var(--color-fill);
   box-shadow: 0 2px 8px rgba(0,0,0,.04);
 }
 .jx-agentCard--disabled {
@@ -1721,7 +1721,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -1741,7 +1741,7 @@
 .jx-agentCard-name {
   font-size: 16px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1751,13 +1751,13 @@
   padding: 1px 4px;
   border-radius: 4px;
   flex-shrink: 0;
-  color: #808080;
-  background: #F5F6F7;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-gray);
   line-height: 1.4;
   transition: var(--motion-transition-hover);
 }
 .jx-agentCard-badge.on {
-  color: #126DFF;
+  color: var(--color-primary);
   background: #DBEAFE;
 }
 
@@ -1783,24 +1783,24 @@
   cursor: pointer;
   padding: 4px 5px;
   border-radius: 4px;
-  color: #808080;
+  color: var(--color-text-tertiary);
   font-size: 13px;
   line-height: 1;
   transition: color .12s, background .12s;
 }
 .jx-agentCard-ops button:hover {
-  color: #126DFF;
-  background: #EBF2FF;
+  color: var(--color-primary);
+  background: var(--color-primary-light);
 }
 .jx-agentCard-ops button.danger:hover {
-  color: #FC5D5D;
-  background: #FFF0F0;
+  color: var(--color-error);
+  background: var(--color-error-light);
 }
 
 /* Description */
 .jx-agentCard-desc {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   line-height: 1.65;
   margin: 0;
   text-align: justify;
@@ -1830,11 +1830,11 @@
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   font-size: 14px;
   transition: color .12s;
 }
-.jx-agentDetail-backBtn:hover { color: #1a1a1a; }
+.jx-agentDetail-backBtn:hover { color: var(--color-text); }
 
 .jx-agentDetail-content {
   flex: 1;
@@ -1853,7 +1853,7 @@
   width: 44px;
   height: 44px;
   border-radius: 8px;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -1864,7 +1864,7 @@
 .jx-agentDetail-name {
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-agentDetail-badge {
@@ -1872,13 +1872,13 @@
   padding: 1px 4px;
   border-radius: 4px;
   flex-shrink: 0;
-  color: #808080;
-  background: #F5F6F7;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-gray);
   line-height: 1.4;
   transition: var(--motion-transition-hover);
 }
 .jx-agentDetail-badge.on {
-  color: #126DFF;
+  color: var(--color-primary);
   background: #DBEAFE;
 }
 
@@ -1892,7 +1892,7 @@
 }
 .jx-agentDetail-enableLabel {
   font-size: 14px;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-agentDetail-versionRow {
@@ -1913,7 +1913,7 @@
 
 .jx-agentDetail-version {
   font-size: 12px;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
 }
 
 .jx-agentDetail-versionMeta {
@@ -1926,9 +1926,9 @@
   height: 24px;
   padding: 0 9px;
   border-radius: 999px;
-  border: 1px solid #D7E3F4;
-  background: #F3F7FC;
-  color: #3F536E;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-layout);
+  color: var(--color-text-secondary);
   font-size: 11px;
   font-weight: 400;
   box-shadow: none;
@@ -1936,14 +1936,14 @@
 
 .jx-agentDetail-versionAction.ant-btn:hover,
 .jx-agentDetail-versionAction.ant-btn:focus {
-  color: #3A4E68;
-  border-color: #D0DDED;
-  background: #F0F5FB;
+  color: var(--color-text-secondary);
+  border-color: var(--color-border);
+  background: var(--color-primary-light);
 }
 
 .jx-agentDetail-divider {
   border: none;
-  border-top: 1px solid #E3E6EA;
+  border-top: 1px solid var(--color-border);
   margin: 0 0 20px;
 }
 
@@ -1955,9 +1955,9 @@
 }
 
 .jx-agentDetail-section {
-  border: 1px solid #E5EAF0;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #FFFFFF;
+  background: var(--color-bg-container);
   box-shadow: none;
   padding: 18px 20px 20px;
 }
@@ -1974,7 +1974,7 @@
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: #1F2937;
+  color: var(--color-text);
 }
 
 .jx-agentDetail-grid {
@@ -1987,8 +1987,8 @@
   min-width: 0;
   padding: 14px 16px;
   border-radius: 10px;
-  background: #FAFBFC;
-  border: 1px solid #ECEFF3;
+  background: var(--color-bg-layout);
+  border: 1px solid var(--color-border);
 }
 
 .jx-agentDetail-field.is-multiline {
@@ -2000,18 +2000,18 @@
   font-size: 12px;
   font-weight: 600;
   letter-spacing: .2px;
-  color: #7B8794;
+  color: var(--color-text-tertiary);
 }
 
 .jx-agentDetail-fieldValue {
   font-size: 14px;
   line-height: 1.75;
-  color: #374151;
+  color: var(--color-text);
   word-break: break-word;
 }
 
 .jx-agentDetail-emptyText {
-  color: #9CA3AF;
+  color: var(--color-text-placeholder);
 }
 
 .jx-agentDetail-chipList {
@@ -2026,8 +2026,8 @@
   min-height: 28px;
   padding: 4px 10px;
   border-radius: 999px;
-  background: #F3F6FA;
-  color: #4B5B72;
+  background: var(--color-fill-hover);
+  color: var(--color-text-secondary);
   font-size: 13px;
   font-weight: 500;
 }
@@ -2039,13 +2039,13 @@
 .jx-agentDetail-fieldValue .jx-md {
   font-size: 14px;
   line-height: 1.75;
-  color: #4D4D4D;
+  color: var(--color-text-secondary);
 }
 .jx-agentDetail-fieldValue .jx-md h1,
 .jx-agentDetail-fieldValue .jx-md h2,
 .jx-agentDetail-fieldValue .jx-md h3,
 .jx-agentDetail-fieldValue .jx-md h4 {
-  color: #262626;
+  color: var(--color-text);
   font-weight: 500;
   margin: 20px 0 8px;
 }
@@ -2073,7 +2073,7 @@
   top: 10px;
   bottom: 10px;
   width: 2px;
-  background: #D7E3F4;
+  background: var(--color-primary-light);
   border-radius: 999px;
 }
 
@@ -2090,8 +2090,8 @@
   height: 10px;
   margin-top: 6px;
   border-radius: 50%;
-  background: #0F5EEA;
-  border: 2px solid #F3F7FC;
+  background: var(--color-primary-active);
+  border: 2px solid var(--color-primary-light);
   box-shadow: 0 0 0 4px #DCE7F7;
   flex-shrink: 0;
 }
@@ -2101,8 +2101,8 @@
   min-width: 0;
   padding: 13px 14px;
   border-radius: 10px;
-  border: 1px solid #D9E3F0;
-  background: #F3F7FC;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-layout);
   box-shadow: none;
 }
 
@@ -2116,7 +2116,7 @@
 
 .jx-agentDetail-historyTime {
   font-size: 11px;
-  color: #7B8794;
+  color: var(--color-text-tertiary);
 }
 
 .jx-agentDetail-historyVersion {
@@ -2125,21 +2125,21 @@
   min-height: 22px;
   padding: 0 8px;
   border-radius: 999px;
-  background: #DDEBFF;
-  color: #0F5EEA;
+  background: var(--color-primary-bg);
+  color: var(--color-primary-active);
   font-size: 11px;
   line-height: 1;
 }
 
 .jx-agentDetail-historyOperator {
   font-size: 11px;
-  color: #7B8794;
+  color: var(--color-text-tertiary);
 }
 
 .jx-agentDetail-historyContent {
   font-size: 13px;
   line-height: 1.6;
-  color: #374151;
+  color: var(--color-text);
 }
 
 .jx-agentDetail-historyInfoRow {
@@ -2156,20 +2156,20 @@
 .jx-agentDetail-historyInfoLabel {
   font-size: 12px;
   line-height: 1.6;
-  color: #8A94A6;
+  color: var(--color-text-placeholder);
 }
 
 .jx-agentDetail-historyInfoValue {
   font-size: 12px;
   line-height: 1.6;
-  color: #374151;
+  color: var(--color-text);
   word-break: break-word;
 }
 
 .jx-agentDetail-historyDetailList {
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px dashed #D7E1EE;
+  border-top: 1px dashed var(--color-border);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -2178,7 +2178,7 @@
 .jx-agentDetail-historyDetailItem {
   padding: 10px 11px;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.58);
+  background: color-mix(in srgb, var(--color-bg-container) 58%, transparent);
   border: 1px solid rgba(215, 225, 238, 0.92);
 }
 
@@ -2186,7 +2186,7 @@
   margin-bottom: 8px;
   font-size: 12px;
   font-weight: 600;
-  color: #4B5B72;
+  color: var(--color-text-secondary);
 }
 
 .jx-agentDetail-historyDetailValues {
@@ -2209,8 +2209,8 @@
   min-height: 20px;
   padding: 0 6px;
   border-radius: 999px;
-  background: #EEF2F7;
-  color: #64748B;
+  background: var(--color-fill-hover);
+  color: var(--color-text-tertiary);
   font-size: 10px;
   line-height: 1;
 }
@@ -2223,14 +2223,14 @@
 .jx-agentDetail-historyDetailText {
   font-size: 12px;
   line-height: 1.55;
-  color: #334155;
+  color: var(--color-text);
   word-break: break-word;
 }
 
 .jx-agentDetail-historyEmpty {
   padding: 12px 0 2px;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--color-text-placeholder);
 }
 
 .jx-agentHistoryDrawer .ant-drawer-header {
@@ -2240,12 +2240,12 @@
 .jx-agentHistoryDrawer .ant-drawer-title {
   font-size: 15px;
   font-weight: 600;
-  color: #1F2937;
+  color: var(--color-text);
 }
 
 .jx-agentHistoryDrawer .ant-drawer-body {
   padding: 8px 20px 20px;
-  background: #FCFDFE;
+  background: var(--color-bg-layout);
 }
 
 .jx-agentDetail-actionsWrap {
@@ -2266,7 +2266,7 @@
   padding: 12px;
   border: 1px solid rgba(229, 234, 240, 0.96);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.92);
+  background: color-mix(in srgb, var(--color-bg-container) 92%, transparent);
   backdrop-filter: blur(12px);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
   pointer-events: auto;
@@ -2278,16 +2278,16 @@
   height: 40px;
   padding: 0;
   border-radius: 12px;
-  border-color: #E5EAF0;
-  color: #6B7280;
+  border-color: var(--color-border);
+  color: var(--color-text-secondary);
   box-shadow: none;
 }
 
 .jx-agentDetail-iconBtn.ant-btn:hover,
 .jx-agentDetail-iconBtn.ant-btn:focus {
-  border-color: #D6DDE6;
-  color: #374151;
-  background: #F8FAFC;
+  border-color: var(--color-border);
+  color: var(--color-text);
+  background: var(--color-bg-layout);
 }
 
 .jx-agentDetail-iconBtn.danger.ant-btn {
@@ -2405,7 +2405,7 @@
   gap: 16px;
   padding: 18px 20px;
   border-radius: 12px;
-  background: #f6f9fc;
+  background: var(--color-bg-layout);
 }
 
 .jx-agentCreatePage-heroIcon {
@@ -2416,7 +2416,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  background: #eaf2ff;
+  background: var(--color-primary-light);
   color: #4f83ff;
   font-size: 20px;
 }
@@ -2434,26 +2434,26 @@
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  color: #6b7280;
+  color: var(--color-text-secondary);
   font-size: 13px;
   width: fit-content;
 }
 
 .jx-agentCreatePage-back:hover {
-  color: #374151;
+  color: var(--color-text);
 }
 
 .jx-agentCreatePage-title {
   font-size: 20px;
   font-weight: 500;
-  color: #262626;
+  color: var(--color-text);
   margin: 0 0 4px;
 }
 
 .jx-agentCreatePage-subtitle {
   font-size: 14px;
   line-height: 1.65;
-  color: #64748b;
+  color: var(--color-text-tertiary);
   margin: 0;
 }
 
@@ -2588,8 +2588,8 @@
 }
 
 .jx-kbHero{
-  background:#fff;
-  border:1px solid #E3E6EA;
+  background:var(--color-bg-container);
+  border:1px solid var(--color-border);
   border-radius:18px;
   padding:28px 30px;
   box-shadow:0 10px 26px rgba(15,23,42,.035);
@@ -2600,18 +2600,18 @@
   font-size:22px;
   line-height:1.25;
   font-weight:700;
-  color:#111827;
+  color:var(--color-text);
 }
 
 .jx-kbHeroDesc{
   margin:10px 0 0;
   font-size:14px;
   line-height:1.65;
-  color:#6b7280;
+  color:var(--color-text-secondary);
 }
 
 .jx-kbTabsWrap{
-  border-bottom:1px solid rgba(15,23,42,.08);
+  border-bottom:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   margin-bottom:4px;
 }
 
@@ -2634,7 +2634,7 @@
   font-size:15px;
   line-height:1.2;
   font-weight:500;
-  color:#0f172a;
+  color:var(--color-text);
   cursor:pointer;
 }
 
@@ -2648,7 +2648,7 @@
   bottom:-1px;
   height:3px;
   border-radius:999px 999px 0 0;
-  background:#126DFF;
+  background:var(--color-primary);
   opacity:0;
   pointer-events:none;
   transition:transform .32s cubic-bezier(.22,1,.36,1), width .32s cubic-bezier(.22,1,.36,1), opacity .18s ease;
@@ -2663,13 +2663,13 @@
   height:22px;
   padding:0 6px;
   border-radius:3px;
-  background:#DBE9FF;
+  background:var(--color-primary-bg);
   display:inline-flex;
   align-items:center;
   justify-content:center;
   font-size:11px;
   font-weight:500;
-  color:#126DFF;
+  color:var(--color-primary);
 }
 
 .jx-kbToolbar{
@@ -2687,10 +2687,10 @@
 .jx-kbToolbarSearch.ant-input-affix-wrapper{
   height:44px;
   border-radius:12px;
-  border-color:#E3E6EA;
+  border-color:var(--color-border);
   box-shadow:none;
   padding-inline:12px;
-  background:#fff;
+  background:var(--color-bg-container);
 }
 
 .jx-kbToolbarSearch .ant-input{
@@ -2703,7 +2703,7 @@
   gap:10px 14px;
   flex-wrap:wrap;
   font-size:13px;
-  color:#4b5563;
+  color:var(--color-text-secondary);
 }
 
 .jx-kbToolbarMeta .ant-btn{
@@ -2724,9 +2724,9 @@
 .jx-kbLibraryCard{
   width:100%;
   appearance:none;
-  border:1px solid #E3E6EA;
+  border:1px solid var(--color-border);
   border-radius:14px;
-  background:#fff;
+  background:var(--color-bg-container);
   padding:16px 16px 12px;
   text-align:left;
   cursor:pointer;
@@ -2787,12 +2787,12 @@
   font-size:15px;
   line-height:1.4;
   font-weight:500;
-  color:#111827;
+  color:var(--color-text);
 }
 
 .jx-kbLibraryDesc{
   margin:6px 0 0;
-  color:#6b7280;
+  color:var(--color-text-secondary);
   font-size:13px;
   font-weight:400;
   line-height:1.7;
@@ -2816,17 +2816,17 @@
   min-height:26px;
   padding:0 10px;
   border-radius:8px;
-  border:1px solid rgba(148,163,184,.18);
-  background:#fff;
-  color:#64748b;
+  border:1px solid color-mix(in srgb, var(--color-text-placeholder) 18%, transparent);
+  background:var(--color-bg-container);
+  color:var(--color-text-tertiary);
   font-size:12px;
   font-weight:400;
   line-height:1.2;
 }
 
 .jx-kbPill-blue{
-  background:#eef6ff;
-  border-color:#d7e9ff;
+  background:var(--color-primary-light);
+  border-color:var(--color-primary-bg);
   color:#4f87c2;
 }
 
@@ -2861,11 +2861,11 @@
 
 .jx-kbEnableLabel{
   font-size:14px;
-  color:#1a1a1a;
+  color:var(--color-text);
 }
 
 .jx-kbLibraryDocCount{
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-size:12px;
   font-weight:400;
   white-space:nowrap;
@@ -2878,7 +2878,7 @@
   align-items:center;
   gap:8px;
   padding:14px 8px;
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-size:13px;
 }
 
@@ -2939,15 +2939,15 @@
 
 .jx-kbLibraryEmpty{
   grid-column:1 / -1;
-  background:#fff;
-  border:1px solid #E3E6EA;
+  background:var(--color-bg-container);
+  border:1px solid var(--color-border);
   border-radius:16px;
   padding:36px 20px;
 }
 
 .jx-kbDetailHeader{
-  background:#fff;
-  border:1px solid #E3E6EA;
+  background:var(--color-bg-container);
+  border:1px solid var(--color-border);
   border-radius:14px;
   padding:16px 18px;
   display:flex;
@@ -2973,7 +2973,7 @@
   border-radius:8px;
   padding:0;
   font-size:16px;
-  color:#475569;
+  color:var(--color-text-secondary);
   border:none;
   background:transparent;
   box-shadow:none;
@@ -2981,8 +2981,8 @@
 
 .jx-kbBackBtn.ant-btn:hover,
 .jx-kbBackBtn.ant-btn:focus{
-  color:#334155;
-  background:#f8fafc;
+  color:var(--color-text);
+  background:var(--color-bg-layout);
 }
 
 .jx-kbDetailDivider{
@@ -3009,14 +3009,14 @@
   font-size:20px;
   line-height:1.3;
   font-weight:600;
-  color:#111827;
+  color:var(--color-text);
 }
 
 .jx-kbDetailDesc{
   margin:0;
   font-size:13px;
   line-height:1.6;
-  color:#6b7280;
+  color:var(--color-text-secondary);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -3089,7 +3089,7 @@
   gap:6px;
   font-size:13px;
   font-weight:500;
-  color:#6b7280;
+  color:var(--color-text-secondary);
 }
 
 .jx-kbSyncInlineStatus{
@@ -3123,7 +3123,7 @@
 .jx-kbSyncInlineHint{
   font-size:12px;
   line-height:1.45;
-  color:#8b95a7;
+  color:var(--color-text-tertiary);
   flex:0 1 auto;
   min-width:0;
 }
@@ -3166,9 +3166,9 @@
   padding:0 14px;
   height:36px;
   border-radius:10px;
-  border:1px solid rgba(148,163,184,.18);
-  background:#fff;
-  color:#64748b;
+  border:1px solid color-mix(in srgb, var(--color-text-placeholder) 18%, transparent);
+  background:var(--color-bg-container);
+  color:var(--color-text-tertiary);
   font-size:12px;
   font-weight:400;
 }
@@ -3199,13 +3199,13 @@
   height:18px;
   font-size:14px;
   line-height:1;
-  color:#9aa4b2;
+  color:var(--color-text-placeholder);
   cursor:pointer;
   flex:0 0 auto;
 }
 
 .jx-kbRuleTrigger:hover{
-  color:#7c8798;
+  color:var(--color-text-tertiary);
 }
 
 .jx-kbRulesPopover .ant-popover-inner{
@@ -3253,19 +3253,19 @@
 }
 
 .jx-kbEditIconBtn.ant-btn{
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
 }
 
 .jx-kbDeleteIconBtn.ant-btn{
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
 }
 
 .jx-kbEditIconBtn.ant-btn:hover,
 .jx-kbEditIconBtn.ant-btn:focus,
 .jx-kbDeleteIconBtn.ant-btn:hover,
 .jx-kbDeleteIconBtn.ant-btn:focus{
-  color:#64748b;
-  background:#f8fafc;
+  color:var(--color-text-tertiary);
+  background:var(--color-bg-layout);
 }
 
 .jx-kbEditorModal .ant-modal-content{
@@ -3282,7 +3282,7 @@
 .jx-kbEditorModal .ant-modal-title{
   font-size:18px;
   font-weight:600;
-  color:#111827;
+  color:var(--color-text);
 }
 
 .jx-kbEditorModal .ant-modal-body{
@@ -3309,7 +3309,7 @@
 .jx-kbEditorLabel{
   font-size:13px;
   font-weight:500;
-  color:#475569;
+  color:var(--color-text-secondary);
 }
 
 .jx-kbEditorField .ant-input,
@@ -3344,9 +3344,9 @@
   height:24px;
   padding:0 8px;
   border-radius:999px;
-  border-color:#bfd2ff;
+  border-color:var(--color-primary-disabled);
   color:#2f66f5;
-  background:#eef4ff;
+  background:var(--color-primary-light);
   box-shadow:none;
   font-size:12px;
   font-weight:500;
@@ -3362,7 +3362,7 @@
 
 .jx-kbEditorCount{
   font-size:12px;
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
 }
 
 .jx-kbEditorFooter{
@@ -3387,7 +3387,7 @@
   border:none;
   border-radius:8px;
   background:transparent;
-  color:#6b7280;
+  color:var(--color-text-secondary);
   font-size:14px;
   font-weight:500;
   line-height:1;
@@ -3397,13 +3397,13 @@
 }
 
 .jx-kbDocFilterTab:hover{
-  background:#F2F4F7;
-  color:#111827;
+  background:var(--color-fill-hover);
+  color:var(--color-text);
 }
 
 .jx-kbDocFilterTab.is-active{
   background:#E8F0FF;
-  color:#126DFF;
+  color:var(--color-primary);
 }
 
 .jx-kbDocFilterTab.is-active:hover{
@@ -3421,12 +3421,12 @@
 }
 
 .jx-kbDocFilterTab.is-active .jx-kbDocFilterTabCount{
-  color:#126DFF;
+  color:var(--color-primary);
 }
 
 .jx-kbDocPanel{
-  background:#fff;
-  border:1px solid #E3E6EA;
+  background:var(--color-bg-container);
+  border:1px solid var(--color-border);
   border-radius:14px;
   overflow:hidden;
   box-shadow:0 10px 30px rgba(15,23,42,.04);
@@ -3438,7 +3438,7 @@
   justify-content:space-between;
   gap:16px;
   padding:16px 18px;
-  border-bottom:1px solid #E3E6EA;
+  border-bottom:1px solid var(--color-border);
   flex-wrap:wrap;
 }
 
@@ -3461,7 +3461,7 @@
 .jx-kbDocSearch.ant-input-affix-wrapper{
   height:40px;
   border-radius:12px;
-  border-color:#E3E6EA;
+  border-color:var(--color-border);
   padding-inline:12px;
   box-shadow:none;
 }
@@ -3483,7 +3483,7 @@
   display:flex;
   justify-content:flex-end;
   padding:14px 18px 18px;
-  border-top:1px solid #E3E6EA;
+  border-top:1px solid var(--color-border);
   background:linear-gradient(180deg, rgba(248,250,252,.92) 0%, #fff 55%);
 }
 
@@ -3495,7 +3495,7 @@
   display:flex;
   align-items:center;
   gap:10px;
-  color:#7b8798;
+  color:var(--color-text-tertiary);
 }
 
 .jx-kbPager .ant-pagination-total-text{
@@ -3513,8 +3513,8 @@
   height:34px;
   line-height:32px;
   border-radius:10px;
-  border:1px solid #e2e8f0;
-  background:#fff;
+  border:1px solid var(--color-border);
+  background:var(--color-bg-container);
   box-shadow:none;
   transition:all .18s ease;
 }
@@ -3522,19 +3522,19 @@
 .jx-kbPager .ant-pagination-prev:hover,
 .jx-kbPager .ant-pagination-next:hover,
 .jx-kbPager .ant-pagination-item:hover{
-  border-color:#cbd5e1;
-  background:#f8fafc;
+  border-color:var(--color-fill);
+  background:var(--color-bg-layout);
 }
 
 .jx-kbPager .ant-pagination-item a{
-  color:#7b8798;
+  color:var(--color-text-tertiary);
   font-size:12px;
   font-weight:500;
 }
 
 .jx-kbPager .ant-pagination-item-active{
   border-color:#dbeafe;
-  background:#f8fbff;
+  background:var(--color-bg-layout);
   box-shadow:inset 0 0 0 1px rgba(59,130,246,.08);
 }
 
@@ -3545,12 +3545,12 @@
 
 .jx-kbPager .ant-pagination-disabled{
   opacity:.5;
-  background:#f8fafc;
+  background:var(--color-bg-layout);
 }
 
 .jx-kbPager .ant-pagination-disabled:hover{
-  border-color:#e2e8f0;
-  background:#f8fafc;
+  border-color:var(--color-border);
+  background:var(--color-bg-layout);
 }
 
 .jx-kbPager .ant-pagination-options{
@@ -3566,7 +3566,7 @@
   padding:0 12px !important;
   border-radius:12px !important;
   border:1px solid #dbe3ef !important;
-  background:rgba(255,255,255,.94) !important;
+  background:color-mix(in srgb, var(--color-bg-container) 94%, transparent) !important;
   box-shadow:none !important;
 }
 
@@ -3574,7 +3574,7 @@
   line-height:34px !important;
   font-size:12px;
   font-weight:500;
-  color:#7b8798;
+  color:var(--color-text-tertiary);
 }
 
 .jx-kbPager .ant-select-arrow{
@@ -3585,7 +3585,7 @@
 .jx-kbPagerSizeDropdown{
   padding:10px;
   border-radius:16px;
-  background:rgba(255,255,255,.96);
+  background:color-mix(in srgb, var(--color-bg-container) 96%, transparent);
   border:1px solid rgba(226,232,240,.9);
   box-shadow:0 18px 40px rgba(15,23,42,.10), 0 6px 16px rgba(15,23,42,.06);
   backdrop-filter:blur(12px);
@@ -3607,8 +3607,8 @@
 }
 
 .jx-kbPagerSizeDropdown .ant-select-item-option-active{
-  background:#f8fafc;
-  color:#5f6c7f;
+  background:var(--color-bg-layout);
+  color:var(--color-text-secondary);
 }
 
 .jx-kbPagerSizeDropdown .ant-select-item-option-selected{
@@ -3628,13 +3628,13 @@
 }
 
 .jx-kbDocTableHead{
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-size:13px;
   font-weight:400;
 }
 
 .jx-kbDocRow{
-  border-top:1px solid #E3E6EA;
+  border-top:1px solid var(--color-border);
 }
 
 .jx-kbDocTableHead > :not(:first-child){
@@ -3692,19 +3692,19 @@
   font-size:13px;
   line-height:1.4;
   font-weight:400;
-  color:#334155;
+  color:var(--color-text);
   word-break:break-word;
 }
 
 .jx-kbDocDesc{
   margin-top:1px;
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-size:12px;
   line-height:1.35;
 }
 
 .jx-kbDocCellMuted{
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-size:13px;
   font-weight:400;
   font-variant-numeric:tabular-nums;
@@ -3714,7 +3714,7 @@
   min-height:24px;
   padding:0 10px;
   border-radius:6px;
-  border:1px solid rgba(148,163,184,.18);
+  border:1px solid color-mix(in srgb, var(--color-text-placeholder) 18%, transparent);
   display:inline-flex;
   align-items:center;
   gap:8px;
@@ -3769,8 +3769,8 @@
 }
 
 .jx-kbStatusPill-processing{
-  background:#eef6ff;
-  border-color:#d7e9ff;
+  background:var(--color-primary-light);
+  border-color:var(--color-primary-bg);
   color:#4f87c2;
 }
 
@@ -3809,7 +3809,7 @@
 
 .jx-kbDocActions .ant-btn{
   border-radius:8px;
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   width:28px;
   min-width:28px;
   height:28px;
@@ -3819,8 +3819,8 @@
 
 .jx-kbDocActions .ant-btn:hover,
 .jx-kbDocActions .ant-btn:focus{
-  color:#64748b;
-  background:#f8fafc;
+  color:var(--color-text-tertiary);
+  background:var(--color-bg-layout);
 }
 
 .jx-kbDocEmpty{
@@ -3861,7 +3861,7 @@
   font-size:16px;
   line-height:1.35;
   font-weight:600;
-  color:#1f2937;
+  color:var(--color-text);
   letter-spacing:.1px;
 }
 
@@ -3873,7 +3873,7 @@
 .jx-kbUploadModal .ant-modal-close-x{
   width:32px;
   height:32px;
-  color:#8b95a7;
+  color:var(--color-text-tertiary);
 }
 
 .jx-kbUploadModal .ant-modal-body{
@@ -3883,7 +3883,7 @@
 .jx-kbUploadModal .ant-modal-footer{
   padding:18px 32px 28px;
   margin:0;
-  border-top:1px solid #eef2f6;
+  border-top:1px solid var(--color-fill-hover);
 }
 
 .jx-kbUploadModalBody{
@@ -3933,7 +3933,7 @@
   font-size:13px;
   line-height:1.5;
   font-weight:500;
-  color:#1f2937;
+  color:var(--color-text);
 }
 
 .jx-kbUploadDragger .ant-upload-hint{
@@ -3958,7 +3958,7 @@
   font-size:12px;
   line-height:1.4;
   font-weight:500;
-  color:#7b8794;
+  color:var(--color-text-tertiary);
 }
 
 .jx-kbUploadSelect.ant-select{
@@ -3971,7 +3971,7 @@
   padding-inline:12px !important;
   border-color:#dbe3ec !important;
   box-shadow:none !important;
-  background:#fcfdff !important;
+  background:var(--color-bg-layout) !important;
 }
 
 .jx-kbUploadSelect .ant-select-selection-item{
@@ -3986,7 +3986,7 @@
 }
 
 .jx-kbUploadSelectDropdown .ant-select-item-option-selected{
-  background:#edf4ff !important;
+  background:var(--color-primary-light) !important;
 }
 
 .jx-kbUploadSelectDropdown .ant-select-item-option-active{
@@ -4011,13 +4011,13 @@
   font-size:14px;
   line-height:1.5;
   font-weight:500;
-  color:#1f2937;
+  color:var(--color-text);
 }
 
 .jx-kbUploadOptionDesc{
   font-size:12px;
   line-height:1.6;
-  color:#8a94a6;
+  color:var(--color-text-placeholder);
 }
 
 .jx-kbUploadOptionBadge{
@@ -4056,13 +4056,13 @@
   font-size:14px;
   line-height:1.5;
   font-weight:500;
-  color:#1f2937;
+  color:var(--color-text);
 }
 
 .jx-kbUploadToggleDesc{
   font-size:12px;
   line-height:1.65;
-  color:#8a94a6;
+  color:var(--color-text-placeholder);
 }
 
 .jx-kbUploadCollapse{
@@ -4085,7 +4085,7 @@
   font-size:14px;
   line-height:1.5;
   font-weight:500;
-  color:#6b7280;
+  color:var(--color-text-secondary);
 }
 
 .jx-kbUploadAdvanced{
@@ -4109,7 +4109,7 @@
   width:100%;
   border-radius:12px;
   border-color:#dbe3ec;
-  background:#fcfdff;
+  background:var(--color-bg-layout);
   box-shadow:none;
 }
 
@@ -4138,7 +4138,7 @@
 
 .jx-kbChunkPreviewSummary{
   margin-bottom:14px;
-  color:#64748b;
+  color:var(--color-text-tertiary);
   font-size:14px;
   font-weight:700;
 }
@@ -4152,17 +4152,17 @@
 }
 
 .jx-kbChunkPreviewCard{
-  border:1px solid rgba(15,23,42,.08);
+  border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   border-radius:16px;
   overflow:hidden;
-  background:#fff;
+  background:var(--color-bg-container);
 }
 
 .jx-kbChunkPreviewHeader{
   width:100%;
   appearance:none;
   border:none;
-  background:#f8fafc;
+  background:var(--color-bg-layout);
   padding:14px 16px;
   display:flex;
   align-items:center;
@@ -4171,12 +4171,12 @@
   cursor:pointer;
   font-size:14px;
   font-weight:700;
-  color:#334155;
+  color:var(--color-text);
 }
 
 .jx-kbChunkPreviewBody{
   padding:14px 16px;
-  color:#475569;
+  color:var(--color-text-secondary);
   font-size:13px;
   line-height:1.7;
   white-space:pre-wrap;
@@ -4191,16 +4191,16 @@
 
 .jx-kbChunkPreviewChild{
   border-radius:12px;
-  background:#f8fafc;
+  background:var(--color-bg-layout);
   padding:12px;
-  color:#64748b;
+  color:var(--color-text-tertiary);
   font-size:13px;
   line-height:1.65;
 }
 
 .jx-kbChunkPreviewChildIndex{
   margin-bottom:6px;
-  color:#334155;
+  color:var(--color-text);
   font-size:12px;
   font-weight:800;
 }
@@ -4312,8 +4312,8 @@
 .jx-mk-catChip {
   position: relative;
   border: 1px solid #E6E8EB;
-  background: #fff;
-  color: #595959;
+  background: var(--color-bg-container);
+  color: var(--color-text-secondary);
   font-size: 12px;
   line-height: 1;
   padding: 6px 12px;
@@ -4323,19 +4323,19 @@
 }
 .jx-mk-catChip:hover {
   border-color: #C9DCFF;
-  color: #126DFF;
+  color: var(--color-primary);
 }
 /* active 实心底由 layoutId="mkCatChip" 的滑动背景块提供（SkillMarketplaceModal） */
 .jx-mk-catChip.active {
   background: transparent;
-  border-color: #126DFF;
-  color: #fff;
+  border-color: var(--color-primary);
+  color: var(--color-text-white);
 }
 .jx-mk-catChipBg {
   position: absolute;
   inset: 0;
   border-radius: 14px;
-  background: #126DFF;
+  background: var(--color-primary);
   z-index: 0;
 }
 .jx-mk-catChipLabel {
@@ -4359,7 +4359,7 @@
   align-items: flex-start;
   gap: 14px;
   padding-bottom: 14px;
-  border-bottom: 1px solid #F0F0F0;
+  border-bottom: 1px solid var(--color-border);
   margin-bottom: 12px;
 }
 .jx-mk-detailHeadInfo { flex: 1; min-width: 0; }
@@ -4369,13 +4369,13 @@
   gap: 8px;
   font-size: 17px;
   font-weight: 600;
-  color: #1A1A1A;
+  color: var(--color-text);
   margin-bottom: 6px;
 }
-.jx-mk-ver { color: #8C8C8C; }
+.jx-mk-ver { color: var(--color-text-tertiary); }
 .jx-mk-detailSummary {
   font-size: 13px;
-  color: #595959;
+  color: var(--color-text-secondary);
   line-height: 1.6;
   margin: 0 0 12px;
 }
@@ -4394,17 +4394,17 @@
 .jx-mk-detailBodyTitle {
   font-size: 13px;
   font-weight: 600;
-  color: #1A1A1A;
+  color: var(--color-text);
   margin: 16px 0 8px;
 }
 .jx-mk-detailBody {
-  background: #FAFBFC;
-  border: 1px solid #F0F0F0;
+  background: var(--color-bg-layout);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 14px 16px;
   font-size: 13px;
   line-height: 1.7;
-  color: #333;
+  color: var(--color-text);
   overflow-x: auto;
 }
 .jx-mk-detailBody pre {
@@ -4419,9 +4419,9 @@
   align-items: center;
   gap: 8px;
   font-size: 12.5px;
-  color: #595959;
+  color: var(--color-text-secondary);
   padding: 5px 10px;
-  background: #FAFBFC;
+  background: var(--color-bg-layout);
   border-radius: 6px;
 }
 .jx-mk-filePath {
@@ -4449,7 +4449,7 @@
   border: 1px solid #ECECEC;
   border-radius: 12px;
   padding: 14px;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 .jx-mk-card:hover {
   border-color: #C9DCFF;
@@ -4472,7 +4472,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #126DFF;
+  color: var(--color-primary);
   font-weight: 600;
   font-size: 18px;
 }
@@ -4488,7 +4488,7 @@
 .jx-mk-cardName {
   font-weight: 600;
   font-size: 14px;
-  color: #1A1A1A;
+  color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4503,11 +4503,11 @@
   gap: 8px;
   margin-top: 4px;
   font-size: 12px;
-  color: #8C8C8C;
+  color: var(--color-text-tertiary);
 }
 .jx-mk-catTag {
   background: #F2F4F8;
-  color: #595959;
+  color: var(--color-text-secondary);
   font-size: 11px;
 }
 .jx-mk-dl {
@@ -4523,7 +4523,7 @@
 }
 .jx-mk-cardDesc {
   font-size: 12.5px;
-  color: #595959;
+  color: var(--color-text-secondary);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -4545,8 +4545,8 @@
   min-width: 0;
 }
 .jx-mk-tag {
-  background: #F7F8FA;
-  color: #8C8C8C;
+  background: var(--color-bg-layout);
+  color: var(--color-text-tertiary);
   font-size: 11px;
   margin: 0;
 }
@@ -4560,15 +4560,15 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  border: 1px dashed #D0D5DD;
-  background: #fff;
+  border: 1px dashed var(--color-fill);
+  background: var(--color-bg-container);
   border-radius: 10px;
   padding: 6px 12px 6px 6px;
   cursor: pointer;
   transition: border-color .12s;
 }
-.jx-iconPicker-trigger:hover { border-color: #126DFF; }
-.jx-iconPicker-triggerHint { font-size: 12px; color: #8C8C8C; }
+.jx-iconPicker-trigger:hover { border-color: var(--color-primary); }
+.jx-iconPicker-triggerHint { font-size: 12px; color: var(--color-text-tertiary); }
 .jx-iconPicker { width: 300px; max-width: 84vw; }
 .jx-iconPicker-grid {
   display: grid;
@@ -4593,13 +4593,13 @@
   transition: all .1s;
 }
 .jx-iconPicker-cell:hover { background: #F2F6FF; }
-.jx-iconPicker-cell.active { border-color: #126DFF; background: #EBF2FF; }
+.jx-iconPicker-cell.active { border-color: var(--color-primary); background: var(--color-primary-light); }
 .jx-iconPicker-actions {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  border-top: 1px solid #F0F0F0;
+  border-top: 1px solid var(--color-border);
   padding-top: 8px;
 }
 

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -1,6 +1,6 @@
 .jx-topbar{
   position:sticky;top:0;z-index:5;
-  background:rgba(255,255,255,.55);
+  background:color-mix(in srgb, var(--color-bg-container) 55%, transparent);
   backdrop-filter: blur(12px);
   box-shadow:
     0 1px 2px rgba(17,24,39,.04),
@@ -29,8 +29,8 @@
   gap:10px;
   padding:8px 58px 8px 16px;
   flex-shrink:0;
-  border-bottom:1px solid rgba(15,23,42,.06);
-  background:rgba(255,255,255,.85);
+  border-bottom:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
+  background:color-mix(in srgb, var(--color-bg-container) 85%, transparent);
   backdrop-filter:blur(8px);
 }
 .jx-appMainLayout{
@@ -89,7 +89,7 @@
   min-width:0;
   font-size:14px;
   font-weight:700;
-  color:#1e293b;
+  color:var(--color-text);
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
@@ -103,16 +103,16 @@
   flex-shrink:0;
   font-size:14px;
   font-weight:600;
-  color:rgba(15,23,42,.5);
+  color:color-mix(in srgb, var(--color-text) 50%, transparent);
   cursor:pointer;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
   transition:color .15s ease;
 }
-.jx-chatTopbarProject:hover{ color:#0F172A; }
+.jx-chatTopbarProject:hover{ color:var(--color-text); }
 .jx-chatTopbarProjectSep{
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-weight:600;
 }
 
@@ -137,7 +137,7 @@
    * 这里临时长出的滚动条会把居中的 .jx-panel 挤左又弹回（每次切换面板都水平抖一下）。
    * 预留两侧槽位后滚动条出现/消失不再改变布局宽度。 */
   scrollbar-gutter: stable both-edges;
-  background:#ffffff;
+  background:var(--color-bg-container);
 }
 
 .jx-panel{
@@ -192,11 +192,11 @@
 .jx-shareSelectionTitle{
   font-size:15px;
   font-weight:600;
-  color:#1e293b;
+  color:var(--color-text);
 }
 .jx-shareSelectionCount{
   font-size:13px;
-  color:rgba(15,23,42,.55);
+  color:color-mix(in srgb, var(--color-text) 55%, transparent);
 }
 .jx-shareSelectionActions{
   display:flex;
@@ -215,24 +215,24 @@
   transition:all .18s ease;
 }
 .jx-shareSelectionPrimaryBtn{
-  background:#126dff;
-  color:#fff;
+  background:var(--color-primary);
+  color:var(--color-text-white);
   font-weight:600;
 }
 .jx-shareSelectionPrimaryBtn:hover:not(:disabled){
-  background:#0f5fe0;
+  background:var(--color-primary-active);
 }
 .jx-shareSelectionPrimaryBtn:disabled{
   opacity:.45;
   cursor:not-allowed;
 }
 .jx-shareSelectionSecondaryBtn{
-  background:#fff;
-  color:#334155;
-  border:1px solid rgba(15,23,42,.09);
+  background:var(--color-bg-container);
+  color:var(--color-text);
+  border:1px solid color-mix(in srgb, var(--color-text) 9%, transparent);
 }
 .jx-shareSelectionSecondaryBtn:hover{
-  background:#f8fafc;
+  background:var(--color-bg-layout);
 }
 /* 消息行：竖向堆叠（不再是头像+内容横排） */
 .jx-msg{
@@ -282,21 +282,21 @@
   height:18px;
   margin:0;
   border-radius:5px;
-  border:1px solid #aeb9c8;
-  background:#ffffff;
+  border:1px solid var(--color-fill-deep);
+  background:var(--color-bg-container);
   box-shadow:0 1px 2px rgba(15, 23, 42, .04);
   cursor:pointer;
   position:relative;
   transition:border-color .18s ease, background-color .18s ease, box-shadow .18s ease, transform .18s ease;
 }
 .jx-shareCheckbox:hover{
-  border-color:#8ea6c7;
-  background:#ffffff;
+  border-color:var(--color-fill-deep);
+  background:var(--color-bg-container);
   box-shadow:0 1px 3px rgba(15, 23, 42, .08);
 }
 .jx-shareCheckbox:checked{
-  border-color:#4f7cff;
-  background:#4f7cff;
+  border-color:var(--color-primary);
+  background:var(--color-primary);
   box-shadow:0 2px 6px rgba(79, 124, 255, .22);
 }
 .jx-shareCheckbox:checked::after{
@@ -306,7 +306,7 @@
   top:2px;
   width:4px;
   height:9px;
-  border:solid #fff;
+  border:solid var(--color-text-white);
   border-width:0 2px 2px 0;
   transform:rotate(45deg);
 }
@@ -342,13 +342,13 @@
   cursor:text;
   padding:10px 14px;
   border-radius:18px 18px 4px 18px;
-  border:1px solid rgba(15,23,42,.09);
-  background:rgba(240,242,245,.96);
+  border:1px solid color-mix(in srgb, var(--color-text) 9%, transparent);
+  background:color-mix(in srgb, var(--color-fill-hover) 96%, transparent);
   line-height:1.74;
   font-size:14px;
   white-space:pre-wrap;
   word-break:break-word;
-  color:rgba(15,23,42,.80);
+  color:color-mix(in srgb, var(--color-text) 80%, transparent);
   box-shadow:0 1px 3px rgba(15,23,42,.045);
   display:inline-block;
   letter-spacing:.003em;
@@ -361,9 +361,9 @@
 }
 /* User bubble 颜色（浅灰 ChatGPT 风格，已在上面默认） */
 .jx-bubble.user{
-  background:rgba(242,244,247,.92);
-  color:rgba(15,23,42,.78);
-  border-color:rgba(15,23,42,.075);
+  background:color-mix(in srgb, var(--color-fill-hover) 92%, transparent);
+  color:color-mix(in srgb, var(--color-text) 78%, transparent);
+  border-color:color-mix(in srgb, var(--color-text) 7.5%, transparent);
   box-shadow:0 1px 3px rgba(15,23,42,.04);
   font-size:15px;
   line-height:1.78;
@@ -375,19 +375,19 @@
   margin-bottom:10px;
   padding:8px 10px;
   border-radius:12px;
-  background:rgba(255,255,255,.46);
-  border:1px solid rgba(15,23,42,.08);
+  background:color-mix(in srgb, var(--color-bg-container) 46%, transparent);
+  border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
 }
 .jx-userQuoteLabel{
   font-size:11px;
   font-weight:600;
-  color:rgba(100,116,139,.88);
+  color:color-mix(in srgb, var(--color-text-tertiary) 88%, transparent);
   line-height:1;
 }
 .jx-userQuoteText{
   font-size:12px;
   line-height:1.55;
-  color:rgba(71,85,105,.88);
+  color:color-mix(in srgb, var(--color-text-secondary) 88%, transparent);
   display:-webkit-box;
   -webkit-line-clamp:2;
   -webkit-box-orient:vertical;
@@ -407,7 +407,7 @@
   font-size:15.5px;
   line-height:1.82;
   letter-spacing:.004em;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   font-weight:400;
   text-rendering:optimizeLegibility;
   -webkit-font-smoothing:antialiased;
@@ -439,7 +439,7 @@
   line-height:1.46;
   letter-spacing:0;
   font-weight:600;
-  color:rgba(15,23,42,.94);
+  color:color-mix(in srgb, var(--color-text) 94%, transparent);
 }
 .jx-msg.assistant .jx-bubble h1:first-child,
 .jx-msg.assistant .jx-bubble h2:first-child,
@@ -453,7 +453,7 @@
 .jx-msg.assistant .jx-bubble h4{
   font-size:14.5px;
   font-weight:600;
-  color:rgba(15,23,42,.74);
+  color:color-mix(in srgb, var(--color-text) 74%, transparent);
 }
 .jx-msg.assistant .jx-bubble ul,
 .jx-msg.assistant .jx-bubble ol{
@@ -463,7 +463,7 @@
 .jx-msg.assistant .jx-bubble li{
   margin:0;
   line-height:1.8;
-  color:rgba(15,23,42,.84);
+  color:color-mix(in srgb, var(--color-text) 84%, transparent);
 }
 .jx-msg.assistant .jx-bubble ul > li + li,
 .jx-msg.assistant .jx-bubble ol > li + li{
@@ -471,7 +471,7 @@
 }
 .jx-msg.assistant .jx-bubble strong{
   font-weight:600;
-  color:rgba(15,23,42,.94);
+  color:color-mix(in srgb, var(--color-text) 94%, transparent);
 }
 .jx-msg.assistant .jx-bubble blockquote{
   margin:14px 0;
@@ -479,7 +479,7 @@
   border-left-width:2px;
   border-radius:10px;
   font-style:normal;
-  color:rgba(30,41,59,.80);
+  color:color-mix(in srgb, var(--color-text-secondary) 80%, transparent);
 }
 .jx-msg.assistant .jx-bubble code{
   font-size:12.5px;
@@ -488,16 +488,16 @@
 .jx-msg.assistant .jx-bubble pre{
   margin:14px 0;
   border-radius:12px;
-  border-color:rgba(15,23,42,.07);
+  border-color:color-mix(in srgb, var(--color-text) 7%, transparent);
   box-shadow:none;
-  background:#f7f8fa;
+  background:var(--color-bg-layout);
 }
 .jx-msg.assistant .jx-bubble table{
   margin:14px 0;
 }
 .jx-msg.assistant .jx-bubble a{
-  color:rgba(15,23,42,.86);
-  border-bottom-color:rgba(15,23,42,.18);
+  color:color-mix(in srgb, var(--color-text) 86%, transparent);
+  border-bottom-color:color-mix(in srgb, var(--color-text) 18%, transparent);
 }
 /* 流式占位：保留三点动画，无外框 */
 .jx-msg.assistant .jx-bubble.streaming{
@@ -509,7 +509,7 @@
 
 /* User 气泡流式状态 */
 .jx-bubble.user.streaming{
-  border-color:rgba(15,23,42,.14);
+  border-color:color-mix(in srgb, var(--color-text) 14%, transparent);
 }
 
 /* ── 流式打字光标：尾随圆点呼吸（非竖线闪烁——markdown 全量重渲染会重置相位，
@@ -542,7 +542,7 @@
 .jx-msgContent::selection,
 .jx-msgContent *::selection{
   background:rgba(148,163,184,.30);
-  color:#0f172a;
+  color:var(--color-text);
 }
 .jx-streamingIndicator{
   display:inline-flex;
@@ -614,7 +614,7 @@
   align-items:center;
   gap:10px;
   padding:10px 12px;
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid rgba(203,213,225,.72);
   border-radius:14px;
   min-width:180px;
@@ -640,14 +640,14 @@
 .jx-fileCard-name{
   font-size:13px;
   font-weight:500;
-  color:#1E293B;
+  color:var(--color-text);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
 }
 .jx-fileCard-type{
   font-size:11px;
-  color:#6B7280;
+  color:var(--color-text-secondary);
   margin-top:2px;
 }
 .jx-fileCard-close{
@@ -657,9 +657,9 @@
   width:20px;
   height:20px;
   background:#374151;
-  border:2px solid #fff;
+  border:2px solid var(--color-bg-container);
   border-radius:50%;
-  color:#fff;
+  color:var(--color-text-white);
   display:flex;
   align-items:center;
   justify-content:center;
@@ -679,7 +679,7 @@ a.jx-fileCard--link{
 }
 a.jx-fileCard--link:hover{
   box-shadow:0 10px 24px rgba(15,23,42,.08);
-  border-color:#cbd5e1;
+  border-color:var(--color-fill);
   transform:translateY(-1px);
 }
 /* Image thumbnail inside file card */
@@ -692,7 +692,7 @@ a.jx-fileCard--link:hover{
 }
 .jx-fileCard-dlIcon{
   font-size:13px;
-  color:#94A3B8;
+  color:var(--color-text-placeholder);
   flex-shrink:0;
   margin-left:2px;
 }
@@ -711,18 +711,18 @@ a.jx-fileCard--link:hover{
   min-height:52px;
   margin-bottom:10px;
   padding:9px 10px 9px 13px;
-  border:1px solid rgba(15,23,42,.10);
+  border:1px solid color-mix(in srgb, var(--color-text) 10%, transparent);
   border-radius:14px;
-  background:#fff;
+  background:var(--color-bg-container);
   box-shadow:0 5px 18px rgba(15,23,42,.055);
 }
 .jx-queuedMessage--steering{
-  border-color:rgba(51,65,85,.22);
-  background:#fff;
+  border-color:color-mix(in srgb, var(--color-text-secondary) 22%, transparent);
+  background:var(--color-bg-container);
 }
 .jx-queuedMessage--applied{
   border-color:rgba(34,197,94,.20);
-  background:#fff;
+  background:var(--color-bg-container);
 }
 .jx-queuedMessage-main{
   display:flex;
@@ -733,13 +733,13 @@ a.jx-fileCard--link:hover{
 }
 .jx-queuedMessage-indicator{
   flex-shrink:0;
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   font-size:18px;
   line-height:1.45;
 }
 .jx-queuedMessage-content{
   min-width:0;
-  color:#1e293b;
+  color:var(--color-text);
   font-size:14px;
   line-height:1.45;
   display:-webkit-box;
@@ -753,11 +753,11 @@ a.jx-fileCard--link:hover{
   flex:1;
   min-width:0;
   resize:vertical;
-  border:1px solid rgba(51,65,85,.28);
+  border:1px solid color-mix(in srgb, var(--color-text-secondary) 28%, transparent);
   border-radius:9px;
   padding:7px 9px;
-  background:#fff;
-  color:#1e293b;
+  background:var(--color-bg-container);
+  color:var(--color-text);
   font:inherit;
   font-size:14px;
   line-height:1.45;
@@ -785,13 +785,13 @@ a.jx-fileCard--link:hover{
   min-height:30px;
   padding:0 11px;
   border-radius:9px;
-  background:#f1f5f9;
-  color:#1f2937;
+  background:var(--color-fill-hover);
+  color:var(--color-text);
   font-size:13px;
   font-weight:650;
 }
 .jx-queuedMessage-steer:hover:not(:disabled){
-  background:#e2e8f0;
+  background:var(--color-fill);
 }
 .jx-queuedMessage-steer:active:not(:disabled),
 .jx-queuedMessage-iconBtn:active:not(:disabled){
@@ -814,11 +814,11 @@ a.jx-fileCard--link:hover{
   padding:0;
   border-radius:9px;
   background:transparent;
-  color:#64748b;
+  color:var(--color-text-tertiary);
 }
 .jx-queuedMessage-iconBtn:hover:not(:disabled){
-  background:#f1f5f9;
-  color:#1e293b;
+  background:var(--color-fill-hover);
+  color:var(--color-text);
 }
 .jx-queuedMessage-iconBtn:disabled{
   cursor:not-allowed;
@@ -861,7 +861,7 @@ a.jx-fileCard--link:hover{
 .jx-inputQuoteText{
   min-width:0;
   flex:1;
-  color:#334155;
+  color:var(--color-text);
   font-size:13px;
   line-height:1.45;
   display:-webkit-box;
@@ -873,7 +873,7 @@ a.jx-fileCard--link:hover{
   appearance:none;
   border:none;
   background:transparent;
-  color:#94a3b8;
+  color:var(--color-text-placeholder);
   width:22px;
   height:22px;
   border-radius:999px;
@@ -887,7 +887,7 @@ a.jx-fileCard--link:hover{
 }
 .jx-inputQuoteRemove:hover{
   background:rgba(148,163,184,.12);
-  color:#475569;
+  color:var(--color-text-secondary);
 }
 /* 用户消息中文件卡片靠右对齐 */
 .jx-userAttachments{
@@ -913,7 +913,7 @@ a.jx-fileCard--link:hover{
   gap:4px;
   height:50px;
   padding:8px 12px 12px;
-  background:#fff;
+  background:var(--color-bg-container);
   border-bottom-left-radius:16px;
   border-bottom-right-radius:16px;
   pointer-events:none;
@@ -926,7 +926,7 @@ a.jx-fileCard--link:hover{
   right:0;
   top:-12px;
   height:12px;
-  background:linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
+  background:linear-gradient(to bottom, transparent 0%, var(--color-bg-container) 100%);
   pointer-events:none;
 }
 .jx-composerBar > *{
@@ -966,12 +966,12 @@ a.jx-fileCard--link:hover{
    会把输入框底部切成生硬的控件条，chip 化之后整条工具栏读起来是一个整体。*/
 .jx-composerBar{
   --jx-chip-h:28px;
-  --jx-chip-fg:rgba(15,23,42,.60);
-  --jx-chip-fg-strong:rgba(15,23,42,.88);
-  --jx-chip-hover:rgba(15,23,42,.055);
-  --jx-chip-active-bg:rgba(18,109,255,.10);
-  --jx-chip-active-hover:rgba(18,109,255,.16);
-  --jx-chip-active-fg:#0B57D0;
+  --jx-chip-fg:color-mix(in srgb, var(--color-text) 60%, transparent);
+  --jx-chip-fg-strong:color-mix(in srgb, var(--color-text) 88%, transparent);
+  --jx-chip-hover:color-mix(in srgb, var(--color-text) 5.5%, transparent);
+  --jx-chip-active-bg:color-mix(in srgb, var(--color-primary) 10%, transparent);
+  --jx-chip-active-hover:color-mix(in srgb, var(--color-primary) 16%, transparent);
+  --jx-chip-active-fg:var(--color-primary-active);
 }
 .jx-composerChip{
   appearance:none;
@@ -987,7 +987,7 @@ a.jx-fileCard--link:hover{
   border:none;
   border-radius:999px;
   background:transparent;
-  color:var(--jx-chip-fg, rgba(15,23,42,.60));
+  color:var(--jx-chip-fg, color-mix(in srgb, var(--color-text) 60%, transparent));
   font-size:13px;
   line-height:20px;
   font-weight:500;
@@ -1005,7 +1005,7 @@ a.jx-fileCard--link:hover{
 .jx-composerChip:hover,
 .jx-composerChip.open{
   background:var(--jx-chip-hover, rgba(15,23,42,.055));
-  color:var(--jx-chip-fg-strong, rgba(15,23,42,.88));
+  color:var(--jx-chip-fg-strong, color-mix(in srgb, var(--color-text) 88%, transparent));
 }
 .jx-composerChip:focus-visible{
   box-shadow:0 0 0 2px rgba(18,109,255,.28);
@@ -1016,13 +1016,13 @@ a.jx-fileCard--link:hover{
 .jx-composerChip.active,
 .jx-composerChip.bound{
   background:var(--jx-chip-active-bg, rgba(18,109,255,.10));
-  color:var(--jx-chip-active-fg, #0B57D0);
+  color:var(--jx-chip-active-fg, var(--color-primary-active));
 }
 .jx-composerChip.active:hover,
 .jx-composerChip.bound:hover,
 .jx-composerChip.bound.open{
   background:var(--jx-chip-active-hover, rgba(18,109,255,.16));
-  color:var(--jx-chip-active-fg, #0B57D0);
+  color:var(--jx-chip-active-fg, var(--color-primary-active));
 }
 
 /* 箭头跟随 chip 文字色（inline SVG，currentColor），展开时翻转 180° ——
@@ -1037,14 +1037,14 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   min-height:30px;
   height:30px;
   padding:7px 12px;
-  border:1px solid #E3E6EA;
+  border:1px solid var(--color-border);
   border-radius:8px;
   background:transparent;
   display:flex;
   align-items:center;
   gap:5px;
   cursor:pointer;
-  color:rgba(15,23,42,.62);
+  color:color-mix(in srgb, var(--color-text) 62%, transparent);
   font-size:13px;
   font-weight:500;
   outline:none;
@@ -1052,7 +1052,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   transition:border-color .18s ease;
 }
 .jx-dispatchDropBtn:hover{
-  border-color:rgba(15,23,42,.22);
+  border-color:color-mix(in srgb, var(--color-text) 22%, transparent);
 }
 .jx-dispatchOptionHead{
   display:flex;
@@ -1082,7 +1082,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   transition:background-color .14s ease;
 }
 .jx-attachBtn:hover,
-.jx-attachBtn.open{ background:rgba(15,23,42,.11); }
+.jx-attachBtn.open{ background:color-mix(in srgb, var(--color-text) 11%, transparent); }
 .jx-attachIcon{
   width:16px;
   height:16px;
@@ -1092,6 +1092,10 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 }
 .jx-attachBtn:hover .jx-attachIcon,
 .jx-attachBtn.open .jx-attachIcon{ opacity:1; }
+/* 图标是 SVG 资产靠 filter 上色（基础滤镜压成近黑），深色下反转为浅色 */
+:root[data-theme='dark'] .jx-attachIcon{
+  filter:brightness(0) saturate(100%) invert(92%);
+}
 
 /* ── 模型 + 思考强度位（工具条右侧，两级菜单）── */
 .jx-modelEffort{ position:relative; min-width:0; flex-shrink:1; }
@@ -1099,18 +1103,18 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 /* 思考强度贴在模型名右侧，弱一档：一个 chip 报两件事，主次要分得开 */
 .jx-modelEffortAside{
   flex:0 0 auto;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   font-weight:400;
 }
-.jx-composerChip.open .jx-modelEffortAside{ color:rgba(15,23,42,.55); }
+.jx-composerChip.open .jx-modelEffortAside{ color:color-mix(in srgb, var(--color-text) 55%, transparent); }
 /* 极速模式下没有可挑的模型/强度时的只读占位：不给 hover 反馈，别装成能点 */
 .jx-modelEffortStatic{
   cursor:default;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   font-weight:400;
 }
-.jx-modelEffortStatic:hover{ background:transparent; color:rgba(15,23,42,.42); }
-.jx-modelEffortStaticIcon{ font-size:13px; color:var(--color-warning, #F8AB42); }
+.jx-modelEffortStatic:hover{ background:transparent; color:color-mix(in srgb, var(--color-text) 42%, transparent); }
+.jx-modelEffortStaticIcon{ font-size:13px; color:var(--color-warning, var(--color-warning)); }
 .jx-modelEffortMenu{
   position:absolute;
   right:0;
@@ -1122,9 +1126,9 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   max-height:min(360px, 60vh);
   overflow:hidden;
   padding:4px;
-  border:1px solid rgba(15,23,42,.06);
+  border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   border-radius:14px;
-  background:#fff;
+  background:var(--color-bg-container);
   box-shadow:0 12px 32px rgba(15,23,42,.12), 0 2px 6px rgba(15,23,42,.05);
 }
 /* 一级 cell：左标签 + 右当前值 + 右尖角，一行说清"这是什么、现在是什么" */
@@ -1139,7 +1143,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   border:none;
   border-radius:10px;
   background:transparent;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   font-size:14px;
   line-height:22px;
   text-align:left;
@@ -1147,7 +1151,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   transition:background-color .12s ease;
 }
 .jx-menuCell:hover:not(:disabled){ background:rgba(15,23,42,.05); }
-.jx-menuCell:disabled{ cursor:default; color:rgba(15,23,42,.35); }
+.jx-menuCell:disabled{ cursor:default; color:color-mix(in srgb, var(--color-text) 35%, transparent); }
 .jx-menuCell-label{ flex:1 1 auto; min-width:0; white-space:nowrap; }
 .jx-menuCell-value{
   flex:0 1 auto;
@@ -1155,9 +1159,9 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
 }
-.jx-menuCell-chevron{ flex:0 0 auto; font-size:11px; color:rgba(15,23,42,.35); }
+.jx-menuCell-chevron{ flex:0 0 auto; font-size:11px; color:color-mix(in srgb, var(--color-text) 35%, transparent); }
 /* 二级返回行：尖角左转，读起来是"退回上一层" */
 .jx-menuBack{
   appearance:none;
@@ -1168,7 +1172,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   padding:6px 10px 5px;
   border:none;
   background:transparent;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   font-size:12px;
   line-height:18px;
   font-weight:500;
@@ -1176,12 +1180,12 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   cursor:pointer;
   border-radius:8px;
 }
-.jx-menuBack:hover{ background:rgba(15,23,42,.04); color:rgba(15,23,42,.7); }
+.jx-menuBack:hover{ background:rgba(15,23,42,.04); color:color-mix(in srgb, var(--color-text) 70%, transparent); }
 .jx-menuBack-chevron{ font-size:10px; transform:rotate(180deg); }
 /* 单层形态（没有可退回的上一级）：同一行位置改成纯标题，不做成可点的返回 */
 .jx-menuPaneTitle{
   padding:7px 10px 4px;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   font-size:12px;
   line-height:18px;
   font-weight:500;
@@ -1215,7 +1219,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   font-size:14px;
   line-height:20px;
   font-weight:500;
-  color:#1e293b;
+  color:var(--color-text);
 }
 .jx-menuOption-desc{
   overflow:hidden;
@@ -1223,7 +1227,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   white-space:nowrap;
   font-size:12px;
   line-height:18px;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
 }
 
 /* ── Context-usage ring (beside the model selector) ── */
@@ -1244,19 +1248,19 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   display:block;
   transform:rotate(-90deg); /* start the arc at 12 o'clock */
 }
-.jx-ctxGauge-track{ stroke:#E9ECF1; }
+.jx-ctxGauge-track{ stroke:var(--color-border); }
 .jx-ctxGauge-fill{
-  stroke:var(--color-success, #02B589);
+  stroke:var(--color-success, var(--color-success));
   transition:stroke-dasharray .35s ease, stroke .25s ease;
 }
-.jx-ctxGauge[data-level="warn"] .jx-ctxGauge-fill{ stroke:var(--color-warning, #F8AB42); }
-.jx-ctxGauge[data-level="high"] .jx-ctxGauge-fill{ stroke:var(--color-error, #FC5D5D); }
+.jx-ctxGauge[data-level="warn"] .jx-ctxGauge-fill{ stroke:var(--color-warning, var(--color-warning)); }
+.jx-ctxGauge[data-level="high"] .jx-ctxGauge-fill{ stroke:var(--color-error, var(--color-error)); }
 
 /* ── Context-usage hover breakdown ── */
 .jx-ctxPop{
   width:250px;
   font-size:13px;
-  color:var(--color-text-secondary, #4D4D4D);
+  color:var(--color-text-secondary, var(--color-text-secondary));
 }
 .jx-ctxPop-head{
   display:flex;
@@ -1268,11 +1272,11 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 .jx-ctxPop-title{
   font-size:13px;
   font-weight:600;
-  color:var(--color-text, #262626);
+  color:var(--color-text, var(--color-text));
 }
 .jx-ctxPop-model{
   font-size:12px;
-  color:var(--color-text-tertiary, #808080);
+  color:var(--color-text-tertiary, var(--color-text-tertiary));
   max-width:132px;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -1288,14 +1292,14 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   font-size:22px;
   font-weight:700;
   line-height:1;
-  color:var(--color-success, #02B589);
+  color:var(--color-success, var(--color-success));
   font-variant-numeric:tabular-nums;
 }
-.jx-ctxPop-big[data-level="warn"]{ color:var(--color-warning, #F8AB42); }
-.jx-ctxPop-big[data-level="high"]{ color:var(--color-error, #FC5D5D); }
+.jx-ctxPop-big[data-level="warn"]{ color:var(--color-warning, var(--color-warning)); }
+.jx-ctxPop-big[data-level="high"]{ color:var(--color-error, var(--color-error)); }
 .jx-ctxPop-frac{
   font-size:12px;
-  color:var(--color-text-tertiary, #808080);
+  color:var(--color-text-tertiary, var(--color-text-tertiary));
   font-variant-numeric:tabular-nums;
 }
 .jx-ctxPop-bar{
@@ -1303,7 +1307,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   height:8px;
   border-radius:999px;
   overflow:hidden;
-  background:#EEF1F5;
+  background:var(--color-fill-hover);
   margin-bottom:12px;
 }
 .jx-ctxPop-seg{ height:100%; }
@@ -1325,23 +1329,23 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 }
 .jx-ctxPop-label{
   flex:1;
-  color:var(--color-text-secondary, #4D4D4D);
+  color:var(--color-text-secondary, var(--color-text-secondary));
 }
 .jx-ctxPop-val{
   font-variant-numeric:tabular-nums;
-  color:var(--color-text, #262626);
+  color:var(--color-text, var(--color-text));
   font-weight:500;
 }
 .jx-ctxPop-share{
   width:38px;
   text-align:right;
-  color:var(--color-text-tertiary, #808080);
+  color:var(--color-text-tertiary, var(--color-text-tertiary));
   font-variant-numeric:tabular-nums;
 }
 .jx-ctxPop-note{
   margin-top:10px;
   font-size:11px;
-  color:var(--color-text-placeholder, #B3B3B3);
+  color:var(--color-text-placeholder, var(--color-text-placeholder));
 }
 
 /* ── 项目选择下拉（工具栏，提示词中心右侧）──
@@ -1373,7 +1377,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 }
 .jx-projectOptionIcon{
   font-size:15px;
-  color:rgba(15,23,42,.5);
+  color:color-mix(in srgb, var(--color-text) 50%, transparent);
   flex-shrink:0;
 }
 .jx-projectOptionName{
@@ -1383,7 +1387,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   text-overflow:ellipsis;
   white-space:nowrap;
   font-size:14px;
-  color:#1e293b;
+  color:var(--color-text);
 }
 
 /* ── Send button (SVG is already a 34px blue circle) ── */
@@ -1413,7 +1417,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 .jx-attachMenu .ant-dropdown-menu{
   padding:4px;
   border-radius:14px;
-  border:1px solid rgba(15,23,42,.06);
+  border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   box-shadow:0 12px 32px rgba(15,23,42,.12), 0 2px 6px rgba(15,23,42,.05);
   min-width:220px;
 }
@@ -1422,7 +1426,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   min-height:auto;
   border-radius:10px;
   font-size:14px;
-  color:rgba(15,23,42,.82);
+  color:color-mix(in srgb, var(--color-text) 82%, transparent);
   padding:7px 10px;
   transition:background-color .12s ease;
 }
@@ -1431,12 +1435,12 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 .jx-projectMenu .ant-dropdown-menu-item:hover,
 .jx-projectMenu .ant-dropdown-menu-item-active{
   background:rgba(15,23,42,.05) !important;
-  color:#111827;
+  color:var(--color-text);
 }
 .jx-modeMenu .ant-dropdown-menu-item-selected,
 .jx-projectMenu .ant-dropdown-menu-item-selected{
   background:transparent !important;
-  color:#111827;
+  color:var(--color-text);
 }
 /* 分组标题：比选项小一号、弱一档，只做分区不抢视线 */
 .jx-modeMenu .ant-dropdown-menu-item-group-title,
@@ -1445,7 +1449,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   font-size:12px;
   line-height:18px;
   font-weight:500;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
 }
 /* 四段选择器：antd v5 自己的分隔线规则是 `.ant-dropdown .ant-dropdown-menu
    .ant-dropdown-menu-item-divider`（0,3,0），两段写法压不过它 */
@@ -1477,7 +1481,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   font-weight:500;
   font-size:14px;
   line-height:20px;
-  color:#1e293b;
+  color:var(--color-text);
 }
 .jx-modeCheckIcon{ width:14px; height:14px; flex-shrink:0; }
 .jx-modeOptionDesc{
@@ -1486,7 +1490,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   white-space:nowrap;
   font-size:12px;
   line-height:18px;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
 }
 
 /* legacy compat */
@@ -1540,14 +1544,18 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   pointer-events:none;
   user-select:none;
 }
+/* 装饰底图是浅色 PNG 资产，暗色下压暗到近隐 */
+:root[data-theme='dark'] .jx-heroBgImg{
+  opacity:.10;
+}
 .jx-heroTitle{
   position:relative; z-index:1;
-  font-size:44px; font-weight:500; color:black;
+  font-size:44px; font-weight:500; color:var(--color-text);
   margin:0 0 2px; line-height:1.2; text-align:center;
 }
 .jx-heroSubtitle{
   position:relative; z-index:1;
-  font-size:16px; font-weight:400; color:#808080;
+  font-size:16px; font-weight:400; color:var(--color-text-tertiary);
   margin:0; text-align:center;
 }
 
@@ -1561,10 +1569,10 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 }
 .jx-homeInput .jx-composerWrap{
   position:relative; width:100%; margin-bottom:0;
-  border:1px solid #99C0FF;
+  border:1px solid var(--color-primary-disabled);
   border-radius:20px;
   box-shadow:0px 2px 14px 1px rgba(102,150,227,0.15);
-  background:#fff;
+  background:var(--color-bg-container);
 }
 .jx-homeInput .jx-composer{
   width:100% !important;
@@ -1581,7 +1589,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   height:100% !important;
   padding:16px 16px 50px 16px !important;
   font-size:16px !important;
-  color:#262626 !important;
+  color:var(--color-text) !important;
   resize:none !important;
 }
 .jx-homeInput .jx-composerBar{
@@ -1589,7 +1597,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   bottom:0; left:0; right:0;
   height:50px;
   padding:8px 12px 12px;
-  background:#fff;
+  background:var(--color-bg-container);
   border-bottom-left-radius:20px;
   border-bottom-right-radius:20px;
 }
@@ -1598,7 +1606,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   position:absolute;
   left:0; right:0; top:-12px;
   height:12px;
-  background:linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
+  background:linear-gradient(to bottom, transparent 0%, var(--color-bg-container) 100%);
   pointer-events:none;
 }
 
@@ -1610,13 +1618,13 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   overflow:hidden;
 }
 .jx-quickPill{
-  appearance:none; border:none; background:#F5F6F7;
+  appearance:none; border:none; background:var(--color-bg-gray);
   border-radius:12px; height:40px; padding:0 12px;
-  font-size:14px; font-weight:400; color:#262626;
+  font-size:14px; font-weight:400; color:var(--color-text);
   cursor:pointer; transition:background .18s;
   white-space:nowrap; display:flex; align-items:center;
 }
-.jx-quickPill:hover{ background:#EBEDEE; }
+.jx-quickPill:hover{ background:var(--color-fill-hover); }
 
 /* 5 Capability cards — 60px below pills */
 .jx-capCards{
@@ -1636,7 +1644,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   padding:4px 10px;
   border-radius:10px;
   background:rgba(15,23,42,.56);
-  color:#fff;
+  color:var(--color-text-white);
   font-size:12px;
   font-weight:400;
   line-height:1.2;
@@ -1647,7 +1655,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 }
 .jx-capCard:hover .jx-capCardIcon{ transform:translateY(-2px); }
 .jx-capCardIcon{ width:56px; height:56px; transition:transform .18s; }
-.jx-capCardLabel{ font-size:14px; font-weight:400; color:black; letter-spacing:0.28px; }
+.jx-capCardLabel{ font-size:14px; font-weight:400; color:var(--color-text); letter-spacing:0.28px; }
 
 @keyframes jxCapToastFade{
   0%{ opacity:0; transform:translateX(-50%) translateY(4px); }
@@ -1658,7 +1666,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
 
 /* AI Disclaimer — at page bottom */
 .jx-aiDisclaimer{
-  font-size:12px; color:rgba(15,23,42,.35);
+  font-size:12px; color:color-mix(in srgb, var(--color-text) 35%, transparent);
   text-align:center; padding:16px 0 12px;
   flex-shrink:0; width:100%;
 }
@@ -1670,11 +1678,11 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   gap:8px;
   height:48px;
   padding:0 24px;
-  background:#EBF2FF;
+  background:var(--color-primary-light);
   border-radius:8px;
   margin:12px 16px 0;
   font-size:14px;
-  color:#262626;
+  color:var(--color-text);
   font-weight:400;
   flex-shrink:0;
 }
@@ -1686,7 +1694,7 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   flex:1;
 }
 .jx-recommendBanner-link{
-  color:#126DFF;
+  color:var(--color-primary);
   font-weight:500;
   cursor:pointer;
   margin-left:4px;
@@ -1707,12 +1715,12 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   display:flex;
   align-items:center;
   justify-content:center;
-  color:#808080;
+  color:var(--color-text-tertiary);
   transition:color .15s;
   flex-shrink:0;
 }
 .jx-recommendBanner-close:hover{
-  color:#555;
+  color:var(--color-text-secondary);
 }
 
 /* legacy — kept so nothing breaks */
@@ -1720,12 +1728,12 @@ svg.jx-modeArrow{ color:currentColor; opacity:.5; transition:transform .16s ease
   text-align:center;
   font-size:13px;
   line-height:1.9;
-  color:rgba(31,35,40,.72);
+  color:color-mix(in srgb, var(--color-text) 72%, transparent);
 }
 .jx-emptyIntro strong{color:var(--color-primary)}
 .jx-emptyGuide{
   border:1px solid rgba(18,109,255,.16);
-  background:rgba(255,255,255,.86);
+  background:color-mix(in srgb, var(--color-bg-container) 86%, transparent);
   border-radius:14px;
   padding:12px;
 }
@@ -1782,14 +1790,14 @@ textarea.jx-composer,
   padding-bottom:50px !important; /* 为底部操作栏留空间 */
   resize:none !important;
   font-size:16px !important;
-  color:#262626 !important;
+  color:var(--color-text) !important;
 }
 .jx-composer .ant-input::placeholder,
 .jx-composer textarea::placeholder,
 textarea.jx-composer::placeholder,
 .jx-composer.ant-input::placeholder{
   font-size:16px !important;
-  color:#B3B3B3 !important;
+  color:var(--color-text-placeholder) !important;
 }
 /* 隐藏 textarea 右下角 resize 把手 */
 .jx-composer textarea,
@@ -1814,10 +1822,10 @@ textarea.jx-composer{
   align-items:center;
   gap:8px;
   padding:6px 12px;
-  background:#F6F8FB;
-  border-bottom:1px solid #ECEFF3;
+  background:var(--color-bg-layout);
+  border-bottom:1px solid var(--color-border);
   font-size:12px;
-  color:#5A6477;
+  color:var(--color-text-secondary);
 }
 .jx-chatShareBanner--owner{
   justify-content:flex-end;
@@ -1826,15 +1834,15 @@ textarea.jx-composer{
   flex:1 1 auto;
 }
 .jx-chatShareBanner-owner{
-  color:#7C8595;
+  color:var(--color-text-tertiary);
 }
 .jx-chatShareReadonly{
   padding:14px 16px;
   margin-top:8px;
   text-align:center;
-  background:#F6F8FB;
-  color:#7C8595;
-  border:1px dashed #DADFE7;
+  background:var(--color-bg-layout);
+  color:var(--color-text-tertiary);
+  border:1px dashed var(--color-border);
   border-radius:8px;
   font-size:13px;
 }
@@ -1845,10 +1853,10 @@ textarea.jx-composer{
   align-items:center;
   gap:8px;
   padding:6px 12px;
-  background:var(--color-primary-light, #EBF2FF);
-  border-bottom:1px solid var(--color-border, #E3E6EA);
+  background:var(--color-primary-light, var(--color-primary-light));
+  border-bottom:1px solid var(--color-border, var(--color-border));
   font-size:12px;
-  color:var(--color-text-tertiary, #808080);
+  color:var(--color-text-tertiary, var(--color-text-tertiary));
 }
 .jx-compactionNotice-text{
   flex:1 1 auto;
@@ -1861,12 +1869,12 @@ textarea.jx-composer{
   font-size:14px;
   line-height:1;
   padding:2px 6px;
-  color:var(--color-text-tertiary, #808080);
+  color:var(--color-text-tertiary, var(--color-text-tertiary));
   border-radius:var(--radius-xs, 4px);
 }
 .jx-compactionNotice-close:hover{
-  background:var(--color-primary-bg, #DBE9FF);
-  color:var(--color-text-secondary, #4D4D4D);
+  background:var(--color-primary-bg, var(--color-primary-bg));
+  color:var(--color-text-secondary, var(--color-text-secondary));
 }
 
 .jx-chatFooter{
@@ -1877,7 +1885,7 @@ textarea.jx-composer{
   display:flex;
   flex-direction:column;
   /* 实色背景防止滚动内容从底部透出；顶部渐变见 ::before */
-  background:#fff;
+  background:var(--color-bg-container);
 }
 .jx-inputArea{
   position:relative;
@@ -1896,7 +1904,7 @@ textarea.jx-composer{
   top:-24px;
   height:24px;
   pointer-events:none;
-  background:linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
+  background:linear-gradient(to bottom, transparent 0%, var(--color-bg-container) 100%);
 }
 /* In empty state, input width matches design */
 .jx-emptyWrap .jx-inputArea,
@@ -1915,9 +1923,9 @@ textarea.jx-composer{
 .jx-composerWrap{
   position:relative;
   margin-bottom:10px;
-  border:1px solid rgba(15,23,42,.12);
+  border:1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
   border-radius:16px;
-  background:#fff;
+  background:var(--color-bg-container);
   transition:border-color var(--motion-duration-fast) var(--motion-ease-standard),
              box-shadow var(--motion-duration-normal) var(--motion-ease-standard);
 }
@@ -1948,8 +1956,8 @@ textarea.jx-composer{
   width:36px;
   height:36px;
   border-radius:50%;
-  border:1px solid rgba(15,23,42,.12);
-  background:#fff;
+  border:1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
+  background:var(--color-bg-container);
   box-shadow:0 4px 14px rgba(15,23,42,.10);
   cursor:pointer;
   display:flex;
@@ -1961,8 +1969,8 @@ textarea.jx-composer{
   /* 出入场由 motion（AnimatePresence）接管，CSS 不再播入场，防双播 */
 }
 .jx-scrollToBottomBtn:hover{
-  background:#f8fafc;
-  border-color:rgba(15,23,42,.22);
+  background:var(--color-bg-layout);
+  border-color:color-mix(in srgb, var(--color-text) 22%, transparent);
   box-shadow:0 6px 16px rgba(15,23,42,.14);
 }
 .jx-scrollToBottomIcon{
@@ -1986,8 +1994,8 @@ textarea.jx-composer{
   display:inline-flex;align-items:center;gap:8px;
   padding:7px 10px;border-radius:999px;
   border:1px solid rgba(17,24,39,.10);
-  background:rgba(255,255,255,.85);
-  color:rgba(31,35,40,.74);
+  background:color-mix(in srgb, var(--color-bg-container) 85%, transparent);
+  color:color-mix(in srgb, var(--color-text) 74%, transparent);
   font-size:12px; font-weight:700;
   outline:none;
   box-shadow:none;
@@ -2024,7 +2032,7 @@ textarea.jx-composer{
   padding:0 10px;
   font-size:12px;
   font-weight:400;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
   letter-spacing:0.03em;
 }
 .jx-historyGroupList{
@@ -2035,7 +2043,7 @@ textarea.jx-composer{
 .jx-historyEmpty{
   padding:24px 8px;
   font-size:12px;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   text-align:center;
 }
 .jx-historyItem{
@@ -2053,11 +2061,11 @@ textarea.jx-composer{
   position:relative;
 }
 .jx-historyItem:hover{
-  background:#EBEDEE;
+  background:var(--color-fill-hover);
   border-color:transparent;
 }
 .jx-historyItem.active{
-  background:#fff;
+  background:var(--color-bg-container);
   border-color:transparent;
 }
 .jx-historyMain{
@@ -2072,18 +2080,18 @@ textarea.jx-composer{
   min-width:0;
   font-size:14px;
   font-weight:500;
-  color:rgba(15,23,42,.76);
+  color:color-mix(in srgb, var(--color-text) 76%, transparent);
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
   line-height:1.2;
 }
 .jx-historyItem:hover .jx-historyTitle{
-  color:rgba(15,23,42,.90);
+  color:color-mix(in srgb, var(--color-text) 90%, transparent);
 }
 .jx-historyItem.active .jx-historyTitle{
   font-weight:400;
-  color:#0f172a;
+  color:var(--color-text);
 }
 .jx-historyEditInput{
   flex:1;
@@ -2134,13 +2142,13 @@ textarea.jx-composer{
   display:flex; align-items:center; justify-content:center;
   cursor:pointer;
   font-size:13px;
-  color:rgba(15,23,42,.48);
+  color:color-mix(in srgb, var(--color-text) 48%, transparent);
   padding:0;
   transition:background .15s ease, color .15s ease;
 }
 .jx-historyMoreBtn:hover{
-  background:#F0F2F5;
-  color:#333;
+  background:var(--color-fill-hover);
+  color:var(--color-text);
 }
 
 
@@ -2161,7 +2169,7 @@ textarea.jx-composer{
   padding:8px 14px;
   border:1px solid var(--color-border);
   border-radius:20px;
-  background:#fff;
+  background:var(--color-bg-container);
   color:var(--color-text);
   font-size:14px;
   line-height:1.5;
@@ -2177,7 +2185,7 @@ textarea.jx-composer{
   background:#f0f5ff;
 }
 .jx-followUpBtn:active{
-  background:#e6f0ff;
+  background:var(--color-primary-light);
 }
 .jx-followUpBtn:disabled{
   opacity:.5;
@@ -2191,7 +2199,7 @@ textarea.jx-composer{
 .jx-followUpArrow{
   flex-shrink:0;
   font-size:14px;
-  color:#999;
+  color:var(--color-text-placeholder);
   transition:color .2s ease;
 }
 .jx-followUpBtn:hover .jx-followUpArrow{
@@ -2238,7 +2246,7 @@ textarea.jx-composer{
   display:inline-flex;
   align-items:center;
   font-size:12px;
-  color:rgba(31,35,40,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
   margin-right:2px;
   white-space:nowrap;
   user-select:none;
@@ -2249,7 +2257,7 @@ textarea.jx-composer{
   align-items:center;
   flex:0 0 auto;
   font-size:11px;
-  color:rgba(31,35,40,.34);
+  color:color-mix(in srgb, var(--color-text) 34%, transparent);
   white-space:nowrap;
   user-select:none;
 }
@@ -2260,10 +2268,10 @@ textarea.jx-composer{
   width:28px;
   height:28px;
   border-radius:7px;
-  border:1px solid rgba(15,23,42,.10);
-  background:rgba(255,255,255,.85);
+  border:1px solid color-mix(in srgb, var(--color-text) 10%, transparent);
+  background:color-mix(in srgb, var(--color-bg-container) 85%, transparent);
   backdrop-filter:blur(4px);
-  color:rgba(31,35,40,.50);
+  color:color-mix(in srgb, var(--color-text) 50%, transparent);
   font-size:13px;
   cursor:pointer;
   transition:all .15s ease;
@@ -2271,9 +2279,9 @@ textarea.jx-composer{
   padding:0;
 }
 .jx-msgActionBtn:hover{
-  color:rgba(31,35,40,.85);
-  background:#fff;
-  border-color:rgba(15,23,42,.18);
+  color:color-mix(in srgb, var(--color-text) 85%, transparent);
+  background:var(--color-bg-container);
+  border-color:color-mix(in srgb, var(--color-text) 18%, transparent);
   box-shadow:0 2px 8px rgba(15,23,42,.08);
 }
 .jx-msgActionBtn.copied{
@@ -2292,7 +2300,7 @@ textarea.jx-composer{
   background:rgba(252,93,93,.06);
 }
 .jx-msgActionBtn.active-share{
-  color:#126dff;
+  color:var(--color-primary);
   border-color:rgba(18,109,255,.30);
   background:rgba(18,109,255,.06);
 }
@@ -2304,9 +2312,9 @@ textarea.jx-composer{
   align-items:center;
   gap:3px;
   padding:5px;
-  border:1px solid rgba(148,163,184,.18);
+  border:1px solid color-mix(in srgb, var(--color-text-placeholder) 18%, transparent);
   border-radius:14px;
-  background:rgba(255,255,255,.96);
+  background:color-mix(in srgb, var(--color-bg-container) 96%, transparent);
   box-shadow:0 10px 24px rgba(15,23,42,.10);
   backdrop-filter:blur(10px);
   /* 入场动画必须纯 CSS（portal + fixed，motion transform 祖先会破坏定位）；
@@ -2328,13 +2336,13 @@ textarea.jx-composer{
   align-items:center;
   justify-content:center;
   gap:6px;
-  color:#64748b;
+  color:var(--color-text-tertiary);
   cursor:pointer;
   transition:background .16s ease, color .16s ease, transform .16s ease;
 }
 .jx-selectionToolbarBtn:hover{
   background:rgba(148,163,184,.08);
-  color:#475569;
+  color:var(--color-text-secondary);
   transform:translateY(-1px);
 }
 .jx-selectionToolbarBtn.copied{
@@ -2355,8 +2363,8 @@ textarea.jx-composer{
 .jx-dislikeFeedback{
   margin-top:8px;
   padding:12px 14px;
-  background:#fff;
-  border:1px solid rgba(15,23,42,.12);
+  background:var(--color-bg-container);
+  border:1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
   border-radius:10px;
   box-shadow:0 4px 16px rgba(15,23,42,.08);
   max-width:480px;
@@ -2364,7 +2372,7 @@ textarea.jx-composer{
 .jx-dislikeFeedback-title{
   font-size:13px;
   font-weight:600;
-  color:#1e293b;
+  color:var(--color-text);
   margin:0 0 8px 0;
 }
 .jx-dislikeFeedback-input{
@@ -2469,9 +2477,9 @@ textarea.jx-composer{
    不该比输入的内容还响。就地改写 chip 的三个 active 变量即可，.jx-composerChip.active
    仍读同一组变量，不用逐条覆盖；✕ 走 currentColor，会跟着一起变灰。 */
 .jx-modeChip{
-  --jx-chip-active-bg:rgba(15,23,42,.06);
-  --jx-chip-active-hover:rgba(15,23,42,.085);
-  --jx-chip-active-fg:rgba(15,23,42,.72);
+  --jx-chip-active-bg:color-mix(in srgb, var(--color-text) 6%, transparent);
+  --jx-chip-active-hover:color-mix(in srgb, var(--color-text) 8.5%, transparent);
+  --jx-chip-active-fg:color-mix(in srgb, var(--color-text) 72%, transparent);
 }
 /* 模式 chip 是纯状态显示（span，不可点），hover 不该有"能按"的假反馈 */
 .jx-modeChip:hover{
@@ -2516,7 +2524,7 @@ textarea.jx-composer{
 .jx-modeChip-close:focus-visible{ opacity:.75; }
 /* 只提亮，不给底色——✕ 本身不该长出一个"按钮"来 */
 .jx-modeChip-close:hover{ opacity:1; }
-.jx-modeChip-close:focus-visible{ outline:1px solid rgba(15,23,42,.35); outline-offset:1px; }
+.jx-modeChip-close:focus-visible{ outline:1px solid color-mix(in srgb, var(--color-text) 35%, transparent); outline-offset:1px; }
 /* 触屏没有 hover 可依赖 */
 @media (pointer:coarse){
   .jx-modeChip-close{ opacity:.5; }
@@ -2538,7 +2546,7 @@ textarea.jx-composer{
   padding:0 14px;
   border:1px solid var(--color-border);
   border-radius:8px;
-  background:#fff;
+  background:var(--color-bg-container);
   color:var(--color-text-secondary);
   font-size:13px;
   font-weight:500;
@@ -2574,8 +2582,8 @@ textarea.jx-composer{
 }
 .jx-promptHub-header{
   padding:14px 16px 12px;
-  border-bottom:1px solid rgba(15,23,42,.07);
-  background:#fff;
+  border-bottom:1px solid color-mix(in srgb, var(--color-text) 7%, transparent);
+  background:var(--color-bg-container);
   flex-shrink:0;
   display:flex;
   flex-direction:column;
@@ -2589,7 +2597,7 @@ textarea.jx-composer{
 .jx-promptHub-title{
   font-size:15px;
   font-weight:700;
-  color:#1e293b;
+  color:var(--color-text);
 }
 .jx-promptHub-search{
   border-radius:8px !important;
@@ -2608,20 +2616,20 @@ textarea.jx-composer{
 .jx-promptHub-empty{
   text-align:center;
   padding:40px 0;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   font-size:13px;
 }
 .jx-promptHub-card{
   padding:12px 14px;
   border-radius:10px;
-  border:1px solid rgba(15,23,42,.08);
+  border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   background:#f8f9fa;
   cursor:pointer;
   transition:all .18s ease;
 }
 .jx-promptHub-card:hover{
   border-color:rgba(18,109,255,.25);
-  background:#f0f7ff;
+  background:var(--color-primary-light);
   box-shadow:0 2px 8px rgba(18,109,255,.08);
 }
 .jx-promptHub-card.selected{
@@ -2631,12 +2639,12 @@ textarea.jx-composer{
 .jx-promptHub-cardTitle{
   font-size:14px;
   font-weight:600;
-  color:#1e293b;
+  color:var(--color-text);
   margin-bottom:6px;
 }
 .jx-promptHub-cardContent{
   font-size:13px;
-  color:rgba(15,23,42,.55);
+  color:color-mix(in srgb, var(--color-text) 55%, transparent);
   line-height:1.6;
   display:-webkit-box;
   -webkit-line-clamp:4;
@@ -2655,7 +2663,7 @@ textarea.jx-composer{
 }
 .jx-promptHub-card--skeleton:hover{
   background:#f8f9fa;
-  border-color:rgba(15,23,42,.08);
+  border-color:color-mix(in srgb, var(--color-text) 8%, transparent);
   box-shadow:none;
 }
 .jx-promptHub-skTitle{
@@ -2699,14 +2707,14 @@ textarea.jx-composer{
     max(14px, env(safe-area-inset-left));
   background:
     radial-gradient(circle at top, rgba(18,109,255,.08), transparent 34%),
-    linear-gradient(180deg, #f8fbff 0%, #ffffff 42%, #f8fafc 100%);
+    linear-gradient(180deg, #f8fbff 0%, #ffffff 42%, var(--color-bg-layout) 100%);
   -webkit-text-size-adjust:100%;
 }
 .jx-shareCard{
   width:min(920px, 100%);
   margin:0 auto;
-  background:rgba(255,255,255,.92);
-  border:1px solid rgba(15,23,42,.04);
+  background:color-mix(in srgb, var(--color-bg-container) 92%, transparent);
+  border:1px solid color-mix(in srgb, var(--color-text) 4%, transparent);
   border-radius:14px;
   box-shadow:0 24px 60px rgba(15,23,42,.08);
   padding:32px;
@@ -2726,20 +2734,20 @@ textarea.jx-composer{
   justify-content:center;
   text-align:center;
   gap:12px;
-  color:#334155;
+  color:var(--color-text);
 }
 .jx-shareStateTitle{
   font-size:28px;
   font-weight:700;
-  color:#0f172a;
+  color:var(--color-text);
 }
 .jx-shareStateDesc{
   font-size:15px;
-  color:rgba(15,23,42,.56);
+  color:color-mix(in srgb, var(--color-text) 56%, transparent);
 }
 .jx-shareHeader{
   padding-bottom:24px;
-  border-bottom:1px solid rgba(15,23,42,.04);
+  border-bottom:1px solid color-mix(in srgb, var(--color-text) 4%, transparent);
 }
 .jx-shareHeaderTop{
   display:flex;
@@ -2776,14 +2784,14 @@ textarea.jx-composer{
 .jx-shareEyebrow{
   font-size:13px;
   letter-spacing:.01em;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   font-weight:500;
 }
 .jx-sharePrintBtn{
   appearance:none;
-  border:1px solid rgba(15,23,42,.10);
-  background:#fff;
-  color:#334155;
+  border:1px solid color-mix(in srgb, var(--color-text) 10%, transparent);
+  background:var(--color-bg-container);
+  color:var(--color-text);
   border-radius:10px;
   height:36px;
   padding:0 14px;
@@ -2793,14 +2801,14 @@ textarea.jx-composer{
 }
 .jx-sharePrintBtn:hover{
   border-color:rgba(18,109,255,.24);
-  color:#126dff;
-  background:#f8fbff;
+  color:var(--color-primary);
+  background:var(--color-bg-layout);
 }
 .jx-shareTitle{
   margin:8px 0 6px;
   font-size:28px;
   line-height:1.24;
-  color:#0f172a;
+  color:var(--color-text);
   font-weight:650;
 }
 .jx-shareMeta{
@@ -2808,7 +2816,7 @@ textarea.jx-composer{
   flex-wrap:wrap;
   gap:10px 18px;
   font-size:12px;
-  color:rgba(15,23,42,.48);
+  color:color-mix(in srgb, var(--color-text) 48%, transparent);
 }
 .jx-shareMetaId{
   margin-left:auto;
@@ -2825,9 +2833,9 @@ textarea.jx-composer{
 .jx-shareFootnote{
   margin-top:28px;
   padding-top:14px;
-  border-top:1px solid rgba(15,23,42,.04);
+  border-top:1px solid color-mix(in srgb, var(--color-text) 4%, transparent);
   font-size:12px;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   text-align:center;
 }
 .jx-shareMessage{
@@ -2877,13 +2885,13 @@ textarea.jx-composer{
 .jx-shareMessageLabel{
   font-size:12px;
   font-weight:600;
-  color:rgba(15,23,42,.50);
+  color:color-mix(in srgb, var(--color-text) 50%, transparent);
   letter-spacing:.02em;
 }
 .jx-shareMessageBody{
   font-size:14px;
   line-height:1.78;
-  color:#0f172a;
+  color:var(--color-text);
   min-width:0;
   overflow-wrap:anywhere;
   word-break:break-word;
@@ -2892,7 +2900,7 @@ textarea.jx-composer{
   font-size:13.5px;
   line-height:1.9;
   letter-spacing:.01em;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
 }
 .jx-shareMessageBody table{
   display:table;
@@ -2928,7 +2936,7 @@ textarea.jx-composer{
   margin:1em 0 .45em;
   line-height:1.4;
   letter-spacing:.015em;
-  color:#0f172a;
+  color:var(--color-text);
 }
 .jx-shareMessageBody h1{
   font-size:19px;
@@ -2962,17 +2970,17 @@ textarea.jx-composer{
 }
 .jx-shareMessage.assistant .jx-shareMessageBody strong{
   font-weight:630;
-  color:#111827;
+  color:var(--color-text);
 }
 .jx-shareMessage.assistant .jx-shareMessageBody em{
   font-style:normal;
-  color:rgba(30,41,59,.78);
+  color:color-mix(in srgb, var(--color-text-secondary) 78%, transparent);
 }
 .jx-shareMessage.assistant .jx-shareMessageBody blockquote{
   margin:.75em 0;
   padding:.2em 0 .2em .85em;
-  border-left:2px solid rgba(148,163,184,.32);
-  color:rgba(51,65,85,.82);
+  border-left:2px solid color-mix(in srgb, var(--color-text-placeholder) 32%, transparent);
+  color:color-mix(in srgb, var(--color-text-secondary) 82%, transparent);
 }
 .jx-shareMessage.assistant .jx-shareMessageBody code{
   font-size:.92em;
@@ -2992,18 +3000,18 @@ textarea.jx-composer{
 }
 .jx-shareMessage.assistant .jx-shareMessageBody hr{
   border:none;
-  border-top:1px solid rgba(15,23,42,.06);
+  border-top:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   margin:1em 0;
 }
 .jx-shareMessageBody.user{
   padding:12px 14px;
   border-radius:18px;
-  background:#f1f5f9;
-  border:1px solid rgba(15,23,42,.06);
+  background:var(--color-fill-hover);
+  border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
 }
 .jx-shareMessageTime{
   font-size:12px;
-  color:rgba(15,23,42,.38);
+  color:color-mix(in srgb, var(--color-text) 38%, transparent);
   text-align:right;
   white-space:nowrap;
 }
@@ -3099,10 +3107,10 @@ textarea.jx-composer{
   left: 16px;
   max-height: 200px;
   min-width: 140px;
-  background: rgba(255, 255, 255, 0.92);
+  background: color-mix(in srgb, var(--color-bg-container) 92%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: 0 -2px 12px rgba(0,0,0,.08);
   z-index: 50;
@@ -3126,15 +3134,15 @@ textarea.jx-composer{
   border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
-  color: #262626;
+  color: var(--color-text);
   transition: background .12s;
 }
 .jx-mentionPopup-item:hover,
 .jx-mentionPopup-item.active {
-  background: #EBF2FF;
+  background: var(--color-primary-light);
 }
 .jx-mentionPopup-at {
-  color: #126DFF;
+  color: var(--color-primary);
   font-weight: 600;
 }
 .jx-mentionPopup-name {
@@ -3148,10 +3156,10 @@ textarea.jx-composer{
   left: 16px;
   max-height: 200px;
   min-width: 160px;
-  background: rgba(255, 255, 255, 0.92);
+  background: color-mix(in srgb, var(--color-bg-container) 92%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: 0 -2px 12px rgba(0,0,0,.08);
   z-index: 50;
@@ -3175,7 +3183,7 @@ textarea.jx-composer{
   border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
-  color: #262626;
+  color: var(--color-text);
   transition: background .12s;
 }
 .jx-slashPopup-item:hover,
@@ -3210,7 +3218,7 @@ textarea.jx-composer{
   /* padding-bottom 给绝对定位的 .jx-composerBar (50px) 让位 */
   padding: 16px 16px 60px 16px;
   font-size: 16px;
-  color: #262626;
+  color: var(--color-text);
   line-height: 1.5715;
   outline: none;
   white-space: pre-wrap;
@@ -3233,7 +3241,7 @@ textarea.jx-composer{
   white-space: pre-wrap;
   word-wrap: break-word;
   overflow: hidden;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   pointer-events: none;
 }
 .jx-composerPlaceholder::before {
@@ -3257,8 +3265,8 @@ textarea.jx-composer{
   white-space: nowrap;
 }
 .jx-editorChip--mention {
-  background: #EBF2FF;
-  color: #126DFF;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
 }
 .jx-editorChip--skill {
   background: #e0f2fe;
@@ -3296,8 +3304,8 @@ textarea.jx-composer{
   line-height: 1.4;
 }
 .jx-msgChip--mention {
-  background: #EBF2FF;
-  color: #126DFF;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
 }
 .jx-msgChip--skill {
   background: #e0f2fe;
@@ -3321,7 +3329,7 @@ textarea.jx-composer{
 .jx-attachMenu .ant-dropdown-menu-submenu-title {
   border-radius: 10px;
   font-size: 14px;
-  color: rgba(15,23,42,.82);
+  color: color-mix(in srgb, var(--color-text) 82%, transparent);
   gap: 10px;
   padding: 8px 10px;
   transition: background-color .12s ease;
@@ -3329,12 +3337,12 @@ textarea.jx-composer{
 .jx-attachMenu .ant-dropdown-menu-item:hover,
 .jx-attachMenu .ant-dropdown-menu-submenu-title:hover {
   background: rgba(15,23,42,.05);
-  color: #111827;
+  color: var(--color-text);
 }
 .jx-attachMenu .ant-dropdown-menu-item .anticon,
 .jx-attachMenu .ant-dropdown-menu-submenu-title .anticon {
   font-size: 15px;
-  color: rgba(15,23,42,.5);
+  color: color-mix(in srgb, var(--color-text) 50%, transparent);
 }
 /* 「自主循环」菜单项：名称在左、开关贴右 */
 /* 子菜单浮层（技能 / 添加到项目）单独挂载，不继承 overlayClassName。
@@ -3488,7 +3496,7 @@ textarea.jx-composer{
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  background: #fff;
+  background: var(--color-bg-container);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
 }
@@ -3523,7 +3531,7 @@ textarea.jx-composer{
 .jx-spaceImportPreview-body {
   flex: 1;
   overflow: auto;
-  background: #fff;
+  background: var(--color-bg-container);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -3619,7 +3627,7 @@ textarea.jx-composer{
   height: 96px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-bg) 100%);
-  color: #fff;
+  color: var(--color-text-white);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3647,7 +3655,7 @@ textarea.jx-composer{
   flex: 1;
   width: 100%;
   border: none;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 /* text / json --------------------------------------------------- */
@@ -3655,7 +3663,7 @@ textarea.jx-composer{
   flex: 1;
   margin: 0;
   padding: 16px 20px;
-  background: #fafbfc;
+  background: var(--color-bg-layout);
   font-family: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
   font-size: 12.5px;
   line-height: 1.65;
@@ -3698,7 +3706,7 @@ textarea.jx-composer{
   font-size: 12.5px;
 }
 .jx-spaceImportPreview-md pre {
-  background: #fafbfc;
+  background: var(--color-bg-layout);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   padding: 12px 14px;
@@ -3744,7 +3752,7 @@ textarea.jx-composer{
   flex: 1;
   overflow: auto;
   padding: 12px;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 .jx-spaceImportPreview-limitNotice {
   position: sticky;
@@ -3784,7 +3792,7 @@ textarea.jx-composer{
 }
 .jx-spaceImportPreview-table tr:nth-child(even) td,
 .jx-spaceImportPreview-tableWrap table tr:nth-child(even) td {
-  background: #fafbfc;
+  background: var(--color-bg-layout);
 }
 
 /* xlsx sheet tabs ----------------------------------------------- */
@@ -3800,7 +3808,7 @@ textarea.jx-composer{
   gap: 4px;
   padding: 8px 12px 0;
   border-bottom: 1px solid var(--color-border);
-  background: #fff;
+  background: var(--color-bg-container);
   overflow-x: auto;
   flex-shrink: 0;
 }
@@ -3830,7 +3838,7 @@ textarea.jx-composer{
 .jx-mermaid {
   margin: 12px 0;
   padding: 16px;
-  background: #FAFBFC;
+  background: var(--color-bg-layout);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   overflow-x: auto;
@@ -3960,7 +3968,7 @@ textarea.jx-composer{
 .jx-editMessage {
   margin-top: 8px;
   padding: 8px;
-  background: var(--color-fill-bg);
+  background: var(--color-fill-hover);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
 }
@@ -4080,7 +4088,7 @@ textarea.jx-composer{
   border:none;
   border-radius:16px;
   background:transparent;
-  color:rgba(15,23,42,.75);
+  color:color-mix(in srgb, var(--color-text) 75%, transparent);
   font-size:13px;
   line-height:20px;
   font-weight:500;
@@ -4091,14 +4099,14 @@ textarea.jx-composer{
 .jx-modeSeatBtn:hover,
 .jx-modeSeatBtn.open{
   background:rgba(15,23,42,.055);
-  color:rgba(15,23,42,.92);
+  color:color-mix(in srgb, var(--color-text) 92%, transparent);
 }
 .jx-modeSeatBtn:focus-visible{ outline:none; box-shadow:0 0 0 2px rgba(18,109,255,.28); }
 .jx-modeSeatIcon{ flex:none; color:currentColor; }
 .jx-modeSeatLabel{ min-width:0; overflow:hidden; text-overflow:ellipsis; }
 /* 非标准模式：标识走暖色，一眼看出"这段对话不在默认档上" */
-.jx-modeSeatBtn.turbo{ color:rgba(15,23,42,.88); }
-.jx-modeSeatBtn.turbo .jx-modeSeatIcon{ color:var(--color-warning, #F8AB42); }
+.jx-modeSeatBtn.turbo{ color:color-mix(in srgb, var(--color-text) 88%, transparent); }
+.jx-modeSeatBtn.turbo .jx-modeSeatIcon{ color:var(--color-warning, var(--color-warning)); }
 .jx-modeSeatBtn svg.jx-modeArrow{ color:currentColor; opacity:.45; transition:transform .16s ease, opacity .14s ease; }
 .jx-modeSeatBtn:hover svg.jx-modeArrow{ opacity:.65; }
 .jx-modeSeatBtn.open svg.jx-modeArrow{ transform:rotate(180deg); opacity:.8; }
@@ -4116,9 +4124,9 @@ textarea.jx-composer{
   max-height:min(360px, 60vh);
   overflow-y:auto;
   padding:4px;
-  border:1px solid rgba(15,23,42,.06);
+  border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   border-radius:14px;
-  background:#fff;
+  background:var(--color-bg-container);
   box-shadow:0 12px 32px rgba(15,23,42,.12), 0 2px 6px rgba(15,23,42,.05);
 }
 /* 模式描述是选择依据，不像模型名那样能省——允许折行 */
@@ -4129,7 +4137,7 @@ textarea.jx-composer{
   padding:0 5px;
   border-radius:4px;
   background:rgba(18,109,255,.10);
-  color:#0B57D0;
+  color:var(--color-primary-active);
   font-size:11px;
   line-height:16px;
   font-weight:500;
@@ -4144,7 +4152,7 @@ textarea.jx-composer{
   display: inline-flex; align-items: center; gap: 6px;
   padding: 4px 10px; border-radius: 999px;
   border: 1px solid var(--color-border, #e5e6eb);
-  background: var(--color-fill-bg, #f7f8fa);
+  background: var(--color-bg-layout);
   color: var(--color-text, #1d2129);
   font-size: 13px; cursor: pointer; line-height: 1; transition: background .15s;
 }
@@ -4166,7 +4174,7 @@ textarea.jx-composer{
   padding: 8px 10px; border: 0; background: transparent; border-radius: 8px;
   cursor: pointer; text-align: left; color: var(--color-text, #1d2129);
 }
-.jx-deploySwitcherItem:hover { background: var(--color-fill-bg, #f2f3f5); }
+.jx-deploySwitcherItem:hover { background: var(--color-fill-hover); }
 .jx-deploySwitcherItemIcon { font-size: 16px; line-height: 1.2; margin-top: 2px; color: var(--color-text-secondary, #4e5969); }
 .jx-deploySwitcherItemBody { display: flex; flex-direction: column; gap: 2px; flex: 1; }
 .jx-deploySwitcherItemTitle { font-size: 14px; font-weight: 500; }
@@ -4175,14 +4183,14 @@ textarea.jx-composer{
 .jx-deploySwitcherDivider { height: 1px; margin: 6px 8px; background: var(--color-border, #e5e6eb); }
 .jx-deploySwitcherItem--action .jx-deploySwitcherItemIcon { color: var(--color-primary, #165dff); font-weight: 700; }
 .jx-deploySwitcherFooter { width: 100%; padding: 8px 10px; border: 0; background: transparent; border-radius: 8px; cursor: pointer; text-align: left; font-size: 13px; color: var(--color-text-secondary, #4e5969); }
-.jx-deploySwitcherFooter:hover { background: var(--color-fill-bg, #f2f3f5); }
+.jx-deploySwitcherFooter:hover { background: var(--color-fill-hover); }
 
 /* Local permissions modal (ticket #06) */
 .jx-localPermOverlay { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,.35); display: flex; align-items: center; justify-content: center; }
 .jx-localPermModal { width: 520px; max-width: 92vw; max-height: 82vh; overflow: auto; background: var(--color-bg-white, #fff); color: var(--color-text, #1d2129); border-radius: 14px; box-shadow: 0 16px 48px rgba(0,0,0,.24); }
 .jx-localPermHead { display: flex; align-items: center; justify-content: space-between; padding: 16px 18px; font-size: 16px; font-weight: 600; border-bottom: 1px solid var(--color-border, #e5e6eb); }
 .jx-localPermClose { border: 0; background: transparent; font-size: 22px; line-height: 1; cursor: pointer; color: var(--color-text-tertiary, #86909c); }
-.jx-localPermSection { padding: 14px 18px; border-bottom: 1px solid var(--color-border, #f0f1f3); }
+.jx-localPermSection { padding: 14px 18px; border-bottom: 1px solid var(--color-border, var(--color-border)); }
 .jx-localPermSectionTitle { font-size: 14px; font-weight: 600; margin-bottom: 4px; }
 .jx-localPermHint { font-size: 12px; color: var(--color-text-secondary, #86909c); margin-bottom: 10px; }
 .jx-localPermEmpty { font-size: 13px; color: var(--color-text-tertiary, #86909c); padding: 6px 0; }
@@ -4197,10 +4205,10 @@ textarea.jx-composer{
 /* 项目框旁的本机操作权限档胶囊（桌面壳本机模式） */
 .jx-approvalPillBtn .jx-approvalPillIcon { font-size: 13px; line-height: 1; flex-shrink: 0; }
 .jx-approvalMenu .ant-dropdown-menu { min-width: 248px; }
-.jx-approvalMenu .ant-dropdown-menu-item-group-title { font-size: 12px; color: rgba(15,23,42,.45); padding: 6px 12px 2px; }
-.jx-approvalDetailEntry { font-size: 13px; color: rgba(15,23,42,.62); }
-.jx-cloudPrompt { display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; border: 1px solid var(--color-border, #e5e6eb); background: var(--color-fill-bg, #f7f8fa); font-size: 13px; }
+.jx-approvalMenu .ant-dropdown-menu-item-group-title { font-size: 12px; color: color-mix(in srgb, var(--color-text) 45%, transparent); padding: 6px 12px 2px; }
+.jx-approvalDetailEntry { font-size: 13px; color: color-mix(in srgb, var(--color-text) 62%, transparent); }
+.jx-cloudPrompt { display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; border: 1px solid var(--color-border, #e5e6eb); background: var(--color-bg-layout); font-size: 13px; }
 .jx-cloudPromptText { color: var(--color-text-secondary, #4e5969); }
 .jx-cloudPromptYes, .jx-cloudPromptNo { border: 0; border-radius: 8px; padding: 4px 10px; cursor: pointer; font-size: 12.5px; }
-.jx-cloudPromptYes { background: var(--color-primary, #165dff); color: #fff; }
+.jx-cloudPromptYes { background: var(--color-primary, #165dff); color: var(--color-text-white); }
 .jx-cloudPromptNo { background: transparent; color: var(--color-text, #1d2129); border: 1px solid var(--color-border, #c9cdd4); }

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -615,7 +615,7 @@
   gap:10px;
   padding:10px 12px;
   background:var(--color-bg-container);
-  border:1px solid rgba(203,213,225,.72);
+  border:1px solid color-mix(in srgb, var(--color-fill) 72%, transparent);
   border-radius:14px;
   min-width:180px;
   max-width:260px;

--- a/src/frontend/src/styles/common.css
+++ b/src/frontend/src/styles/common.css
@@ -2,7 +2,7 @@
 .jx-md{
   font-size:14.5px;
   line-height:1.74;
-  color:rgba(31,35,40,.84);
+  color:var(--color-text);
   letter-spacing:.004em;
 }
 
@@ -14,7 +14,7 @@
   font-weight:600;
   margin:12px 0 6px;
   line-height:1.44;
-  color:rgba(15,23,42,.94);
+  color:var(--color-text);
 }
 .jx-md h1:first-child,
 .jx-md h2:first-child,
@@ -30,12 +30,12 @@
 }
 .jx-md h3{
   font-size:15px;
-  color:rgba(15,23,42,.88);
+  color:var(--color-text);
   margin-bottom:4px;
 }
 .jx-md h4{
   font-size:13px;
-  color:rgba(15,23,42,.70);
+  color:var(--color-text-secondary);
   margin-bottom:4px;
 }
 
@@ -55,7 +55,7 @@
 .jx-md li{
   line-height:1.74;
   margin:0;
-  color:rgba(31,35,40,.82);
+  color:var(--color-text);
 }
 .jx-md li > p{
   margin:0;
@@ -75,7 +75,7 @@
 
 /* Code blocks with syntax highlighting style */
 .jx-md pre{
-  background:#f7f8fa;
+  background:var(--color-bg-layout);
   padding:11px 14px;
   border-radius:12px;
   overflow:auto;
@@ -85,7 +85,7 @@
 }
 .jx-md code{
   background:rgba(15,23,42,.05);
-  color:rgba(15,23,42,.82);
+  color:var(--color-text-secondary);
   padding:2px 6px;
   border-radius:6px;
   font-size:12.5px;
@@ -94,7 +94,7 @@
 }
 .jx-md pre code{
   background:transparent;
-  color:rgba(31,35,40,.90);
+  color:var(--color-text);
   padding:0;
   font-weight:400;
 }
@@ -106,7 +106,7 @@
   margin:10px 0;
   background:rgba(18,109,255,.035);
   border-radius:10px;
-  color:rgba(31,35,40,.82);
+  color:var(--color-text);
   font-style:normal;
 }
 
@@ -127,38 +127,38 @@
   text-align:left;
 }
 .jx-md th{
-  background:#f3f6f9;
+  background:var(--color-bg-gray);
   font-weight:900;
   font-size:12px;
-  color:rgba(15,23,42,.85);
+  color:var(--color-text-secondary);
   text-transform:uppercase;
   letter-spacing:0.3px;
 }
 .jx-md td{
   font-size:12px;
-  color:rgba(31,35,40,.85);
+  color:var(--color-text);
 }
 .jx-md tr:nth-child(even) td{
-  background:#f8fafc;
+  background:var(--color-bg-layout);
 }
 
 /* Links */
 .jx-md a{
-  color:rgba(15,23,42,.88);
+  color:var(--color-text);
   text-decoration:none;
   font-weight:600;
-  border-bottom:1px solid rgba(15,23,42,.25);
+  border-bottom:1px solid color-mix(in srgb, var(--color-text) 25%, transparent);
   transition:all 0.2s ease;
 }
 .jx-md a:hover{
-  color:rgba(15,23,42,.98);
-  border-bottom-color:rgba(15,23,42,.5);
+  color:var(--color-text);
+  border-bottom-color:color-mix(in srgb, var(--color-text) 50%, transparent);
 }
 
 /* Strong/Bold text */
 .jx-md strong{
   font-weight:900;
-  color:rgba(15,23,42,.95);
+  color:var(--color-text);
 }
 
 /* Horizontal rule */
@@ -294,14 +294,14 @@
   display:flex;
   height:100vh;
   width:100vw;
-  background:#fff;
+  background:var(--color-bg-container);
 }
 .jx-appLoading-sidebar{
   width:260px;
   flex:0 0 260px;
   padding:16px 12px;
   border-right:1px solid var(--color-border);
-  background:#F4F5F7;
+  background:var(--color-bg-gray);
   display:flex;
   flex-direction:column;
   gap:12px;

--- a/src/frontend/src/styles/config.css
+++ b/src/frontend/src/styles/config.css
@@ -5,7 +5,7 @@
   transition: background var(--motion-duration-fast) var(--motion-ease-standard);
 }
 .ant-list-item:hover {
-  background: #fafafa;
+  background: var(--color-bg-layout);
 }
 
 /* Message card left border highlight */
@@ -19,7 +19,7 @@
 }
 .jx-cfgSessionItem.active,
 .jx-cfgSessionItem.active:hover {
-  background: #E6F4FF;
+  background: var(--color-primary-light);
 }
 
 /* 消息卡入场瀑布（每次选中会话重挂一次；--stagger-i 由 staggerStyle(i, 6) 写入，封顶 6 档防长列表拖尾） */
@@ -57,5 +57,5 @@
 }
 .jx-col-resize-handle:hover::after,
 .jx-col-resize-handle:active::after {
-  background: var(--jx-primary, #1677ff);
+  background: var(--color-primary);
 }

--- a/src/frontend/src/styles/evolution.css
+++ b/src/frontend/src/styles/evolution.css
@@ -4,12 +4,12 @@
 .jx-evolutionCard {
   margin-top: 12px;
   padding: 14px 16px;
-  border: 1px solid var(--jx-border, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: var(--jx-surface-2, #fafafa);
+  background: var(--color-bg-layout);
 }
 
-.jx-evolutionCard.is-failed { border-color: var(--jx-danger-border, #fecaca); }
+.jx-evolutionCard.is-failed { border-color: var(--color-error-bg); }
 
 .jx-evolutionCard-head {
   display: flex;
@@ -25,13 +25,13 @@
   gap: 8px;
   font-weight: 600;
   font-size: 13px;
-  color: var(--jx-text, #111827);
+  color: var(--color-text);
 }
 
 .jx-evolutionCard-gain {
   font-weight: 700;
   font-size: 15px;
-  color: var(--jx-primary, #2563eb);
+  color: var(--color-primary);
 }
 
 .jx-evolutionCard-entries {
@@ -48,9 +48,9 @@
   align-items: flex-start;
   gap: 10px;
   padding: 10px 12px;
-  border: 1px solid var(--jx-border, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
-  background: var(--jx-surface, #fff);
+  background: var(--color-bg-container);
 }
 
 .jx-evolutionCard-entry.is-busy { opacity: .6; pointer-events: none; }
@@ -78,7 +78,7 @@
   margin: 0;
   font-size: 13px;
   line-height: 1.55;
-  color: var(--jx-text, #111827);
+  color: var(--color-text);
   overflow-wrap: anywhere;
 }
 
@@ -88,22 +88,22 @@
   gap: 4px 12px;
   margin: 4px 0 0;
   font-size: 11px;
-  color: var(--jx-text-secondary, #6b7280);
+  color: var(--color-text-tertiary);
 }
 
 .jx-evolutionCard-entryError {
   margin: 4px 0 0;
   font-size: 11px;
-  color: var(--jx-danger, #b91c1c);
+  color: var(--color-error);
 }
 
 .jx-evolutionCard-editor {
   width: 100%;
   padding: 6px 8px;
-  border: 1px solid var(--jx-primary, #2563eb);
+  border: 1px solid var(--color-primary);
   border-radius: 8px;
-  background: var(--jx-surface, #fff);
-  color: var(--jx-text, #111827);
+  background: var(--color-bg-container);
+  color: var(--color-text);
   font: inherit;
   font-size: 13px;
   line-height: 1.55;
@@ -123,12 +123,12 @@
   padding: 2px 6px;
   border-radius: 6px;
   font-size: 12px;
-  color: var(--jx-text-secondary, #6b7280);
+  color: var(--color-text-tertiary);
   cursor: pointer;
 }
 .jx-evolutionCard-entryActions button:hover:not(:disabled) {
-  background: var(--jx-surface-2, #f3f4f6);
-  color: var(--jx-primary, #2563eb);
+  background: var(--color-fill-hover);
+  color: var(--color-primary);
 }
 .jx-evolutionCard-entryActions button:disabled { cursor: default; opacity: .5; }
 
@@ -137,14 +137,14 @@
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: var(--jx-danger, #b91c1c);
+  color: var(--color-error);
 }
-.jx-evolutionCard-error small { color: var(--jx-text-secondary, #6b7280); }
+.jx-evolutionCard-error small { color: var(--color-text-tertiary); }
 
 /* ── Settings: contribution details card ─────────────────────────────────── */
 
 .jx-evoContrib-loading { display: grid; place-items: center; padding: 40px 0; }
-.jx-evoContrib-error { color: var(--jx-danger, #b91c1c); font-size: 13px; padding: 16px 0; }
+.jx-evoContrib-error { color: var(--color-error); font-size: 13px; padding: 16px 0; }
 
 .jx-evoContrib-stats {
   display: grid;
@@ -155,27 +155,27 @@
 .jx-evoContrib-stat {
   display: flex; flex-direction: column; gap: 2px;
   padding: 12px;
-  border: 1px solid var(--jx-border, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
-  background: var(--jx-surface-2, #fafafa);
+  background: var(--color-bg-layout);
 }
 .jx-evoContrib-stat strong { font-size: 20px; font-weight: 700; line-height: 1.2; }
-.jx-evoContrib-stat span { font-size: 11px; color: var(--jx-text-secondary, #6b7280); }
+.jx-evoContrib-stat span { font-size: 11px; color: var(--color-text-tertiary); }
 
 .jx-evoContrib-list { display: flex; flex-direction: column; gap: 10px; }
 
 .jx-evoContrib-row {
   padding: 12px 14px;
-  border: 1px solid var(--jx-border, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
-  background: var(--jx-surface, #fff);
+  background: var(--color-bg-container);
 }
 .jx-evoContrib-rowHead { display: flex; align-items: center; gap: 8px; }
-.jx-evoContrib-rowIcon { color: var(--jx-primary, #2563eb); }
+.jx-evoContrib-rowIcon { color: var(--color-primary); }
 .jx-evoContrib-rowKind { font-size: 13px; font-weight: 600; margin-right: auto; }
 .jx-evoContrib-rowSummary {
   margin: 8px 0 0; font-size: 12px;
-  color: var(--jx-text-secondary, #6b7280);
+  color: var(--color-text-tertiary);
   overflow-wrap: anywhere;
 }
 
@@ -184,30 +184,30 @@
 .jx-evoContrib-chain {
   display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
   margin-top: 10px; padding-top: 10px;
-  border-top: 1px dashed var(--jx-border, #e5e7eb);
+  border-top: 1px dashed var(--color-border);
   font-size: 11.5px;
 }
 .jx-evoContrib-chainNode {
   padding: 2px 8px; border-radius: 999px;
-  background: var(--jx-surface-2, #f3f4f6);
-  color: var(--jx-text-secondary, #6b7280);
+  background: var(--color-fill-hover);
+  color: var(--color-text-tertiary);
 }
 .jx-evoContrib-chainNode.is-terminal {
   background: rgba(37, 99, 235, .10); color: #1d4ed8; font-weight: 600;
 }
-.jx-evoContrib-chainArrow { color: var(--jx-primary, #2563eb); }
+.jx-evoContrib-chainArrow { color: var(--color-primary); }
 
 .jx-evoContrib-empty {
   display: flex; flex-direction: column; align-items: center; gap: 6px;
   padding: 32px 20px; text-align: center;
-  border: 1px dashed var(--jx-border, #e5e7eb); border-radius: 12px;
+  border: 1px dashed var(--color-border); border-radius: 12px;
 }
 .jx-evoContrib-empty strong { font-size: 13px; }
-.jx-evoContrib-empty span { font-size: 12px; color: var(--jx-text-secondary, #6b7280); max-width: 380px; }
+.jx-evoContrib-empty span { font-size: 12px; color: var(--color-text-tertiary); max-width: 380px; }
 
 .jx-evoContrib-note {
   margin: 16px 0 0; font-size: 11.5px;
-  color: var(--jx-text-secondary, #9ca3af); line-height: 1.6;
+  color: var(--color-text-placeholder); line-height: 1.6;
 }
 
 @media (max-width: 640px) {
@@ -220,14 +220,14 @@
 
 .jx-evoApproval-item {
   padding: 14px 16px;
-  border: 1px solid var(--jx-border, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: var(--jx-surface, #fff);
+  background: var(--color-bg-container);
   box-shadow: 0 1px 2px rgba(15, 23, 42, .03);
   transition: border-color .18s ease, box-shadow .18s ease;
 }
 .jx-evoApproval-item:hover {
-  border-color: color-mix(in srgb, var(--jx-primary, #2563eb) 24%, var(--jx-border, #e5e7eb));
+  border-color: color-mix(in srgb, var(--color-primary) 24%, var(--color-border));
   box-shadow: 0 6px 18px rgba(15, 23, 42, .055);
 }
 .jx-evoApproval-head { display: flex; align-items: flex-start; gap: 10px; }
@@ -239,22 +239,22 @@
 .jx-evoApproval-title { font-size: 13.5px; font-weight: 650; overflow-wrap: anywhere; }
 .jx-evoApproval-subtitle {
   font-size: 11.5px; line-height: 1.5;
-  color: var(--jx-text-secondary, #6b7280);
+  color: var(--color-text-tertiary);
 }
 
 .jx-evoApproval-finding {
   display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 8px;
   align-items: baseline; margin-top: 10px; padding: 9px 10px;
   border-radius: 8px;
-  background: color-mix(in srgb, var(--jx-primary, #2563eb) 5%, var(--jx-surface-2, #f8fafc));
+  background: color-mix(in srgb, var(--color-primary) 5%, var(--color-bg-layout));
 }
 .jx-evoApproval-finding > span {
   font-size: 10.5px; font-weight: 650; letter-spacing: .02em;
-  color: var(--jx-primary, #2563eb); white-space: nowrap;
+  color: var(--color-primary); white-space: nowrap;
 }
 .jx-evoApproval-finding p {
   margin: 0; font-size: 12px; line-height: 1.55;
-  color: var(--jx-text-secondary, #6b7280); overflow-wrap: anywhere;
+  color: var(--color-text-tertiary); overflow-wrap: anywhere;
 }
 
 /* The concrete change: a skill's body, or the memory ops that will run.
@@ -265,15 +265,15 @@
 .jx-evoApproval-toggle {
   height: 26px !important; padding: 0 6px !important;
   margin-left: -6px;
-  font-size: 12px !important; color: var(--jx-primary, #2563eb) !important;
+  font-size: 12px !important; color: var(--color-primary) !important;
 }
-.jx-evoApproval-toggle:hover { background: color-mix(in srgb, var(--jx-primary, #2563eb) 8%, transparent) !important; }
+.jx-evoApproval-toggle:hover { background: color-mix(in srgb, var(--color-primary) 8%, transparent) !important; }
 
 .jx-evoApproval-detailPanel {
   display: flex; flex-direction: column; gap: 12px;
   margin-top: 6px; padding: 13px 14px;
-  border: 1px solid var(--jx-border, #e5e7eb); border-radius: 10px;
-  background: var(--jx-surface-2, #fafafa);
+  border: 1px solid var(--color-border); border-radius: 10px;
+  background: var(--color-bg-layout);
   animation: jx-evoApproval-reveal .18s ease-out;
 }
 @keyframes jx-evoApproval-reveal {
@@ -284,45 +284,45 @@
 .jx-evoApproval-detailPanel section > strong { font-size: 11.5px; font-weight: 650; }
 .jx-evoApproval-detailPanel section > p {
   margin: 0; font-size: 12px; line-height: 1.6;
-  color: var(--jx-text-secondary, #6b7280);
+  color: var(--color-text-tertiary);
 }
 .jx-evoApproval-detailSteps {
   display: flex; flex-direction: column; gap: 7px;
   margin: 0; padding-left: 22px; font-size: 12px;
 }
 .jx-evoApproval-detailSteps li { padding-left: 2px; }
-.jx-evoApproval-detailSteps li > span { color: var(--jx-text, #111827); }
+.jx-evoApproval-detailSteps li > span { color: var(--color-text); }
 .jx-evoApproval-detailSteps code {
   margin-left: 7px; padding: 1px 5px; border-radius: 4px;
-  background: color-mix(in srgb, var(--jx-text, #111827) 6%, transparent);
-  color: var(--jx-text-secondary, #6b7280); font-size: 10.5px;
+  background: color-mix(in srgb, var(--color-text) 6%, transparent);
+  color: var(--color-text-tertiary); font-size: 10.5px;
 }
 .jx-evoApproval-scope {
   display: flex; align-items: center; gap: 6px;
-  padding-top: 10px; border-top: 1px dashed var(--jx-border, #e5e7eb);
-  font-size: 11.5px; color: var(--jx-text-secondary, #6b7280);
+  padding-top: 10px; border-top: 1px dashed var(--color-border);
+  font-size: 11.5px; color: var(--color-text-tertiary);
 }
 .jx-evoApproval-scope svg { color: #059669; }
 
 .jx-evoApproval-desc {
   margin: 6px 0 0; font-size: 12px;
-  color: var(--jx-text-secondary, #6b7280); overflow-wrap: anywhere;
+  color: var(--color-text-tertiary); overflow-wrap: anywhere;
 }
 
 .jx-evoApproval-tools {
   display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
-  margin-top: 6px; font-size: 11.5px; color: var(--jx-text-secondary, #6b7280);
+  margin-top: 6px; font-size: 11.5px; color: var(--color-text-tertiary);
 }
 .jx-evoApproval-tools code {
   padding: 1px 6px; border-radius: 5px;
-  background: var(--jx-surface-2, #f3f4f6); font-size: 11px;
+  background: var(--color-fill-hover); font-size: 11px;
 }
 
 .jx-evoApproval-doc {
   margin: 8px 0 0; padding: 10px 12px;
   max-height: 320px; overflow: auto;
-  border: 1px solid var(--jx-border, #e5e7eb); border-radius: 8px;
-  background: var(--jx-surface-2, #fafafa);
+  border: 1px solid var(--color-border); border-radius: 8px;
+  background: var(--color-bg-layout);
   font-size: 12px; line-height: 1.6; white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
@@ -332,9 +332,9 @@
   display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px;
   font-size: 12px;
 }
-.jx-evoApproval-opText { color: var(--jx-text, #111827); overflow-wrap: anywhere; }
+.jx-evoApproval-opText { color: var(--color-text); overflow-wrap: anywhere; }
 .jx-evoApproval-ops em {
-  font-style: normal; font-size: 11.5px; color: var(--jx-text-secondary, #6b7280);
+  font-style: normal; font-size: 11.5px; color: var(--color-text-tertiary);
 }
 
 .jx-evoApproval-steps {
@@ -344,22 +344,22 @@
 .jx-evoApproval-step {
   display: inline-flex; align-items: center; gap: 5px;
   padding: 4px 8px 4px 5px; border-radius: 999px;
-  background: var(--jx-surface-2, #f3f4f6);
-  color: var(--jx-text, #111827);
+  background: var(--color-fill-hover);
+  color: var(--color-text);
 }
 .jx-evoApproval-stepIndex {
   display: inline-grid; place-items: center; width: 16px; height: 16px;
-  border-radius: 50%; background: var(--jx-surface, #fff);
-  color: var(--jx-primary, #2563eb); font-size: 9.5px; font-weight: 700;
+  border-radius: 50%; background: var(--color-bg-container);
+  color: var(--color-primary); font-size: 9.5px; font-weight: 700;
 }
-.jx-evoApproval-arrow { color: var(--jx-primary, #2563eb); }
+.jx-evoApproval-arrow { color: var(--color-primary); }
 
 .jx-evoApproval-meta {
   display: flex; align-items: center; justify-content: space-between;
   flex-wrap: wrap; gap: 8px;
   margin-top: 10px; padding-top: 10px;
-  border-top: 1px dashed var(--jx-border, #e5e7eb);
-  font-size: 11.5px; color: var(--jx-text-secondary, #6b7280);
+  border-top: 1px dashed var(--color-border);
+  font-size: 11.5px; color: var(--color-text-tertiary);
 }
 
 .jx-evoApproval-empty {
@@ -367,16 +367,16 @@
   padding: 26px 18px; text-align: center;
 }
 .jx-evoApproval-empty strong { font-size: 13px; }
-.jx-evoApproval-empty span { font-size: 12px; color: var(--jx-text-secondary, #6b7280); max-width: 400px; }
+.jx-evoApproval-empty span { font-size: 12px; color: var(--color-text-tertiary); max-width: 400px; }
 
 .jx-evoApproval-loading {
   display: flex; align-items: center; justify-content: center; gap: 9px;
-  min-height: 96px; color: var(--jx-text-secondary, #6b7280); font-size: 12px;
+  min-height: 96px; color: var(--color-text-tertiary); font-size: 12px;
 }
 
 .jx-evoApproval-note {
   margin: 12px 0 0; font-size: 11.5px;
-  color: var(--jx-text-secondary, #9ca3af);
+  color: var(--color-text-placeholder);
 }
 
 @media (max-width: 640px) {
@@ -395,8 +395,8 @@
 }
 .jx-evoPrefs-label { display: flex; flex-direction: column; gap: 2px; min-width: 190px; flex: 1; }
 .jx-evoPrefs-label > span { font-size: 13px; font-weight: 600; display: inline-flex; align-items: center; gap: 6px; }
-.jx-evoPrefs-label small { font-size: 11.5px; color: var(--jx-text-secondary, #6b7280); }
-.jx-evoPrefs-hint { color: var(--jx-text-secondary, #9ca3af); font-size: 12px; }
+.jx-evoPrefs-label small { font-size: 11.5px; color: var(--color-text-tertiary); }
+.jx-evoPrefs-hint { color: var(--color-text-placeholder); font-size: 12px; }
 
 .jx-evoPrefs-mechs { display: flex; flex-direction: column; gap: 8px; min-width: 260px; }
 .jx-evoPrefs-mech {
@@ -404,7 +404,7 @@
   gap: 8px; cursor: pointer;
 }
 .jx-evoPrefs-mechName { font-size: 12.5px; font-weight: 600; }
-.jx-evoPrefs-mech small { font-size: 11px; color: var(--jx-text-secondary, #9ca3af); }
+.jx-evoPrefs-mech small { font-size: 11px; color: var(--color-text-placeholder); }
 
 .jx-evoPrefs-ontology { display: flex; flex-direction: column; gap: 8px; align-items: flex-end; }
 .jx-evoPrefs-packSelect { min-width: 200px; }
@@ -428,19 +428,19 @@
 .jx-evoConsole-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
 .jx-evoConsole-stat {
   display: flex; flex-direction: column; gap: 2px;
-  padding: 14px; border: 1px solid var(--jx-border, #e5e7eb);
-  border-radius: 10px; background: var(--jx-surface-2, #fafafa);
+  padding: 14px; border: 1px solid var(--color-border);
+  border-radius: 10px; background: var(--color-bg-layout);
 }
 .jx-evoConsole-stat strong { font-size: 22px; font-weight: 700; line-height: 1.2; }
-.jx-evoConsole-stat span { font-size: 11.5px; color: var(--jx-text-secondary, #6b7280); }
+.jx-evoConsole-stat span { font-size: 11.5px; color: var(--color-text-tertiary); }
 
 .jx-evoConsole-funnel { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
 .jx-evoConsole-funnelItem { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; }
-.jx-evoConsole-muted { color: var(--jx-text-secondary, #9ca3af); font-size: 12px; }
+.jx-evoConsole-muted { color: var(--color-text-placeholder); font-size: 12px; }
 
 .jx-evoConsole-note {
   margin: 4px 0 0; font-size: 11.5px;
-  color: var(--jx-text-secondary, #9ca3af); line-height: 1.6;
+  color: var(--color-text-placeholder); line-height: 1.6;
 }
 
 /* Capability health + orchestration: the "subtraction" side of the console. */
@@ -455,7 +455,7 @@
    asset ids alone cannot say so. */
 .jx-evoConsole-healthHint {
   font-size: 11.5px; font-weight: 400; line-height: 1.6;
-  color: var(--jx-text-secondary, #9ca3af);
+  color: var(--color-text-placeholder);
 }
 
 @media (max-width: 900px) {
@@ -466,9 +466,9 @@
    the page — a console showing an empty funnel with no explanation is how
    "misconfigured" gets mistaken for "nothing to learn". */
 .jx-evoConsole-blocked {
-  border: 1px solid var(--jx-danger, #dc2626); border-left-width: 3px;
+  border: 1px solid var(--color-error); border-left-width: 3px;
   border-radius: 8px; padding: 14px 18px;
-  background: var(--jx-danger-bg, #fef2f2);
+  background: var(--color-error-light);
 }
 .jx-evoConsole-blocked strong { font-size: 14px; }
 .jx-evoConsole-blocked p { margin: 6px 0 8px; font-size: 12.5px; line-height: 1.65; }
@@ -480,14 +480,14 @@
    arrives hours later — it is a footnote to the turn, not its headline. */
 .jx-evolutionCard-contrib {
   margin-top: 10px; padding-top: 10px;
-  border-top: 1px dashed var(--jx-border, #e5e7eb);
+  border-top: 1px dashed var(--color-border);
 }
 .jx-evolutionCard-contribHead {
-  font-size: 11.5px; font-weight: 600; color: var(--jx-text-secondary, #6b7280);
+  font-size: 11.5px; font-weight: 600; color: var(--color-text-tertiary);
 }
 .jx-evolutionCard-contrib ul { margin: 6px 0 0; padding-left: 18px; }
 .jx-evolutionCard-contrib li {
-  font-size: 11.5px; line-height: 1.7; color: var(--jx-text-secondary, #6b7280);
+  font-size: 11.5px; line-height: 1.7; color: var(--color-text-tertiary);
 }
 .jx-evolutionCard-contrib em {
   font-style: normal; margin-left: 6px; opacity: .75;

--- a/src/frontend/src/styles/kb-wiki.css
+++ b/src/frontend/src/styles/kb-wiki.css
@@ -18,7 +18,7 @@
   flex-direction: column;
   gap: 10px;
   padding: var(--space-md) var(--space-lg);
-  background: linear-gradient(135deg, var(--color-primary-light) 0%, #fff 62%);
+  background: linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-bg-container) 62%);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
 }
@@ -35,7 +35,7 @@
   display: inline-flex;
   padding: 3px;
   gap: 2px;
-  background: rgba(255, 255, 255, 0.72);
+  background: color-mix(in srgb, var(--color-bg-container) 72%, transparent);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
 }
@@ -61,7 +61,7 @@
 
 .jx-wikiTab.is-active {
   color: var(--color-primary);
-  background: #fff;
+  background: var(--color-bg-container);
   box-shadow: 0 1px 4px rgba(18, 109, 255, 0.14);
 }
 
@@ -91,7 +91,7 @@
   padding: 3px 10px;
   font-size: 12px;
   color: var(--color-text-tertiary);
-  background: rgba(255, 255, 255, 0.8);
+  background: color-mix(in srgb, var(--color-bg-container) 80%, transparent);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-xs);
 }
@@ -124,7 +124,7 @@
   flex-direction: column;
   gap: 10px;
   padding: var(--space-md);
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   max-height: 720px;
@@ -289,15 +289,15 @@
   background: var(--color-bg-gray);
 }
 
-.jx-wikiTypeTag--entity { color: #126DFF; background: #DBE9FF; }
-.jx-wikiTypeTag--concept { color: #02B589; background: #DFF5EE; }
+.jx-wikiTypeTag--entity { color: var(--color-primary); background: var(--color-primary-bg); }
+.jx-wikiTypeTag--concept { color: var(--color-success); background: #DFF5EE; }
 .jx-wikiTypeTag--summary { color: #C77B14; background: #FEF0DC; }
 .jx-wikiTypeTag--index { color: #7C5CFC; background: #EDE9FE; }
 
 /* ── 阅读区 ───────────────────────────────────────────────────────────────── */
 
 .jx-wikiReader {
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   min-height: 480px;
@@ -511,7 +511,7 @@
 
 .jx-wikiSourceItem {
   padding: 10px 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
 }
@@ -538,7 +538,7 @@
   flex-direction: column;
   gap: var(--space-sm);
   padding: var(--space-md);
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
 }
@@ -671,7 +671,7 @@
   padding: 10px var(--space-md);
   flex-wrap: wrap;
   border-top: 1px solid var(--color-border);
-  background: rgba(255, 255, 255, 0.7);
+  background: color-mix(in srgb, var(--color-bg-container) 70%, transparent);
 }
 
 .jx-wikiGraphLegendItem {
@@ -765,7 +765,7 @@
   text-align: left;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: #fff;
+  background: var(--color-bg-container);
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
 }
@@ -800,7 +800,7 @@
 
 .jx-idxModeCard.is-active .jx-idxModeIcon {
   color: var(--color-primary);
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-idxModeText {
@@ -913,7 +913,7 @@
   border-radius: var(--radius-sm);
   background: var(--color-bg-gray);
   font-size: 13px;
-  color: var(--color-text-secondary, #666);
+  color: var(--color-text-secondary, var(--color-text-secondary));
 }
 
 .jx-kbViewSwitch {
@@ -944,7 +944,7 @@
 
 .jx-kbViewSwitchBtn.is-active {
   color: var(--color-primary);
-  background: #fff;
+  background: var(--color-bg-container);
   box-shadow: 0 1px 4px rgba(18, 109, 255, 0.14);
 }
 
@@ -1145,7 +1145,7 @@
   gap: 4px;
   padding: 10px 12px;
   text-align: left;
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -1234,7 +1234,7 @@
   flex-wrap: wrap;
   max-width: calc(100% - 24px);
   padding: 8px 12px;
-  background: rgba(255, 255, 255, 0.92);
+  background: color-mix(in srgb, var(--color-bg-container) 92%, transparent);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   backdrop-filter: blur(6px);
@@ -1271,7 +1271,7 @@
   display: flex;
   flex-direction: column;
   max-height: 660px;
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;

--- a/src/frontend/src/styles/mcp.css
+++ b/src/frontend/src/styles/mcp.css
@@ -21,13 +21,13 @@
 .jx-mcp-title {
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0 0 6px;
 }
 
 .jx-mcp-subtitle {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-weight: 400;
   margin: 0;
 }
@@ -44,8 +44,8 @@
   padding: 6px 12px;
   width: 224px;
   height: 32px;
-  background: #fff;
-  border: 1px solid #E3E6EA;
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   cursor: pointer;
   box-sizing: border-box;
@@ -53,14 +53,14 @@
 
 .jx-mcp-searchPlaceholder {
   font-size: 14px;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
 }
 
 .jx-mcp-searchInput {
   width: 224px;
   height: 32px;
   border-radius: 8px;
-  border-color: #E3E6EA;
+  border-color: var(--color-border);
   /* 假搜索框 → 真 Input 切换淡入（技能库 / MCP 库共用） */
   animation: jx-kf-fadeIn 150ms var(--motion-ease-standard) backwards;
 }
@@ -78,9 +78,9 @@
    入场 stagger 由容器 .jx-anim-stagger + 子项 --stagger-i 提供 */
 .jx-mcp-card {
   padding: 16px 20px;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -89,7 +89,7 @@
 }
 
 .jx-mcp-card:hover {
-  border-color: #c0cadb;
+  border-color: var(--color-fill);
   box-shadow: 0 2px 8px rgba(0,0,0,.04);
 }
 
@@ -154,7 +154,7 @@
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 12px;
-  background: var(--bg, #f8fafc);
+  background: var(--bg, var(--color-bg-layout));
   color: var(--primary);
   font-size: 20px;
 }
@@ -223,7 +223,7 @@
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: var(--bg, #f8fafc);
+  background: var(--bg, var(--color-bg-layout));
 }
 
 .jx-mcp-marketTool .ant-typography {
@@ -246,7 +246,7 @@
   overflow: auto;
   border-radius: 8px;
   background: #111827;
-  color: #e5e7eb;
+  color: var(--color-border);
   font-size: 11px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -264,7 +264,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -279,10 +279,10 @@
 }
 
 .jx-mcp-iconFallback {
-  background: #f0f2f5;
+  background: var(--color-fill-hover);
   font-size: 12px;
   font-weight: 600;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .jx-mcp-cardNameGroup {
@@ -294,7 +294,7 @@
 .jx-mcp-cardName {
   font-size: 16px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   overflow-wrap: anywhere;
 }
 
@@ -311,7 +311,7 @@
 
 .jx-mcp-cardDesc {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   line-height: 1.6;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -341,7 +341,7 @@
   padding: 6px 0;
   margin-right: 16px;
   margin-top: 4px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-size: 14px;
   display: inline-flex;
   align-items: center;
@@ -350,7 +350,7 @@
 }
 
 .jx-mcp-backBtn:hover {
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-mcp-detailContent {
@@ -399,12 +399,12 @@
 .jx-mcp-detailName {
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-mcp-version {
   font-size: 12px;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   font-weight: 400;
 }
 
@@ -418,20 +418,20 @@
 
 .jx-mcp-enableLabel {
   font-size: 14px;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-mcp-divider {
   border: none;
-  border-top: 1px solid #E3E6EA;
+  border-top: 1px solid var(--color-border);
   margin: 20px 0;
 }
 
 /* ── Explain card ───────────────────────────────────────────────── */
 
 .jx-mcp-explainCard {
-  background: #F5F5F5;
-  border: 1px solid #E3E6EA;
+  background: var(--color-bg-gray);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: 20px;
   margin-bottom: 24px;
@@ -449,12 +449,12 @@
 .jx-mcp-explainLabel {
   font-size: 14px;
   font-weight: 500;
-  color: #000;
+  color: var(--color-text);
 }
 
 .jx-mcp-explainValue {
   font-size: 14px;
-  color: #1a1a1a;
+  color: var(--color-text);
   font-weight: 400;
   line-height: 1.5;
 }
@@ -468,13 +468,13 @@
 .jx-mcp-bodyTitle {
   font-size: 16px;
   font-weight: 500;
-  color: #000;
+  color: var(--color-text);
   margin: 0 0 8px;
 }
 
 .jx-mcp-bodyDesc {
   font-size: 14px;
-  color: #555;
+  color: var(--color-text-secondary);
   line-height: 1.75;
   margin: 0 0 20px;
 }
@@ -486,16 +486,16 @@
 .jx-mcp-detailBody .jx-md {
   font-size: 14px;
   line-height: 1.78;
-  color: rgba(31,35,40,.90);
+  color: color-mix(in srgb, var(--color-text) 90%, transparent);
 }
 
 .jx-mcp-detailBody .jx-md h1 { font-size: 20px; }
 .jx-mcp-detailBody .jx-md h2 { font-size: 17px; }
-.jx-mcp-detailBody .jx-md h3 { font-size: 15px; font-weight: 500; color: #000; }
+.jx-mcp-detailBody .jx-md h3 { font-size: 15px; font-weight: 500; color: var(--color-text); }
 .jx-mcp-detailBody .jx-md p { margin: 0 0 12px; }
 .jx-mcp-detailBody .jx-md ul,
 .jx-mcp-detailBody .jx-md ol { margin: 8px 0; padding-left: 24px; }
-.jx-mcp-detailBody .jx-md li { line-height: 2; color: #555; }
+.jx-mcp-detailBody .jx-md li { line-height: 2; color: var(--color-text-secondary); }
 .jx-mcp-detailBody .jx-md li + li { margin-top: 2px; }
 
 .jx-mcp-toolsList {
@@ -505,7 +505,7 @@
 
 .jx-mcp-toolsList li {
   font-size: 14px;
-  color: #555;
+  color: var(--color-text-secondary);
   line-height: 2;
 }
 
@@ -525,12 +525,12 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: #fff;
+  background: var(--color-bg-container);
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 16px 0 14px;
-  border-bottom: 1px solid #E3E6EA;
+  border-bottom: 1px solid var(--color-border);
   box-shadow: 0 2px 6px rgba(15,23,42,.04);
 }
 

--- a/src/frontend/src/styles/mobile.css
+++ b/src/frontend/src/styles/mobile.css
@@ -22,9 +22,9 @@
     gap:10px;
     min-height:64px;
     padding:10px 12px;
-    border:1px solid rgba(255,255,255,.88);
+    border:1px solid color-mix(in srgb, var(--color-bg-container) 88%, transparent);
     border-radius:18px;
-    background:rgba(255,255,255,.84);
+    background:color-mix(in srgb, var(--color-bg-container) 84%, transparent);
     box-shadow:0 10px 28px rgba(42,61,94,.08),inset 0 0 0 .5px rgba(15,23,42,.035);
     backdrop-filter:saturate(180%) blur(22px);
     -webkit-backdrop-filter:saturate(180%) blur(22px);
@@ -34,10 +34,10 @@
     width:36px;
     height:36px;
     padding:0;
-    border:1px solid rgba(15,23,42,.06);
+    border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
     border-radius:50%;
-    background:rgba(255,255,255,.82);
-    color:#475467;
+    background:color-mix(in srgb, var(--color-bg-container) 82%, transparent);
+    color:var(--color-text-secondary);
     justify-content:center;
     box-shadow:0 4px 12px rgba(42,61,94,.055);
   }
@@ -101,9 +101,9 @@
   .jx-abilityCenter .jx-sk-metaCard{
     margin-bottom:14px;
     padding:18px 16px;
-    border:1px solid rgba(15,23,42,.055);
+    border:1px solid color-mix(in srgb, var(--color-text) 5.5%, transparent);
     border-radius:18px;
-    background:rgba(255,255,255,.88);
+    background:color-mix(in srgb, var(--color-bg-container) 88%, transparent);
     box-shadow:0 8px 24px rgba(42,61,94,.055);
   }
 
@@ -165,9 +165,9 @@
   .jx-projects-actions .ant-select-selector{
     min-height:42px !important;
     padding:5px 12px !important;
-    border-color:rgba(15,23,42,.08) !important;
+    border-color:color-mix(in srgb, var(--color-text) 8%, transparent) !important;
     border-radius:14px !important;
-    background:rgba(255,255,255,.82) !important;
+    background:color-mix(in srgb, var(--color-bg-container) 82%, transparent) !important;
     box-shadow:0 4px 14px rgba(42,61,94,.045) !important;
   }
 
@@ -183,9 +183,9 @@
   .jx-projects-searchInput.ant-input-affix-wrapper{
     width:100%;
     min-height:44px;
-    border-color:rgba(15,23,42,.08);
+    border-color:color-mix(in srgb, var(--color-text) 8%, transparent);
     border-radius:14px;
-    background:rgba(255,255,255,.84);
+    background:color-mix(in srgb, var(--color-bg-container) 84%, transparent);
     box-shadow:0 5px 16px rgba(42,61,94,.045);
   }
 
@@ -196,7 +196,7 @@
   .jx-projects-sectionTitle{
     margin-top:4px;
     padding:0 4px;
-    color:#667085;
+    color:var(--color-text-tertiary);
     font-size:13px;
     font-weight:600;
   }
@@ -204,7 +204,7 @@
   .jx-projects-grid{
     display:block;
     overflow:hidden;
-    border:1px solid rgba(15,23,42,.065);
+    border:1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:20px;
     background:var(--jx-mobile-surface);
     box-shadow:var(--jx-mobile-shadow);
@@ -330,7 +330,7 @@
     width:40px;
     height:40px;
     border-radius:50%;
-    background:rgba(255,255,255,.72);
+    background:color-mix(in srgb, var(--color-bg-container) 72%, transparent);
   }
 
   .jx-projectDetail-titleRow > .ant-tag{
@@ -359,9 +359,9 @@
 
   .jx-projectDetail-inputWrap .jx-composerWrap{
     overflow:visible;
-    border-color:rgba(15,23,42,.08);
+    border-color:color-mix(in srgb, var(--color-text) 8%, transparent);
     border-radius:20px;
-    background:rgba(255,255,255,.9);
+    background:color-mix(in srgb, var(--color-bg-container) 90%, transparent);
     box-shadow:0 10px 30px rgba(42,61,94,.075);
   }
 
@@ -409,7 +409,7 @@
     gap:0;
     margin-top:4px;
     overflow:hidden;
-    border:1px solid rgba(15,23,42,.065);
+    border:1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:18px;
     background:var(--jx-mobile-surface);
     box-shadow:0 8px 24px rgba(42,61,94,.05);
@@ -422,7 +422,7 @@
     gap:10px;
     padding:14px 16px 11px;
     border-bottom:1px solid var(--jx-mobile-line);
-    color:#667085;
+    color:var(--color-text-tertiary);
   }
 
   .jx-projectDetail-chatListTitle .ant-radio-group{
@@ -475,7 +475,7 @@
   .jx-projectRail-card{
     padding:16px;
     gap:10px;
-    border-color:rgba(15,23,42,.065);
+    border-color:color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:18px;
     background:var(--jx-mobile-surface);
     box-shadow:0 8px 24px rgba(42,61,94,.05);
@@ -572,7 +572,7 @@
     max-width:min(280px, 84vw) !important;
     height:100dvh !important;
     flex:0 0 min(280px, 84vw) !important;
-    border-right:1px solid rgba(15,23,42,.08);
+    border-right:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
     border-bottom:none;
     box-shadow:18px 0 44px rgba(15,23,42,.16);
     transform:translateX(0);
@@ -623,7 +623,7 @@
     height:58px;
     align-items:center;
     padding:0 18px;
-    background:#fff;
+    background:var(--color-bg-container);
     box-sizing:border-box;
   }
 
@@ -637,13 +637,13 @@
     border:0;
     border-radius:8px;
     background:transparent;
-    color:#111827;
+    color:var(--color-text);
     font-size:24px;
     cursor:pointer;
   }
 
   .jx-mobileMenuBtn:active{
-    background:#f2f4f7;
+    background:var(--color-fill-hover);
   }
 
   .jx-mobileMenuBtn:focus-visible{
@@ -760,7 +760,7 @@
 
   .jx-mobileQuickTasksLabel{
     margin:0 0 12px 1px;
-    color:#4b5563;
+    color:var(--color-text-secondary);
     font-size:14px;
     font-weight:400;
     line-height:20px;
@@ -783,7 +783,7 @@
     padding:0 8px;
     border:1px solid #d7deea;
     border-radius:7px;
-    background:#fff;
+    background:var(--color-bg-container);
     color:#141923;
     font-size:13px;
     font-weight:400;
@@ -796,7 +796,7 @@
   .jx-mobileQuickTask:hover,
   .jx-mobileQuickTask:focus-visible{
     border-color:#8db9ff;
-    background:#f8fbff;
+    background:var(--color-bg-layout);
   }
 
   .jx-mobileQuickTask:active{
@@ -1024,12 +1024,12 @@
  * restrained translucent material; content stays opaque and high-contrast. */
 @media (max-width: 960px){
   :root{
-    --jx-mobile-canvas:#F5F7FB;
-    --jx-mobile-surface:rgba(255,255,255,.94);
-    --jx-mobile-material:rgba(255,255,255,.76);
-    --jx-mobile-line:rgba(15,23,42,.075);
-    --jx-mobile-label:#101828;
-    --jx-mobile-secondary:#667085;
+    --jx-mobile-canvas:var(--color-bg-layout);
+    --jx-mobile-surface:color-mix(in srgb, var(--color-bg-container) 94%, transparent);
+    --jx-mobile-material:color-mix(in srgb, var(--color-bg-container) 76%, transparent);
+    --jx-mobile-line:color-mix(in srgb, var(--color-text) 7.5%, transparent);
+    --jx-mobile-label:var(--color-text);
+    --jx-mobile-secondary:var(--color-text-tertiary);
     --jx-mobile-radius:22px;
     --jx-mobile-control-radius:18px;
     --jx-mobile-shadow:0 12px 34px rgba(42,61,94,.075),0 1px 2px rgba(15,23,42,.035);
@@ -1079,10 +1079,10 @@
     width:42px;
     height:42px;
     flex:0 0 42px;
-    border:1px solid rgba(255,255,255,.86);
+    border:1px solid color-mix(in srgb, var(--color-bg-container) 86%, transparent);
     border-radius:50%;
     background:var(--jx-mobile-material);
-    color:#101828;
+    color:var(--color-text);
     font-size:21px;
     box-shadow:0 7px 20px rgba(42,61,94,.07),inset 0 0 0 .5px rgba(15,23,42,.045);
     backdrop-filter:saturate(180%) blur(18px);
@@ -1091,7 +1091,7 @@
   }
 
   .jx-mobileMenuBtn:active{
-    background:rgba(255,255,255,.94);
+    background:color-mix(in srgb, var(--color-bg-container) 94%, transparent);
     transform:scale(.96);
   }
 
@@ -1099,7 +1099,7 @@
     min-height:64px;
     padding:10px 16px;
     background:rgba(245,247,251,.84);
-    border-bottom:1px solid rgba(15,23,42,.05);
+    border-bottom:1px solid color-mix(in srgb, var(--color-text) 5%, transparent);
     backdrop-filter:saturate(180%) blur(22px);
     -webkit-backdrop-filter:saturate(180%) blur(22px);
   }
@@ -1113,9 +1113,9 @@
 
   .ant-dropdown .ant-dropdown-menu,
   .ant-popover .ant-popover-inner{
-    border:1px solid rgba(255,255,255,.82);
+    border:1px solid color-mix(in srgb, var(--color-bg-container) 82%, transparent);
     border-radius:16px;
-    background:rgba(255,255,255,.9);
+    background:color-mix(in srgb, var(--color-bg-container) 90%, transparent);
     box-shadow:var(--shadow-dropdown);
     backdrop-filter:saturate(180%) blur(24px);
     -webkit-backdrop-filter:saturate(180%) blur(24px);
@@ -1163,8 +1163,8 @@
   }
 
   .ant-btn-primary{
-    border-color:#126DFF;
-    background:#126DFF;
+    border-color:var(--color-primary);
+    background:var(--color-primary);
   }
 
   .ant-input,
@@ -1172,8 +1172,8 @@
   .ant-select-selector,
   .ant-input-number,
   textarea.ant-input{
-    border-color:rgba(15,23,42,.105);
-    background:rgba(255,255,255,.88);
+    border-color:color-mix(in srgb, var(--color-text) 10.5%, transparent);
+    background:color-mix(in srgb, var(--color-bg-container) 88%, transparent);
     box-shadow:none !important;
   }
 
@@ -1186,9 +1186,9 @@
 
   .ant-modal-content,
   .ant-drawer-content{
-    border:1px solid rgba(255,255,255,.78);
+    border:1px solid color-mix(in srgb, var(--color-bg-container) 78%, transparent);
     border-radius:22px;
-    background:rgba(255,255,255,.94);
+    background:color-mix(in srgb, var(--color-bg-container) 94%, transparent);
     box-shadow:0 24px 70px rgba(28,43,68,.18);
     backdrop-filter:saturate(170%) blur(24px);
     -webkit-backdrop-filter:saturate(170%) blur(24px);
@@ -1221,7 +1221,7 @@
     align-items:center;
     gap:4px;
     padding:4px;
-    border:1px solid rgba(255,255,255,.9);
+    border:1px solid color-mix(in srgb, var(--color-bg-container) 90%, transparent);
     border-radius:24px;
     background:var(--jx-mobile-material);
     box-shadow:0 10px 30px rgba(42,61,94,.065),inset 0 0 0 .5px rgba(15,23,42,.045);
@@ -1242,7 +1242,7 @@
   }
 
   .jx-agentLibraryPage .jx-agentPage-search.ant-input-affix-wrapper-focused{
-    background:rgba(255,255,255,.72);
+    background:color-mix(in srgb, var(--color-bg-container) 72%, transparent);
     box-shadow:none !important;
   }
 
@@ -1267,7 +1267,7 @@
   .jx-agentLibraryPage .jx-agentPage-grid{
     display:block;
     overflow:hidden;
-    border:1px solid rgba(15,23,42,.07);
+    border:1px solid color-mix(in srgb, var(--color-text) 7%, transparent);
     border-radius:var(--jx-mobile-radius);
     background:var(--jx-mobile-surface);
     box-shadow:var(--jx-mobile-shadow);
@@ -1303,7 +1303,7 @@
     height:52px;
     border:0;
     border-radius:16px;
-    background:#EEF4FF;
+    background:var(--color-primary-light);
   }
 
   .jx-agentLibraryPage .jx-agentCard-iconWrap img{
@@ -1336,14 +1336,14 @@
     padding:2px 8px;
     border-radius:999px;
     background:#F1F4F8;
-    color:#667085;
+    color:var(--color-text-tertiary);
     font-size:11px;
     line-height:18px;
   }
 
   .jx-agentLibraryPage .jx-agentCard-badge.on{
-    background:#EAF2FF;
-    color:#126DFF;
+    background:var(--color-primary-light);
+    color:var(--color-primary);
   }
 
   .jx-agentLibraryPage .jx-agentCard-ops{
@@ -1372,10 +1372,10 @@
   .jx-agentCreatePage-back{
     min-width:40px;
     min-height:40px;
-    border:1px solid rgba(255,255,255,.86);
+    border:1px solid color-mix(in srgb, var(--color-bg-container) 86%, transparent);
     border-radius:20px;
     background:var(--jx-mobile-material);
-    color:#344054;
+    color:var(--color-text-secondary);
     box-shadow:0 6px 18px rgba(42,61,94,.06);
     backdrop-filter:saturate(180%) blur(18px);
     -webkit-backdrop-filter:saturate(180%) blur(18px);
@@ -1399,7 +1399,7 @@
 
   .jx-agentLibraryPage .jx-agentDetail-section,
   .jx-agentCreatePage-card{
-    border:1px solid rgba(15,23,42,.065);
+    border:1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:20px;
     background:var(--jx-mobile-surface);
     box-shadow:var(--jx-mobile-shadow);
@@ -1410,7 +1410,7 @@
     gap:0;
     overflow:hidden;
     border-radius:14px;
-    background:#F7F8FA;
+    background:var(--color-bg-layout);
   }
 
   .jx-agentLibraryPage .jx-agentDetail-field{
@@ -1466,7 +1466,7 @@
   .jx-labPage .jx-agentPage-grid{
     display:block;
     overflow:hidden;
-    border:1px solid rgba(15,23,42,.065);
+    border:1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:var(--jx-mobile-radius);
     background:var(--jx-mobile-surface);
     box-shadow:var(--jx-mobile-shadow);
@@ -1519,7 +1519,7 @@
   .jx-abilityCenter .jx-mcp-grid{
     display:block;
     overflow:hidden;
-    border:1px solid rgba(15,23,42,.065);
+    border:1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:var(--jx-mobile-radius);
     background:var(--jx-mobile-surface);
     box-shadow:var(--jx-mobile-shadow);
@@ -1552,7 +1552,7 @@
     overflow:hidden;
     gap:0;
     padding:0;
-    border:1px solid rgba(15,23,42,.065);
+    border:1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius:var(--jx-mobile-radius);
     background:var(--jx-mobile-surface);
     box-shadow:var(--jx-mobile-shadow);
@@ -1585,18 +1585,18 @@
 
   .jx-mobileQuickTask{
     height:36px;
-    border-color:rgba(15,23,42,.08);
+    border-color:color-mix(in srgb, var(--color-text) 8%, transparent);
     border-radius:14px;
-    background:rgba(255,255,255,.78);
+    background:color-mix(in srgb, var(--color-bg-container) 78%, transparent);
     box-shadow:0 4px 14px rgba(42,61,94,.04);
     backdrop-filter:saturate(170%) blur(16px);
     -webkit-backdrop-filter:saturate(170%) blur(16px);
   }
 
   .jx-emptyPage--main .jx-homeInput .jx-composerWrap{
-    border-color:rgba(15,23,42,.09);
+    border-color:color-mix(in srgb, var(--color-text) 9%, transparent);
     border-radius:24px;
-    background:rgba(255,255,255,.9);
+    background:color-mix(in srgb, var(--color-bg-container) 90%, transparent);
     box-shadow:0 14px 40px rgba(42,61,94,.09),0 1px 2px rgba(15,23,42,.035);
     backdrop-filter:saturate(180%) blur(22px);
     -webkit-backdrop-filter:saturate(180%) blur(22px);

--- a/src/frontend/src/styles/myspace.css
+++ b/src/frontend/src/styles/myspace.css
@@ -7,7 +7,7 @@
   position: relative; /* 拖拽上传高亮层的定位锚点 */
   height: 100%;
   overflow: hidden;
-  background: #fff;
+  background: var(--color-bg-container);
   container-type: inline-size;
   container-name: myspace;
 }
@@ -30,7 +30,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -54,7 +54,7 @@
   font-family: var(--font-family);
   font-size: 20px;
   font-weight: 400;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   transition: color 0.18s ease;
 }
@@ -64,11 +64,11 @@
 }
 
 .jx-mySpace-tab:hover {
-  color: #394556;
+  color: var(--color-text-secondary);
 }
 
 .jx-mySpace-tab.active {
-  color: #1c2430;
+  color: var(--color-text);
   font-weight: 500;
 }
 
@@ -98,8 +98,8 @@
   height: 20px;
   padding: 0 6px;
   border-radius: 999px;
-  background: #ff5c5c;
-  color: #fff;
+  background: var(--color-error);
+  color: var(--color-text-white);
   font-size: 12px;
   line-height: 20px;
   text-align: center;
@@ -116,7 +116,7 @@
 
 .jx-mySpace-desc {
   margin: 0;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   font-size: 14px;
   line-height: 1.7;
 }
@@ -139,8 +139,8 @@
 .jx-mySpace-assetChip {
   appearance: none;
   border: 1px solid transparent;
-  background: #f1f3f6;
-  color: #5f6c7f;
+  background: var(--color-fill-hover);
+  color: var(--color-text-secondary);
   border-radius: 10px;
   padding: 7px 14px;
   font-size: 14px;
@@ -150,8 +150,8 @@
 }
 
 .jx-mySpace-assetChip:hover {
-  color: #334155;
-  background: #edf1f7;
+  color: var(--color-text);
+  background: var(--color-fill-hover);
 }
 
 .jx-mySpace-assetChip.active {
@@ -174,7 +174,7 @@
 .jx-mySpace-sourceFilter .ant-select-selector {
   height: 40px !important;
   border-radius: 12px !important;
-  border-color: rgba(148, 163, 184, 0.28) !important;
+  border-color: color-mix(in srgb, var(--color-text-placeholder) 28%, transparent) !important;
   box-shadow: none !important;
   padding: 0 14px !important;
 }
@@ -189,7 +189,7 @@
   max-width: 100%;
   height: 40px;
   border-radius: 12px;
-  border-color: rgba(148, 163, 184, 0.28);
+  border-color: color-mix(in srgb, var(--color-text-placeholder) 28%, transparent);
   box-shadow: none;
   padding: 0 12px;
 }
@@ -255,7 +255,7 @@
   gap: 8px;
   padding: 18px 30px;
   border-radius: 14px;
-  background: #fff;
+  background: var(--color-bg-container);
   color: var(--color-primary);
   font-size: 14px;
   box-shadow:
@@ -291,7 +291,7 @@
   display: inline-flex;
   align-items: baseline;
   flex-shrink: 0;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   font-size: 12px;
   font-family: var(--font-family-number);
 }
@@ -329,7 +329,7 @@
   top: 0;
   z-index: 2;
   min-height: 44px;
-  background: #fff;
+  background: var(--color-bg-container);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid rgba(226, 232, 240, 0.9);
 }
@@ -356,7 +356,7 @@
 .jx-mySpace-docTable-col--size,
 .jx-mySpace-docTable-col--source,
 .jx-mySpace-docTable-col--time {
-  color: #8a94a3;
+  color: var(--color-text-tertiary);
 }
 
 .jx-mySpace-docTable-col--actions {
@@ -367,7 +367,7 @@
 }
 
 .jx-mySpace-docTable-header .jx-mySpace-docTable-col {
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   font-size: 14px;
   font-weight: 500;
 }
@@ -395,7 +395,7 @@
 }
 
 .jx-mySpace-docRow:hover {
-  background: #f8fafc;
+  background: var(--color-bg-layout);
 }
 
 .jx-mySpace-docRow--checked {
@@ -419,7 +419,7 @@
   width: 16px;
   height: 16px;
   border-radius: 5px;
-  border-color: #c7d0dc;
+  border-color: var(--color-fill);
 }
 
 .jx-mySpace-docRow .ant-checkbox-checked .ant-checkbox-inner,
@@ -449,7 +449,7 @@
   white-space: nowrap;
   font-size: 14px;
   font-weight: 400;
-  color: #283241;
+  color: var(--color-text);
   transition: color 0.16s ease;
 }
 
@@ -461,7 +461,7 @@
 .jx-mySpace-docRow-meta,
 .jx-mySpace-docRow-time {
   font-size: 14px;
-  color: #465262;
+  color: var(--color-text-secondary);
   white-space: nowrap;
 }
 
@@ -471,10 +471,10 @@
   gap: 4px;
   flex-shrink: 0;
   padding: 3px 8px;
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  border: 1px solid color-mix(in srgb, var(--color-text-placeholder) 22%, transparent);
   border-radius: 999px;
-  background: #fff;
-  color: #64748b;
+  background: var(--color-bg-container);
+  color: var(--color-text-tertiary);
   font-size: 12px;
   line-height: 1;
   cursor: pointer;
@@ -500,7 +500,7 @@
 
 .jx-mySpace-kbUsageItem {
   font-size: 13px;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .jx-mySpace-moreBtn {
@@ -510,7 +510,7 @@
   width: 28px;
   height: 28px;
   border-radius: 8px;
-  color: #8a94a3;
+  color: var(--color-text-tertiary);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -527,8 +527,8 @@
 }
 
 .jx-mySpace-moreBtn:hover {
-  background: #edf2f7;
-  color: #334155;
+  background: var(--color-fill-hover);
+  color: var(--color-text);
 }
 
 /* 出入场由 motion（AnimatePresence + x:'-50%'）接管：
@@ -547,7 +547,7 @@
   padding: 10px 16px;
   border-radius: 18px;
   border: 1px solid rgba(226, 232, 240, 0.96);
-  background: #fff;
+  background: var(--color-bg-container);
   box-shadow:
     0 2px 10px rgba(15, 23, 42, 0.06),
     0 18px 42px rgba(15, 23, 42, 0.12);
@@ -555,7 +555,7 @@
 
 .jx-mySpace-bulkBar-count {
   margin-right: 2px;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   font-size: 14px;
   white-space: nowrap;
 }
@@ -571,12 +571,12 @@
   height: 34px;
   padding: 0 16px;
   border: 1px solid rgba(203, 213, 225, 0.9);
-  background: #fff;
+  background: var(--color-bg-container);
   border-radius: 10px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: #334155;
+  color: var(--color-text);
   font-size: 14px;
   font-family: var(--font-family);
   cursor: pointer;
@@ -600,12 +600,12 @@
 }
 
 .jx-mySpace-bulkBar-btn--cancel {
-  color: #7b8697;
+  color: var(--color-text-tertiary);
 }
 
 .jx-mySpace-bulkBar-btn--cancel:hover {
-  color: #475569;
-  background: #f8fafc;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-layout);
   border-color: rgba(203, 213, 225, 0.92);
 }
 
@@ -707,17 +707,17 @@
 }
 
 .jx-mySpace-imgOverlay .jx-mySpace-actionBtn {
-  color: #fff;
+  color: var(--color-text-white);
   font-size: 16px;
 }
 
 .jx-mySpace-imgOverlay .jx-mySpace-actionBtn:hover {
-  color: #fff;
+  color: var(--color-text-white);
   background: rgba(255, 255, 255, .2);
 }
 
 .jx-mySpace-imgOverlay .jx-mySpace-actionBtn--danger:hover {
-  color: #fff;
+  color: var(--color-text-white);
   background: rgba(220, 53, 69, .6);
 }
 
@@ -731,7 +731,7 @@
   padding: 18px 20px;
   border-radius: 18px;
   border: 1px solid rgba(226, 232, 240, 0.9);
-  background: #fff;
+  background: var(--color-bg-container);
   box-shadow:
     0 1px 2px rgba(15, 23, 42, 0.04),
     0 12px 28px rgba(15, 23, 42, 0.04);
@@ -755,20 +755,20 @@
 }
 
 .jx-mySpace-favSource {
-  color: #1f2937;
+  color: var(--color-text);
   font-size: 14px;
   font-weight: 500;
   line-height: 1.6;
 }
 
 .jx-mySpace-favTime {
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   font-size: 12px;
   white-space: nowrap;
 }
 
 .jx-mySpace-favPreview {
-  color: #64748b;
+  color: var(--color-text-tertiary);
   font-size: 14px;
   line-height: 1.75;
   display: -webkit-box;
@@ -790,12 +790,12 @@
   height: 34px;
   padding: 0 14px;
   border-radius: 10px;
-  color: #475569;
-  background: #f8fafc;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-layout);
 }
 
 .jx-mySpace-favActions .jx-mySpace-actionBtn:hover {
-  background: #eef4ff;
+  background: var(--color-primary-light);
   color: var(--color-primary);
 }
 
@@ -810,7 +810,7 @@
 
 .jx-mySpace-kbPickerText {
   margin-bottom: 12px;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 14px;
   line-height: 1.7;
 }
@@ -827,7 +827,7 @@
   min-height: 320px;
   border: 1px dashed rgba(203, 213, 225, 0.9);
   border-radius: 20px;
-  background: #fff;
+  background: var(--color-bg-container);
   text-align: center;
   animation: jx-kf-fadeInUp var(--motion-duration-normal) var(--motion-ease-brand-out) both;
 }
@@ -844,13 +844,13 @@
 }
 
 .jx-mySpace-emptyText {
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 16px;
 }
 
 .jx-mySpace-emptyHint {
   margin-top: 6px;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   font-size: 13px;
 }
 
@@ -864,7 +864,7 @@
 
 .jx-mySpace-noMore {
   padding: 20px 0 0;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   font-size: 13px;
   text-align: center;
 }
@@ -960,7 +960,7 @@
 }
 
 .jx-mySpace-notifActions-label {
-  color: #64748b;
+  color: var(--color-text-tertiary);
   font-size: 13px;
 }
 
@@ -978,7 +978,7 @@
   margin-bottom: 10px;
   border-radius: 16px;
   border: 1px solid rgba(226, 232, 240, 0.9);
-  background: #fff;
+  background: var(--color-bg-container);
   cursor: pointer;
   transition: border-color 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
 }
@@ -1011,13 +1011,13 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #ff5c5c;
+  background: var(--color-error);
 }
 
 /* 未读点涟漪：只给列表前 3 个未读卡片挂 .jx-anim-ripple（motion.css 原语，
    compositor-only，替代原 box-shadow 呼吸动画） */
 .jx-mySpace-notifDot.jx-anim-ripple {
-  --ripple-color: #ff5c5c;
+  --ripple-color: var(--color-error);
   --ripple-dur: 2s;
 }
 
@@ -1034,13 +1034,13 @@
 }
 
 .jx-mySpace-notifCard-name {
-  color: #1f2937;
+  color: var(--color-text);
   font-size: 14px;
   font-weight: 500;
 }
 
 .jx-mySpace-notifCard-summary {
-  color: #64748b;
+  color: var(--color-text-tertiary);
   font-size: 14px;
   line-height: 1.7;
   display: -webkit-box;
@@ -1051,7 +1051,7 @@
 
 .jx-mySpace-notifCard-time {
   margin-top: 8px;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   font-size: 12px;
 }
 
@@ -1062,7 +1062,7 @@
   width: 28px;
   height: 28px;
   border-radius: 8px;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   opacity: 0;
   cursor: pointer;
   transition: opacity 0.16s ease, background 0.16s ease, color 0.16s ease;

--- a/src/frontend/src/styles/onboarding.css
+++ b/src/frontend/src/styles/onboarding.css
@@ -7,7 +7,7 @@
   flex-direction:column;
   overflow:hidden;
   color:var(--color-text);
-  background:#fff;
+  background:var(--color-bg-container);
 }
 
 .jx-firstRun-topbar{
@@ -20,7 +20,7 @@
   display:flex;
   align-items:center;
   justify-content:space-between;
-  background:#fff;
+  background:var(--color-bg-container);
   border-bottom:1px solid #ececec;
 }
 .jx-firstRun-brand{
@@ -58,7 +58,7 @@
   grid-template-columns:248px minmax(0,1fr);
   grid-template-rows:minmax(0,1fr);
   overflow:hidden;
-  background:#fff;
+  background:var(--color-bg-container);
 }
 
 .jx-firstRun-rail{
@@ -116,7 +116,7 @@
 }
 .jx-firstRun-rail li.is-active{color:#202020}
 .jx-firstRun-rail li.is-active::after{background:#202020}
-.jx-firstRun-rail li.is-done{color:#666}
+.jx-firstRun-rail li.is-done{color:var(--color-text-secondary)}
 .jx-firstRun-stepIndex{
   width:22px;
   display:grid;
@@ -236,14 +236,14 @@
 }
 .jx-firstRun-actions .jx-firstRun-primaryButton{
   min-width:108px;
-  color:#fff;
+  color:var(--color-text-white);
   background:#202020;
   border-color:#202020;
   box-shadow:none;
 }
 .jx-firstRun-actions .jx-firstRun-primaryButton:hover,
 .jx-firstRun-actions .jx-firstRun-primaryButton:focus-visible{
-  color:#fff;
+  color:var(--color-text-white);
   background:#000;
   border-color:#000;
 }
@@ -265,7 +265,7 @@
   gap:20px;
   color:#202020;
   text-align:left;
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid #dedede;
   border-radius:12px;
   cursor:pointer;
@@ -277,7 +277,7 @@
   outline-offset:2px;
 }
 .jx-firstRun-choice--active{
-  background:#fafafa;
+  background:var(--color-bg-layout);
   border-color:#202020;
 }
 .jx-firstRun-choiceText{
@@ -364,8 +364,8 @@
   border-radius:10px !important;
 }
 .jx-firstRun-card .ant-alert{
-  background:#f7f7f7;
-  border-color:#e5e5e5;
+  background:var(--color-bg-gray);
+  border-color:var(--color-border);
   border-radius:10px;
 }
 .jx-firstRun-card .ant-alert-info .ant-alert-icon{color:#676767}
@@ -377,7 +377,7 @@
   color:#5f5f5f;
   font-size:12px;
   line-height:1.5;
-  background:#f7f7f7;
+  background:var(--color-bg-gray);
   border-radius:10px;
 }
 .jx-firstRun-note .anticon{color:#535353}
@@ -408,18 +408,18 @@
   display:flex;
   align-items:flex-start;
   gap:16px;
-  background:#fff;
+  background:var(--color-bg-container);
   border-top:1px solid #ececec;
 }
 .jx-firstRun-feature:last-child{border-bottom:1px solid #ececec}
-.jx-firstRun-feature--active{background:#fff}
+.jx-firstRun-feature--active{background:var(--color-bg-container)}
 .jx-firstRun-featureIcon{
   width:38px;
   height:38px;
   display:grid;
   flex:none;
   place-items:center;
-  color:#333;
+  color:var(--color-text);
   font-size:17px;
   background:#f1f1f1;
   border-radius:50%;
@@ -450,7 +450,7 @@
   margin:0 0 24px;
   display:grid;
   place-items:center;
-  color:#fff;
+  color:var(--color-text-white);
   font-size:22px;
   background:#202020;
   border-radius:50%;
@@ -490,7 +490,7 @@
   display:flex;
   flex-direction:column;
   gap:20px;
-  background:#fff;
+  background:var(--color-bg-container);
   transform:translate(-50%,-50%);
 }
 
@@ -511,7 +511,7 @@
   }
   .jx-firstRun-rail{
     padding:18px 20px 14px;
-    background:#fafafa;
+    background:var(--color-bg-layout);
     border-right:0;
     border-bottom:1px solid #ececec;
   }

--- a/src/frontend/src/styles/ontology.css
+++ b/src/frontend/src/styles/ontology.css
@@ -92,7 +92,7 @@
   overflow: hidden;
   border: 1px solid var(--color-border);
   border-radius: 7px;
-  background: rgba(255, 255, 255, 0.78);
+  background: color-mix(in srgb, var(--color-bg-container) 78%, transparent);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -372,7 +372,7 @@
   padding: 9px 10px;
   border: 1px solid var(--color-border);
   border-radius: 9px;
-  background: rgba(255, 255, 255, .7);
+  background: color-mix(in srgb, var(--color-bg-container) 70%, transparent);
 }
 
 .jx-ontologyPassResult-summary span,
@@ -450,7 +450,7 @@
   padding: 4px 18px 18px;
   overflow-x: hidden;
   overflow-y: visible;
-  color: rgba(15, 23, 42, .86);
+  color: color-mix(in srgb, var(--color-text) 86%, transparent);
 }
 
 .jx-ontologyRevision-documentHead {
@@ -586,7 +586,7 @@
   padding: 10px 10px 10px 38px;
   border: 1px solid rgba(95, 68, 14, .11);
   border-radius: 9px;
-  background: rgba(255, 255, 255, .82);
+  background: color-mix(in srgb, var(--color-bg-container) 82%, transparent);
 }
 
 .jx-ontologyManualReview-index {
@@ -640,7 +640,7 @@
   gap: 12px;
   padding: 12px 14px;
   border-top: 1px solid rgba(21, 45, 74, .09);
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-ontologyRevision-actions > span {
@@ -791,7 +791,7 @@
   border: 1px solid var(--color-border);
   border-left-width: 3px;
   border-radius: var(--radius-sm);
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-ontologyValidation-issue--error { border-left-color: var(--color-error); }
@@ -910,7 +910,7 @@
   place-items: center;
   flex: 0 0 52px;
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-text-white);
   box-shadow: 0 10px 24px rgba(18, 109, 255, .22);
   font-size: 24px;
 }
@@ -935,7 +935,7 @@
   padding: 12px 16px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: #fff;
+  background: var(--color-bg-container);
   box-shadow: var(--shadow-card);
 }
 
@@ -958,7 +958,7 @@
   padding: 0 18px 18px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  background: #fff;
+  background: var(--color-bg-container);
   box-shadow: var(--shadow-card);
 }
 
@@ -1263,7 +1263,7 @@
   padding: 12px 12px 0;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-ontologyEditor-propertyRemove {

--- a/src/frontend/src/styles/plan.css
+++ b/src/frontend/src/styles/plan.css
@@ -5,7 +5,7 @@
 /* ── Card container ── */
 .jx-plan-card{
   position:relative;
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid var(--color-border);
   border-radius:var(--radius-md);
   overflow:hidden;
@@ -232,7 +232,7 @@
   justify-content:center;
   border-radius:50%;
   background:var(--color-primary);
-  color:#fff;
+  color:var(--color-text-white);
   font-size:11px;
   font-weight:700;
   font-family:var(--font-family-number);
@@ -459,7 +459,7 @@
    ═══════════════════════════════════════════ */
 .jx-planStrip{
   margin:0 0 8px;
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid var(--color-border);
   border-radius:var(--radius-md);
   box-shadow:0 1px 4px rgba(38,38,38,.04);
@@ -591,13 +591,13 @@
 .jx-plan-approveBtn--primary{
   border:none;
   background:var(--color-primary);
-  color:#fff;
+  color:var(--color-text-white);
 }
 .jx-plan-approveBtn--primary:hover{ background:var(--color-primary-hover); }
 .jx-plan-approveBtn--primary:active{ background:var(--color-primary-active); }
 .jx-plan-approveBtn--ghost{
   border:1px solid var(--color-border);
-  background:#fff;
+  background:var(--color-bg-container);
   color:var(--color-text-secondary);
 }
 .jx-plan-approveBtn--ghost:hover{ border-color:var(--color-fill); background:var(--color-bg-gray); }

--- a/src/frontend/src/styles/projects.css
+++ b/src/frontend/src/styles/projects.css
@@ -6,7 +6,7 @@
   /* 预留两侧滚动条槽位：内容增减导致滚动条出现/消失时，
    * margin:auto 居中的 shell 不再左右平移（列表↔详情切换时的水平抖动） */
   scrollbar-gutter: stable both-edges;
-  background: #fff;
+  background: var(--color-bg-container);
   padding: 32px 40px 80px;
 }
 
@@ -74,7 +74,7 @@
 
 /* Card */
 .jx-projectCard {
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: 16px 18px;
@@ -140,7 +140,7 @@
   overflow: auto;
   /* 同 .jx-projects：滚动条槽位常驻，详情页加载完成出现滚动条时内容不平移 */
   scrollbar-gutter: stable both-edges;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-projectDetail--loading {
@@ -277,7 +277,7 @@
 
 .jx-projectRail-card {
   position: relative; /* FilesCard 拖拽上传高亮层的定位锚点 */
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: 16px;

--- a/src/frontend/src/styles/settings.css
+++ b/src/frontend/src/styles/settings.css
@@ -10,7 +10,7 @@
 .jx-settings-title {
   font-size: 20px;
   font-weight: 600;
-  color: #1a1a1a;
+  color: var(--color-text);
   margin: 0;
 }
 
@@ -28,14 +28,14 @@
 .jx-settings-section-title {
   font-size: 16px;
   font-weight: 500;
-  color: #000;
+  color: var(--color-text);
   margin: 0 0 10px;
 }
 
 /* Card container — bg-neutral-100, rounded-xl, border */
 .jx-settings-card {
-  background: #F5F5F5;
-  border: 1px solid #E3E6EA;
+  background: var(--color-bg-gray);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: 0;
   margin-bottom: 24px;
@@ -86,7 +86,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: var(--color-text-white);
 }
 .jx-conn-logo--lark {
   background: linear-gradient(135deg, #00D6B9 0%, #3370FF 100%);
@@ -104,14 +104,14 @@
 .jx-conn-title {
   font-size: 15px;
   font-weight: 600;
-  color: #1a1a1a;
+  color: var(--color-text);
   line-height: 1.4;
   margin-bottom: 4px;
 }
 .jx-conn-desc {
   font-size: 13px;
   line-height: 1.7;
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 /* 状态条：白底浮层，左侧状态徽标 + 账号名，右侧操作按钮 */
@@ -122,8 +122,8 @@
   flex-wrap: wrap;
   gap: 12px;
   padding: 12px 14px;
-  background: #fff;
-  border: 1px solid #E8EAED;
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   box-shadow: 0 1px 2px rgba(17, 24, 39, 0.04);
 }
@@ -156,10 +156,10 @@
 .jx-conn-badge--connected   { background: #E7F7EF; color: #0A9D52; }
 .jx-conn-badge--pending     { background: #FFF7E6; color: #D48806; }
 .jx-conn-badge--error       { background: #FFF1F0; color: #CF1322; }
-.jx-conn-badge--disconnected{ background: #F0F1F3; color: #8C8C8C; }
+.jx-conn-badge--disconnected{ background: #F0F1F3; color: var(--color-text-tertiary); }
 .jx-conn-account {
   font-size: 13px;
-  color: #4b5563;
+  color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -179,8 +179,8 @@
   flex-wrap: wrap;
   margin-top: 12px;
   padding: 16px;
-  background: #fff;
-  border: 1px solid #E8EAED;
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
 }
 .jx-conn-qr {
@@ -190,15 +190,15 @@
 .jx-conn-qr img {
   width: 168px;
   height: 168px;
-  background: #fff;
+  background: var(--color-bg-container);
   padding: 8px;
   border-radius: 10px;
-  border: 1px solid #E8EAED;
+  border: 1px solid var(--color-border);
 }
 .jx-conn-qrTip {
   margin-top: 6px;
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--color-text-placeholder);
 }
 .jx-conn-pendingMain {
   flex: 1;
@@ -210,7 +210,7 @@
 .jx-conn-pendingTitle {
   font-size: 14px;
   font-weight: 600;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 .jx-conn-link {
   font-size: 13px;
@@ -220,19 +220,19 @@
 }
 .jx-conn-code {
   font-size: 13px;
-  color: #4b5563;
+  color: var(--color-text-secondary);
 }
 .jx-conn-code code {
   padding: 2px 8px;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
+  background: var(--color-fill-hover);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 13px;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 .jx-conn-hint {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--color-text-placeholder);
 }
 /* 宜搭：多组织账号扫码后的组织选择列表 */
 .jx-conn-orgList {
@@ -257,7 +257,7 @@
 .jx-conn-fieldLabel {
   font-size: 13px;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-text);
 }
 .jx-conn-advGrid {
   display: flex;
@@ -339,8 +339,8 @@
   border-radius: 50%;
   display: block;
   object-fit: cover;
-  background: #fff;
-  border: 1px solid #E3E6EA;
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
 }
 
 .jx-settings-avatarOverlay {
@@ -376,14 +376,14 @@
   font-size: 14px;
   font-weight: 500;
   line-height: 1.4;
-  color: #334155;
+  color: var(--color-text);
 }
 
 .jx-settings-avatarPickerDesc {
   margin-top: 4px;
   font-size: 13px;
   line-height: 1.5;
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .jx-settings-avatarGrid {
@@ -394,9 +394,9 @@
 
 .jx-settings-avatarOption {
   appearance: none;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 18px;
-  background: #fff;
+  background: var(--color-bg-container);
   padding: 10px;
   cursor: pointer;
   transition: transform .15s ease, border-color .15s ease, box-shadow .15s ease;
@@ -431,12 +431,12 @@
 .jx-settings-userName {
   font-size: 18px;
   font-weight: 400;
-  color: #262626;
+  color: var(--color-text);
 }
 
 .jx-settings-userId {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
   font-weight: 400;
 }
 
@@ -459,7 +459,7 @@
   background: transparent !important;
   border: none;
   border-radius: 0 !important;
-  border-bottom: 1px solid #E3E6EA;
+  border-bottom: 1px solid var(--color-border);
   overflow: hidden;
 }
 
@@ -479,7 +479,7 @@
 
 .jx-settings-teamCollapse .ant-collapse-content {
   background: transparent;
-  border-top: 1px solid #E3E6EA;
+  border-top: 1px solid var(--color-border);
 }
 
 .jx-settings-teamCollapse .ant-collapse-content-box {
@@ -503,7 +503,7 @@
 
 .jx-settings-teamDesc {
   margin: 0 0 14px;
-  color: #6b7280;
+  color: var(--color-text-secondary);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -522,15 +522,15 @@
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
-  background: #fff;
-  border: 1px solid #E3E6EA;
+  background: var(--color-bg-container);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   transition: border-color .18s ease, background .18s ease;
 }
 
 .jx-settings-memberRow:hover {
   border-color: rgba(18,109,255,0.35);
-  background: #fafcff;
+  background: var(--color-bg-layout);
 }
 
 .jx-settings-memberInfo {
@@ -544,7 +544,7 @@
 .jx-settings-memberName {
   font-size: 14px;
   font-weight: 500;
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .jx-settings-memberMeta {
@@ -556,7 +556,7 @@
 
 .jx-settings-memberJoined {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--color-text-placeholder);
 }
 
 .jx-settings-teamActions {
@@ -564,7 +564,7 @@
   gap: 8px;
   margin-top: 14px;
   padding-top: 12px;
-  border-top: 1px dashed #E3E6EA;
+  border-top: 1px dashed var(--color-border);
 }
 
 /* ── 设置页：左侧锚点导航 ────────────────────────────────────── */
@@ -595,7 +595,7 @@
 }
 
 .jx-settings-ontologyGovernance {
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-settings-nav {
@@ -611,7 +611,7 @@
 
 .jx-settings-navTitle {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--color-text-placeholder);
   letter-spacing: .04em;
   padding: 0 12px 10px;
   margin: 0;
@@ -625,7 +625,7 @@
   padding: 8px 12px;
   border-radius: 8px;
   font-size: 14px;
-  color: #4b5563;
+  color: var(--color-text-secondary);
   cursor: pointer;
   position: relative;
   transition: background .18s ease, color .18s ease;
@@ -642,19 +642,19 @@
   margin-top: -8px;
   width: 3px;
   height: 16px;
-  background: #126dff;
+  background: var(--color-primary);
   border-radius: 2px;
   pointer-events: none;
 }
 
 .jx-settings-navItem:hover {
   background: rgba(18,109,255,0.06);
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .jx-settings-navItem.active {
   background: rgba(18,109,255,0.09);
-  color: #126dff;
+  color: var(--color-primary);
   font-weight: 500;
 }
 
@@ -734,19 +734,19 @@
 .jx-settings-rowLabel {
   font-size: 14px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
 }
 
 .jx-settings-rowDesc {
   font-size: 14px;
-  color: #B3B3B3;
+  color: var(--color-text-placeholder);
   line-height: 1.5;
   font-weight: 400;
 }
 
 .jx-settings-divider {
   height: 0;
-  border-top: 1px solid #E3E6EA;
+  border-top: 1px solid var(--color-border);
   margin: 0 20px;
 }
 
@@ -800,7 +800,7 @@
 
 .jx-settings-memoryCount {
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
 }
 
 .jx-settings-memoryLink {
@@ -826,7 +826,7 @@
 .jx-settings-enabledLabel {
   font-size: 14px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: var(--color-text);
   display: block;
   margin-bottom: 10px;
 }
@@ -844,9 +844,9 @@
   font-size: 14px;
   font-weight: 400;
   padding: 4px 8px;
-  border: 1px solid #E3E6EA;
-  background: #fff;
-  color: #475569;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-container);
+  color: var(--color-text-secondary);
   transition: transform var(--motion-duration-fast) var(--motion-ease-standard),
               border-color var(--motion-duration-fast) var(--motion-ease-standard);
 }
@@ -859,7 +859,7 @@
 .jx-settings-emptyHint {
   padding: 20px 20px;
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-placeholder);
 }
 
 /* ── Logout button — outline 主色, text-blue-600 ────────────────── */
@@ -871,13 +871,13 @@
   color: var(--color-primary);
   font-size: 14px;
   font-weight: 500;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-settings-logoutBtn.ant-btn:hover {
   border-color: var(--color-primary-active);
   color: var(--color-primary-active);
-  background: #f8faff;
+  background: var(--color-bg-layout);
 }
 
 /* ── 退出登录全屏遮罩（与硬跳转并行，盖住清空会话的中间帧） ──── */
@@ -886,13 +886,13 @@
   position: fixed;
   inset: 0;
   z-index: 3000;
-  background: #fff;
+  background: var(--color-bg-container);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 14px;
-  color: #4b5563;
+  color: var(--color-text-secondary);
   font-size: 14px;
 }
 
@@ -904,7 +904,7 @@
 .jx-settings-profileMeter {
   height: 4px;
   border-radius: 999px;
-  background: #ECEEF1;
+  background: var(--color-fill-hover);
   overflow: hidden;
   margin: 0 0 10px;
 }
@@ -938,7 +938,7 @@
     linear-gradient(-45deg, rgba(226,232,240,.9) 25%, transparent 25%) -12px 0/24px 24px,
     linear-gradient(45deg, transparent 75%, rgba(226,232,240,.9) 75%) -12px 0/24px 24px,
     linear-gradient(-45deg, transparent 75%, rgba(226,232,240,.9) 75%) -12px 0/24px 24px,
-    #f8fafc;
+    var(--color-bg-layout);
   touch-action: none;
   user-select: none;
   cursor: grab;
@@ -961,7 +961,7 @@
 .jx-settings-avatarCropMask {
   position: absolute;
   inset: 0;
-  border: 1px solid rgba(255,255,255,.85);
+  border: 1px solid color-mix(in srgb, var(--color-bg-container) 85%, transparent);
   border-radius: 18px;
   box-shadow: inset 0 0 0 1px rgba(15,23,42,.08);
   pointer-events: none;
@@ -970,7 +970,7 @@
 .jx-settings-avatarCropHint {
   font-size: 13px;
   line-height: 1.6;
-  color: #64748B;
+  color: var(--color-text-tertiary);
   text-align: center;
 }
 
@@ -983,7 +983,7 @@
 .jx-settings-avatarZoomLabel {
   flex: 0 0 auto;
   font-size: 13px;
-  color: #334155;
+  color: var(--color-text);
 }
 
 .jx-settings-avatarZoomRow .ant-slider {
@@ -1069,14 +1069,14 @@
   margin: 0;
   font-size: 20px;
   font-weight: 600;
-  color: #111827;
+  color: var(--color-text);
 }
 
 .jx-shareRecordsDesc {
   margin: 0;
   font-size: 14px;
   line-height: 1.6;
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 .jx-shareRecordsEmpty {
@@ -1084,9 +1084,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #f8fafc;
+  background: var(--color-bg-layout);
 }
 
 .jx-shareRecordsList {
@@ -1096,9 +1096,9 @@
 }
 
 .jx-shareRecordCard {
-  border: 1px solid #E3E6EA;
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-bg-container);
   padding: 18px 20px;
   width: 100%;
   box-sizing: border-box;
@@ -1238,12 +1238,12 @@
   font-size: 15px;
   font-weight: 500;
   line-height: 1.45;
-  color: #111827;
+  color: var(--color-text);
   transition: color .16s ease;
 }
 
 .jx-shareRecordTitleBtn:hover .jx-shareRecordTitle {
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 .jx-shareRecordMeta {
@@ -1252,7 +1252,7 @@
   gap: 8px 18px;
   font-size: 13px;
   line-height: 1.7;
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 .jx-shareRecordMetaBtn {
@@ -1264,7 +1264,7 @@
   border: none;
   background: transparent;
   padding: 0;
-  color: #64748b;
+  color: var(--color-text-tertiary);
   font-size: 13px;
   line-height: 1.7;
   cursor: pointer;
@@ -1277,7 +1277,7 @@
 
 .jx-shareRecordMetaBtn:hover,
 .jx-shareRecordMetaBtn:focus {
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .jx-shareRecordIdPopover .ant-popover-inner {
@@ -1288,7 +1288,7 @@
 .jx-shareRecordIdValue {
   display: inline-block;
   max-width: 360px;
-  color: #334155;
+  color: var(--color-text);
   font-size: 12px;
   line-height: 1.6;
   word-break: break-all;
@@ -1308,7 +1308,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   font-variant-numeric: tabular-nums;
   font-size: 12px;
   line-height: 1;
@@ -1332,7 +1332,7 @@
   border: none;
   background: transparent;
   padding: 0;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   font-size: 12px;
   line-height: 1;
   cursor: pointer;
@@ -1341,7 +1341,7 @@
 
 .jx-shareRecordTerminateBtn:hover,
 .jx-shareRecordTerminateBtn:focus {
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .jx-shareRecordActions {
@@ -1357,20 +1357,20 @@
 }
 
 .jx-shareRecordDeleteBtn {
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
 }
 
 .jx-shareRecordDeleteBtn:hover,
 .jx-shareRecordDeleteBtn:focus {
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .jx-shareRecordSide .ant-btn {
   height: 36px;
   padding: 0 16px;
   border-radius: 11px;
-  border-color: rgba(148, 163, 184, 0.28);
-  color: #334155;
+  border-color: color-mix(in srgb, var(--color-text-placeholder) 28%, transparent);
+  color: var(--color-text);
   font-size: 12px;
   font-weight: 500;
   box-shadow: none;
@@ -1383,9 +1383,9 @@
 
 .jx-shareRecordSide .ant-btn:hover,
 .jx-shareRecordSide .ant-btn:focus {
-  border-color: rgba(148, 163, 184, 0.42);
-  color: #0f172a;
-  background: #fbfcfe;
+  border-color: color-mix(in srgb, var(--color-text-placeholder) 42%, transparent);
+  color: var(--color-text);
+  background: var(--color-bg-layout);
 }
 
 @media (max-width: 768px) {
@@ -1503,10 +1503,10 @@
   justify-content:space-between;
   gap:16px;
   padding:12px 14px;
-  border:1px solid rgba(15,23,42,.08);
+  border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   border-radius:12px;
-  background:#fff;
+  background:var(--color-bg-container);
   transition:border-color .14s ease;
 }
-.jx-modeMine-item:hover{ border-color:rgba(15,23,42,.16); }
+.jx-modeMine-item:hover{ border-color:color-mix(in srgb, var(--color-text) 16%, transparent); }
 .jx-modeMine-body{ min-width:0; flex:1; }

--- a/src/frontend/src/styles/sidebar.css
+++ b/src/frontend/src/styles/sidebar.css
@@ -5,28 +5,28 @@
   width:280px !important;
   min-width:280px !important;
   max-width:280px !important;
-  border-right:1px solid rgba(15,23,42,.06);
+  border-right:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   display:flex !important;
   flex-direction:column !important;
   height:100% !important;
   transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), min-width 0.3s cubic-bezier(0.4, 0, 0.2, 1), max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
-  background:rgba(245,246,247,.72) !important;
+  background:color-mix(in srgb, var(--color-bg-gray) 72%, transparent) !important;
   backdrop-filter:blur(14px) saturate(1.3);
   -webkit-backdrop-filter:blur(14px) saturate(1.3);
   will-change: width;
 }
 /* 回退：不支持 backdrop-filter 时用实色 */
 @supports not (backdrop-filter:blur(1px)){
-  .jx-sider{ background:#F5F6F7 !important; }
+  .jx-sider{ background:var(--color-bg-gray) !important; }
 }
 .jx-sider.ant-layout-sider-collapsed{
   width:56px !important;
   min-width:56px !important;
   max-width:56px !important;
-  background:rgba(245,246,247,.85) !important;
+  background:color-mix(in srgb, var(--color-bg-gray) 85%, transparent) !important;
 }
 @supports not (backdrop-filter:blur(1px)){
-  .jx-sider.ant-layout-sider-collapsed{ background:#F5F6F7 !important; }
+  .jx-sider.ant-layout-sider-collapsed{ background:var(--color-bg-gray) !important; }
 }
 
 /* ══════════════════════════════════════════
@@ -90,11 +90,11 @@
   border-radius:10px;
   transition:background .15s, transform .12s;
   position:relative;
-  color:#262626;
+  color:var(--color-text);
 }
-.jx-miniRailBtn:hover{ background:#E3E6EA; }
+.jx-miniRailBtn:hover{ background:var(--color-border); }
 .jx-miniRailBtn:active{ transform:scale(.92); transition-duration:.06s; }
-.jx-miniRailBtn.active{ background:#EBEDEE; }
+.jx-miniRailBtn.active{ background:var(--color-fill-hover); }
 .jx-miniRailBtn.active::before{
   content:"";
   position:absolute;
@@ -102,13 +102,13 @@
   top:8px; bottom:8px;
   width:3px;
   border-radius:0 3px 3px 0;
-  background:#126DFF;
+  background:var(--color-primary);
 }
 .jx-miniRailIcon{ width:20px; height:20px; opacity:.72; transition:opacity .15s; display:block; }
 .jx-miniRailBtn:hover .jx-miniRailIcon,
 .jx-miniRailBtn.active .jx-miniRailIcon{ opacity:1; }
 .jx-miniRailBtn--primary{
-  background:#fff;
+  background:var(--color-bg-container);
   box-shadow:0 1px 2px rgba(0,0,0,.06), 0 3px 8px rgba(0,0,0,.05);
 }
 .jx-miniRailBtn--primary:hover{
@@ -124,7 +124,7 @@
   width:28px; height:28px;
   border-radius:50%;
   object-fit:cover;
-  background:#fff;
+  background:var(--color-bg-container);
   display:block;
 }
 .jx-miniRailNav{ margin-top:2px; }
@@ -154,6 +154,16 @@
       rgba(203, 223, 255, 0.38) 0px,
       rgba(223, 235, 255, 0.35) 39px,
       rgba(242, 245, 247, 0.28) 245px,
+      transparent 245px
+    );
+}
+/* 浅蓝装饰渐变在暗底上是一块灰雾，深色改用主色系暗渐变（从令牌派生，调色自动跟随） */
+:root[data-theme='dark'] .jx-siderInner{
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--color-primary) 10%, transparent) 0px,
+      color-mix(in srgb, var(--color-primary) 6%, transparent) 39px,
+      color-mix(in srgb, var(--color-primary) 3%, transparent) 245px,
       transparent 245px
     );
 }
@@ -187,8 +197,8 @@
 .jx-logo{ width:40px; height:40px; flex-shrink:0; }
 .jx-logoImg{ width:100%; height:100%; object-fit:contain; display:block; }
 .jx-brand-text{ flex:1; min-width:0; display:flex; flex-direction:column; justify-content:center; min-height:40px; }
-.jx-brand-title{ font-weight:800; font-size:18px; line-height:1.2; color:#1e293b; }
-.jx-brand-sub{ font-size:11px; color:rgba(15,23,42,.45); margin-top:1px; }
+.jx-brand-title{ font-weight:800; font-size:18px; line-height:1.2; color:var(--color-text); }
+.jx-brand-sub{ font-size:11px; color:color-mix(in srgb, var(--color-text) 45%, transparent); margin-top:1px; }
 
 /* Search button */
 .jx-searchBtn{
@@ -198,7 +208,7 @@
   display:flex; align-items:center; justify-content:center;
   border-radius:6px; transition:background .15s;
 }
-.jx-searchBtn:hover{ background:#E3E6EA; }
+.jx-searchBtn:hover{ background:var(--color-border); }
 .jx-searchBtn:active{ transform:scale(.92); transition-duration:.06s; }
 
 /* Collapse button — aligned with logo top, 10px from right */
@@ -209,18 +219,18 @@
   display:flex; align-items:center; justify-content:center;
   border-radius:6px; transition:background .15s, transform .12s;
 }
-.jx-collapseBtn:hover{ background:#E3E6EA; }
+.jx-collapseBtn:hover{ background:var(--color-border); }
 .jx-collapseBtn:active{ transform:scale(.92); transition-duration:.06s; }
 
-/* ── New Chat button: 248×38, pill, text #126DFF ── */
+/* ── New Chat button: 248×38, pill, text var(--color-primary) ── */
 .jx-newChatBtn{
   appearance:none;
   width:248px;
   height:38px;
   border:none;
   border-radius:100px;
-  background:#fff;
-  color:#126DFF;
+  background:var(--color-bg-container);
+  color:var(--color-primary);
   font-size:13px;
   font-weight:600;
   display:flex;
@@ -278,18 +288,31 @@
   cursor:pointer;
   font-size:13px;
   font-weight:400;
-  color:#262626;
+  color:var(--color-text);
   text-align:left;
   transition:background .15s, transform .12s;
 }
-.jx-navItem:hover{ background:#EBEDEE; }
+.jx-navItem:hover{ background:var(--color-fill-hover); }
 .jx-navItem:active{ transform:scale(.98); transition-duration:.06s; }
 .jx-navItem.active{
-  background:#EBEDEE;
-  color:#262626;
+  background:var(--color-fill-hover);
+  color:var(--color-text);
   font-weight:400;
 }
 .jx-navItemIcon{ width:18px; height:18px; flex-shrink:0; opacity:.7; }
+/* ── 深色下侧栏 SVG 资产统一提亮 ──
+   这些图标是深灰描边的 SVG 资产（img 引入，无法用 color 上色），暗底上会发闷；
+   压黑再反转成浅灰，蓝色系图标（newChatIcon / miniRailIcon--primary 有自己的上色滤镜）不动。 */
+:root[data-theme='dark'] .jx-navItemIcon,
+:root[data-theme='dark'] .jx-miniRailIcon:not(.jx-miniRailIcon--primary),
+:root[data-theme='dark'] .jx-searchBtn img,
+:root[data-theme='dark'] .jx-collapseBtn img,
+:root[data-theme='dark'] .jx-helpBtn img,
+:root[data-theme='dark'] .jx-historyTypeIcon--agent,
+:root[data-theme='dark'] .jx-historyTypeIcon--plan,
+:root[data-theme='dark'] .jx-settingsMenu .ant-dropdown-menu-item img{
+  filter:brightness(0) saturate(100%) invert(88%);
+}
 
 /* ══════════════════════════════════════════
    带二级列表的导航分组（能力中心 → 智能体/技能/连接器/插件）
@@ -333,13 +356,13 @@
   cursor:pointer;
   font-size:13px;
   font-weight:400;
-  color:rgba(15,23,42,.62);
+  color:color-mix(in srgb, var(--color-text) 62%, transparent);
   text-align:left;
   transition:background .15s, color .15s, transform .12s;
 }
-.jx-navSubItem:hover{ background:#EBEDEE; color:#262626; }
+.jx-navSubItem:hover{ background:var(--color-fill-hover); color:var(--color-text); }
 .jx-navSubItem:active{ transform:scale(.98); transition-duration:.06s; }
-.jx-navSubItem.active{ background:#EBEDEE; color:#262626; font-weight:500; }
+.jx-navSubItem.active{ background:var(--color-fill-hover); color:var(--color-text); font-weight:500; }
 /* 选中项把引导线对应的那一节染成主色，指明"线上的哪一节是当前项"。
    left/width 与 .jx-navSubList::before 完全一致，正好盖在竖线上。 */
 .jx-navSubItem.active::before{
@@ -350,7 +373,7 @@
   bottom:7px;
   width:2px;
   border-radius:2px;
-  background:var(--color-primary, #126DFF);
+  background:var(--color-primary, var(--color-primary));
 }
 .jx-navItem:hover .jx-navItemIcon{ opacity:1; }
 .jx-navItem.active .jx-navItemIcon{ opacity:1; }
@@ -378,7 +401,11 @@
 
 .jx-skeletonBlock{
   border-radius:999px;
-  background:linear-gradient(90deg, rgba(230,230,230,.86) 0%, rgba(238,238,238,.96) 50%, rgba(230,230,230,.86) 100%);
+  /* 从文字令牌派生的低透明度灰，深浅两个主题下都是「比底色深/亮一点」的微光 */
+  background:linear-gradient(90deg,
+    color-mix(in srgb, var(--color-text) 10%, transparent) 0%,
+    color-mix(in srgb, var(--color-text) 6%, transparent) 50%,
+    color-mix(in srgb, var(--color-text) 10%, transparent) 100%);
   background-size:240% 100%;
   animation:jxSkeletonShimmer 2.2s ease-in-out infinite;
 }
@@ -407,11 +434,11 @@
   margin:6px 0 0;
   border-radius:8px;
   cursor:pointer;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
   text-align:left;
   transition:color .12s;
 }
-.jx-historyGroupHeader:hover{ color:rgba(15,23,42,.72); }
+.jx-historyGroupHeader:hover{ color:color-mix(in srgb, var(--color-text) 72%, transparent); }
 .jx-historyGroupHeader:focus-visible{ outline:2px solid rgba(18,109,255,.32); outline-offset:0; }
 .jx-historyGroupTitle{
   font-size:11px;
@@ -479,9 +506,9 @@
   transition:background .15s;
   position:relative;
 }
-.jx-projectRow:hover{ background:#EBEDEE; }
-.jx-projectRow.active{ background:#fff; border-color:transparent; }
-.jx-projectRow.active .jx-projectRowIcon{ color:rgba(15,23,42,.8); }
+.jx-projectRow:hover{ background:var(--color-fill-hover); }
+.jx-projectRow.active{ background:var(--color-bg-container); border-color:transparent; }
+.jx-projectRow.active .jx-projectRowIcon{ color:color-mix(in srgb, var(--color-text) 80%, transparent); }
 .jx-projectRow.active .jx-projectRowName{ font-weight:400; }
 .jx-projectRowToggle{
   appearance:none; border:0; outline:0; background:transparent;
@@ -491,13 +518,13 @@
 }
 .jx-projectRowIcon{
   font-size:13px;
-  color:rgba(15,23,42,.55);
+  color:color-mix(in srgb, var(--color-text) 55%, transparent);
   flex-shrink:0;
   transition:color .15s;
 }
 .jx-projectRowName{
   flex:1; min-width:0;
-  font-size:12px; font-weight:500; color:#262626;
+  font-size:12px; font-weight:500; color:var(--color-text);
   overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
   transition:color .15s;
 }
@@ -517,12 +544,12 @@
   display:inline-flex; align-items:center; justify-content:center;
   border-radius:6px;
   cursor:pointer;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
   font-size:13px;
   padding:0;
   transition:background .12s, color .12s;
 }
-.jx-projectRowActionBtn:hover{ background:rgba(15,23,42,.08); color:rgba(15,23,42,.72); }
+.jx-projectRowActionBtn:hover{ background:rgba(15,23,42,.08); color:color-mix(in srgb, var(--color-text) 72%, transparent); }
 /* 嵌套会话列表：整体右缩进，形成"项目文件夹 → 会话"的层级观感 */
 .jx-projectChatList{ padding-left:16px; }
 .jx-projectChatList .jx-historyTitle{ max-width:210px; }
@@ -548,8 +575,8 @@
 .jx-historyItemSkeleton:hover{
   background:transparent;
 }
-.jx-historyItem:hover{ background:#EBEDEE; }
-.jx-historyItem.active{ background:#fff; border-color:transparent; }
+.jx-historyItem:hover{ background:var(--color-fill-hover); }
+.jx-historyItem.active{ background:var(--color-bg-container); border-color:transparent; }
 .jx-historyMain{ flex:1; min-width:0; display:flex; align-items:center; }
 .jx-historySkLine{
   width:100%;
@@ -584,14 +611,14 @@
   align-items:center;
   justify-content:center;
   margin-right:4px;
-  color:rgba(15,23,42,.45);
+  color:color-mix(in srgb, var(--color-text) 45%, transparent);
   font-size:10px;
   opacity:.9;
   transition:color .15s ease;
 }
-.jx-historyItem:hover .jx-historyPinIcon{ color:rgba(15,23,42,.72); }
+.jx-historyItem:hover .jx-historyPinIcon{ color:color-mix(in srgb, var(--color-text) 72%, transparent); }
 .jx-historyTitle{
-  font-size:12px; font-weight:500; color:#262626;
+  font-size:12px; font-weight:500; color:var(--color-text);
   overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
   flex:1;
   min-width:0;
@@ -604,10 +631,10 @@
   flex-shrink:0;
   font-size:12px;
   margin-right:5px;
-  color:rgba(15,23,42,.38);
+  color:color-mix(in srgb, var(--color-text) 38%, transparent);
   transition:color .15s;
 }
-.jx-historyItem:hover .jx-historyTypeIcon{ color:rgba(15,23,42,.55); }
+.jx-historyItem:hover .jx-historyTypeIcon{ color:color-mix(in srgb, var(--color-text) 55%, transparent); }
 
 /* ── Running indicator (pulse dot) ── */
 .jx-historyRunningDot{
@@ -615,7 +642,7 @@
   width:7px; height:7px;
   margin-left:6px;
   border-radius:50%;
-  background:#2563eb;
+  background:var(--color-primary);
   animation: jx-pulse 1.4s ease-in-out infinite;
 }
 @keyframes jx-pulse{
@@ -650,9 +677,9 @@
   appearance:none; border:none; outline:none; background:transparent;
   width:24px; height:24px; border-radius:6px;
   display:flex; align-items:center; justify-content:center;
-  cursor:pointer; font-size:13px; color:rgba(15,23,42,.48); padding:0;
+  cursor:pointer; font-size:13px; color:color-mix(in srgb, var(--color-text) 48%, transparent); padding:0;
 }
-.jx-historyMoreBtn:hover{ background:#F0F2F5; color:#333; }
+.jx-historyMoreBtn:hover{ background:var(--color-fill-hover); color:var(--color-text); }
 /* 重命名编辑框：挂载时轻微水平展开入场 */
 @keyframes jx-kf-renameIn{
   from{ opacity:0; transform:scaleX(.98); }
@@ -664,7 +691,7 @@
   animation:jx-kf-renameIn var(--motion-duration-fast) var(--motion-ease-standard) both;
 }
 .jx-historyEditInput .ant-input{ border-radius:8px; }
-.jx-historyEmpty{ padding:20px 8px; font-size:11px; color:rgba(15,23,42,.40); text-align:center; }
+.jx-historyEmpty{ padding:20px 8px; font-size:11px; color:color-mix(in srgb, var(--color-text) 40%, transparent); text-align:center; }
 
 /* 关键词高亮：被 utils/highlight.ts 用于侧栏 + 搜索弹窗的高亮 span */
 .jx-searchHighlight{ color:var(--color-primary); font-weight:600; }
@@ -673,7 +700,7 @@
 .jx-sideFooter{
   flex-shrink:0;
   padding:8px 16px 14px;
-  border-top:1px solid rgba(15,23,42,.06);
+  border-top:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   display:flex;
   align-items:center;
   gap:4px;
@@ -683,11 +710,11 @@
   flex:1; min-width:0;
   display:flex; align-items:center; gap:6px;
   padding:6px 4px; border-radius:8px; background:transparent;
-  cursor:pointer; font-size:12px; font-weight:500; color:#262626;
+  cursor:pointer; font-size:12px; font-weight:500; color:var(--color-text);
   text-align:left; transition:background .15s;
 }
 .jx-userInfoBtn:hover{ background:rgba(0,0,0,.04); }
-.jx-userAvatar{ width:24px; height:24px; border-radius:50%; flex-shrink:0; object-fit:cover; background:#fff; }
+.jx-userAvatar{ width:24px; height:24px; border-radius:50%; flex-shrink:0; object-fit:cover; background:var(--color-bg-container); }
 .jx-userName{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .jx-helpBtn{
   appearance:none; border:none; outline:none; background:transparent;
@@ -701,28 +728,28 @@
 /* ── Dropdown menus ── */
 .jx-chatItemMenu.ant-dropdown .ant-dropdown-menu{
   border-radius:10px; padding:4px;
-  box-shadow:0 8px 24px rgba(15,23,42,.12); border:1px solid rgba(15,23,42,.08); min-width:140px;
+  box-shadow:0 8px 24px rgba(15,23,42,.12); border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent); min-width:140px;
 }
 .jx-chatItemMenu.ant-dropdown .ant-dropdown-menu-item{ border-radius:6px; padding:7px 10px; font-size:12px; }
 .jx-chatItemMenu.ant-dropdown .ant-dropdown-menu-item-divider{ margin:4px 0; background:rgba(15,23,42,.08); }
 
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu{
   border-radius:12px; padding:4px;
-  box-shadow:0 8px 32px rgba(15,23,42,.14); border:1px solid rgba(15,23,42,.08); min-width:160px;
+  box-shadow:0 8px 32px rgba(15,23,42,.14); border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent); min-width:160px;
 }
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-item,
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-submenu-title{
-  border-radius:8px; padding:8px 12px; font-size:12px; color:rgba(15,23,42,.82);
+  border-radius:8px; padding:8px 12px; font-size:12px; color:color-mix(in srgb, var(--color-text) 82%, transparent);
 }
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-item:hover,
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-submenu-title:hover{
-  background:rgba(18,109,255,.06); color:#126DFF;
+  background:rgba(18,109,255,.06); color:var(--color-primary);
 }
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-item-divider{ margin:4px 0; background:rgba(15,23,42,.08); }
 
 /* 退出登录：悬停时才显示红色背景 */
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-item-danger {
-  color: #FC5D5D !important;
+  color: var(--color-error) !important;
 }
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-item-danger:hover {
   background: rgba(252,93,93,.08) !important;
@@ -732,19 +759,19 @@
 /* ── Legacy selectors ── */
 .jx-sideSection{padding:0 8px;}
 .jx-sectionHead{padding:2px 4px 6px;display:flex;align-items:center;justify-content:space-between;gap:4px;}
-.jx-sectionTitle{font-size:12px;font-weight:700;color:rgba(15,23,42,.52);}
+.jx-sectionTitle{font-size:12px;font-weight:700;color:color-mix(in srgb, var(--color-text) 52%, transparent);}
 .jx-sectionTag{margin:0;border-radius:999px;font-weight:900;font-size:11px;color:var(--color-primary);border-color:rgba(18,109,255,.20);background:rgba(18,109,255,.10);}
 .jx-sideTools{padding:0 2px 8px;display:flex;flex-direction:column;gap:10px;}
 .jx-capabilitySection{flex:0 0 auto;}
 .jx-capabilityList{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
-.jx-toolCard{width:100%;appearance:none;text-align:left;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 10px;background:#fff;border:1px solid rgba(15,23,42,.10);border-radius:12px;cursor:pointer;transition:box-shadow .2s,border-color .2s,background .2s;}
+.jx-toolCard{width:100%;appearance:none;text-align:left;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 10px;background:var(--color-bg-container);border:1px solid color-mix(in srgb, var(--color-text) 10%, transparent);border-radius:12px;cursor:pointer;transition:box-shadow .2s,border-color .2s,background .2s;}
 .jx-toolCard:hover{box-shadow:0 8px 18px rgba(15,23,42,.08);border-color:rgba(18,109,255,.25)}
 .jx-toolCard.active{border-color:rgba(18,109,255,.34);background:rgba(18,109,255,.08)}
 .jx-toolLeft{min-width:0;display:flex;flex-direction:column;gap:2px;}
 .jx-toolLine{display:flex;align-items:center;justify-content:space-between;gap:8px;}
 .jx-toolName{font-weight:900;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:6px;}
-.jx-toolIcon{color:rgba(15,23,42,.52);font-size:13px;display:inline-flex;align-items:center;}
-.jx-toolStatus{font-size:11px;color:rgba(15,23,42,.78);font-weight:900;border-radius:999px;padding:1px 6px;border:1px solid rgba(15,23,42,.18);background:rgba(255,255,255,.76);margin-left:auto;text-align:center;min-width:42px;}
+.jx-toolIcon{color:color-mix(in srgb, var(--color-text) 52%, transparent);font-size:13px;display:inline-flex;align-items:center;}
+.jx-toolStatus{font-size:11px;color:color-mix(in srgb, var(--color-text) 78%, transparent);font-weight:900;border-radius:999px;padding:1px 6px;border:1px solid color-mix(in srgb, var(--color-text) 18%, transparent);background:color-mix(in srgb, var(--color-bg-container) 76%, transparent);margin-left:auto;text-align:center;min-width:42px;}
 .jx-toolTag{flex:0 0 auto;font-size:12px;font-weight:900;padding:6px 8px;border-radius:10px;color:rgba(18,109,255,.9);background:rgba(18,109,255,.10);border:1px solid rgba(18,109,255,.22);}
 .jx-sideActionBar{display:none;}
 .jx-newChatWrap{display:none;}

--- a/src/frontend/src/styles/sites.css
+++ b/src/frontend/src/styles/sites.css
@@ -18,7 +18,7 @@
   justify-content: space-between;
   gap: var(--space-md);
   padding: var(--space-md) var(--space-lg);
-  background: #fff;
+  background: var(--color-bg-container);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
 }
@@ -249,9 +249,9 @@
   .jx-sites-list {
     overflow: hidden;
     gap: 0;
-    border: 1px solid rgba(15,23,42,.065);
+    border: 1px solid color-mix(in srgb, var(--color-text) 6.5%, transparent);
     border-radius: 22px;
-    background: rgba(255,255,255,.94);
+    background: color-mix(in srgb, var(--color-bg-container) 94%, transparent);
     box-shadow: 0 12px 34px rgba(42,61,94,.075), 0 1px 2px rgba(15,23,42,.035);
   }
 
@@ -263,18 +263,18 @@
   }
 
   .jx-sites-card + .jx-sites-card {
-    border-top: 1px solid rgba(15,23,42,.075);
+    border-top: 1px solid color-mix(in srgb, var(--color-text) 7.5%, transparent);
   }
 
   .jx-sites-cardTitle {
-    color: #101828;
+    color: var(--color-text);
     font-size: 17px;
     font-weight: 650;
     line-height: 1.4;
   }
 
   .jx-sites-cardMeta {
-    color: #667085;
+    color: var(--color-text-tertiary);
     font-size: 13px;
   }
 

--- a/src/frontend/src/styles/team-folder.css
+++ b/src/frontend/src/styles/team-folder.css
@@ -14,7 +14,7 @@
   align-items: center;
   gap: 8px;
   margin-top: 18px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -38,7 +38,7 @@
   font-family: var(--font-family);
   font-size: 16px;
   font-weight: 400;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   transition: color 0.18s ease;
 }
@@ -49,11 +49,11 @@
 
 /* 下划线由 motion layoutId 共享滑动接管（.jx-mySpace-tabInk--sub），不再用 ::after */
 .jx-mySpace-subTab:hover {
-  color: #394556;
+  color: var(--color-text-secondary);
 }
 
 .jx-mySpace-subTab.active {
-  color: #1c2430;
+  color: var(--color-text);
   font-weight: 500;
 }
 
@@ -80,7 +80,7 @@
   font-family: var(--font-family);
   font-size: 14px;
   font-weight: 400;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   transition: color 0.18s ease;
 }
@@ -91,11 +91,11 @@
 
 /* 下划线由 motion layoutId 共享滑动接管（.jx-mySpace-tabInk--filter），不再用 ::after */
 .jx-mySpace-filterTab:hover {
-  color: #394556;
+  color: var(--color-text-secondary);
 }
 
 .jx-mySpace-filterTab.active {
-  color: #1c2430;
+  color: var(--color-text);
   font-weight: 500;
 }
 
@@ -116,7 +116,7 @@
   min-width: 220px;
   max-width: 280px;
   padding: 8px 12px 8px 0;
-  border-right: 1px solid rgba(15, 23, 42, 0.06);
+  border-right: 1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   overflow: auto;
 }
 
@@ -135,7 +135,7 @@
   gap: 12px;
   padding: 0 2px 14px;
   margin-bottom: 12px;
-  border-bottom: 1px dashed rgba(15, 23, 42, 0.08);
+  border-bottom: 1px dashed color-mix(in srgb, var(--color-text) 8%, transparent);
 }
 
 .jx-team-workspace-actions {
@@ -167,7 +167,7 @@
   padding: 48px 24px;
   text-align: center;
   gap: 12px;
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .jx-team-workspace-hint-icon {
@@ -178,21 +178,21 @@
   height: 72px;
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.04);
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   margin-bottom: 4px;
 }
 
 .jx-team-workspace-hint-title {
   font-size: 15px;
   font-weight: 500;
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 .jx-team-workspace-hint-desc {
   font-size: 13px;
   line-height: 1.7;
   max-width: 320px;
-  color: #7b8697;
+  color: var(--color-text-tertiary);
 }
 
 
@@ -215,13 +215,13 @@
 .jx-team-scopeTree-title {
   font-size: 12px;
   font-weight: 600;
-  color: #64748b;
+  color: var(--color-text-tertiary);
   letter-spacing: 0.6px;
 }
 
 .jx-team-scopeTree-hint {
   font-size: 12px;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
 }
 
 .jx-team-scopeTree-body.ant-tree {
@@ -247,12 +247,12 @@
 
 .jx-team-scopeTree-body .ant-tree-node-content-wrapper:hover {
   background: rgba(15, 23, 42, 0.04);
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 .jx-team-scopeTree-body .ant-tree-node-selected {
   background: rgba(18, 109, 255, 0.10) !important;
-  color: #1c2430;
+  color: var(--color-text);
   font-weight: 500;
 }
 
@@ -306,7 +306,7 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: #94a3b8;
+  color: var(--color-text-placeholder);
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
@@ -315,7 +315,7 @@
 .jx-team-tree-more:hover,
 .jx-team-tree-more:focus-visible {
   background: rgba(15, 23, 42, 0.08);
-  color: #1e293b;
+  color: var(--color-text);
   outline: none;
 }
 
@@ -331,7 +331,7 @@
 .jx-team-tree-more[aria-expanded='true'] {
   opacity: 1;
   background: rgba(15, 23, 42, 0.08);
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 
@@ -351,7 +351,7 @@
 }
 
 .jx-team-breadcrumb .ant-breadcrumb-separator {
-  color: rgba(15, 23, 42, 0.25);
+  color: color-mix(in srgb, var(--color-text) 25%, transparent);
 }
 
 
@@ -360,13 +360,13 @@
 .jx-team-folder-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid rgba(15, 23, 42, 0.14);
+  border: 1px solid color-mix(in srgb, var(--color-text) 14%, transparent);
   border-radius: 6px;
   font-size: 14px;
   outline: none;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   margin-top: 10px;
-  background: #fff;
+  background: var(--color-bg-container);
 }
 
 .jx-team-folder-input:focus {
@@ -382,8 +382,8 @@
   overflow: auto;
   border-radius: 8px;
   padding: 10px 6px;
-  background: #fafbfc;
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  background: var(--color-bg-layout);
+  border: 1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
 }
 
 .jx-team-moveTree .ant-tree-node-content-wrapper {
@@ -417,7 +417,7 @@
     max-height: 240px;
     padding: 12px 0;
     border-right: none;
-    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   }
 
   .jx-team-workspace-toolbar {
@@ -439,7 +439,7 @@
     max-height: 240px;
     padding: 12px 0;
     border-right: none;
-    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   }
 
   .jx-team-workspace-toolbar {

--- a/src/frontend/src/styles/tool.css
+++ b/src/frontend/src/styles/tool.css
@@ -793,7 +793,7 @@
   gap:16px;
   padding:12px 14px;
   background:var(--color-bg-container);
-  border:1px solid rgba(203,213,225,.72);
+  border:1px solid color-mix(in srgb, var(--color-fill) 72%, transparent);
   border-radius:16px;
   box-shadow:0 6px 18px rgba(15,23,42,.05);
   max-width:460px;
@@ -819,9 +819,9 @@
   align-items:center;
   justify-content:center;
   flex-shrink:0;
-  background:linear-gradient(180deg, #fbfdff 0%, #f2f6fc 100%);
-  border:1px solid rgba(203,213,225,.72);
-  box-shadow:inset 0 1px 0 rgba(255,255,255,.85);
+  background:linear-gradient(180deg, var(--color-bg-layout) 0%, var(--color-fill-hover) 100%);
+  border:1px solid color-mix(in srgb, var(--color-fill) 72%, transparent);
+  box-shadow:inset 0 1px 0 color-mix(in srgb, var(--color-bg-container) 85%, transparent);
 }
 .jx-dlCard-fileIcon{
   object-fit:contain;
@@ -835,7 +835,7 @@
 .jx-dlCard-name{
   font-weight:600;
   font-size:14px;
-  color:rgba(17,24,39,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -859,7 +859,7 @@
   height:36px;
   padding:0 14px;
   border-radius:10px;
-  border:1px solid rgba(191,219,254,.95);
+  border:1px solid color-mix(in srgb, var(--color-primary) 30%, transparent);
   background:var(--color-primary-light);
   color:var(--color-primary);
   font-size:14px;
@@ -869,8 +869,8 @@
 }
 .jx-dlCard-btn:hover{
   background:var(--color-primary-bg);
-  border-color:#93c5fd;
-  color:#1d4ed8;
+  border-color:var(--color-primary-disabled);
+  color:var(--color-primary-active);
 }
 
 /* ── 图片卡片（ChatGPT 风格：裸图 + hover 内嵌操作） ─────────── */

--- a/src/frontend/src/styles/tool.css
+++ b/src/frontend/src/styles/tool.css
@@ -42,21 +42,21 @@
 }
 /* Monochrome: status is conveyed by icon shape, not colour. */
 .jx-tcr-icon--success {
-  color: rgba(15, 23, 42, 0.42);
+  color: color-mix(in srgb, var(--color-text) 42%, transparent);
 }
 .jx-tcr-icon--running {
-  color: rgba(15, 23, 42, 0.55);
+  color: color-mix(in srgb, var(--color-text) 55%, transparent);
 }
 /* Per-step category glyph (replaces the generic success tick) — quiet,
    thin-stroked, no fill; the kind of step is the signal, not "✓". */
 .jx-tcr-icon--step {
-  color: rgba(15, 23, 42, 0.4);
+  color: color-mix(in srgb, var(--color-text) 40%, transparent);
   font-size: 13px;
   stroke-width: 0;
   transition: color 0.15s ease;
 }
 .jx-tcr-header[role="button"]:hover .jx-tcr-icon--step {
-  color: rgba(15, 23, 42, 0.6);
+  color: color-mix(in srgb, var(--color-text) 60%, transparent);
 }
 /* Fallback marker for tools with no category icon — a small hollow ring */
 .jx-tcr-dot {
@@ -200,7 +200,7 @@
 }
 .jx-tcr-liveCode .jx-ce-codeBar {
   background: var(--color-fill-hover);
-  border-bottom-color: rgba(71, 84, 103, 0.12);
+  border-bottom-color: color-mix(in srgb, var(--color-text-secondary) 12%, transparent);
 }
 .jx-tcr-liveCode .jx-ce-langDot {
   background: var(--color-fill-heavy) !important;
@@ -290,7 +290,7 @@
   border-radius: 7px;
   font: inherit;
   text-align: left;
-  color: rgba(15, 23, 42, 0.72);
+  color: color-mix(in srgb, var(--color-text) 72%, transparent);
   cursor: pointer;
   transition: background 0.15s ease;
 }
@@ -298,7 +298,7 @@
   background: rgba(15, 23, 42, 0.035);
 }
 .jx-trs-head:focus-visible {
-  outline: 2px solid rgba(15, 23, 42, 0.18);
+  outline: 2px solid color-mix(in srgb, var(--color-text) 18%, transparent);
   outline-offset: 1px;
 }
 
@@ -341,7 +341,7 @@
   position: absolute;
   inset: 2px;
   border-radius: 50%;
-  border: 1.5px solid rgba(15, 23, 42, 0.28);
+  border: 1.5px solid color-mix(in srgb, var(--color-text) 28%, transparent);
   animation: jx-trs-ring 0.55s ease-out forwards;
 }
 @keyframes jx-trs-ring {
@@ -360,21 +360,21 @@
   font-size: 13.5px;
   font-weight: 500;
   letter-spacing: 0.01em;
-  color: rgba(15, 23, 42, 0.78);
+  color: color-mix(in srgb, var(--color-text) 78%, transparent);
 }
 .jx-trs-sep {
-  color: rgba(15, 23, 42, 0.25);
+  color: color-mix(in srgb, var(--color-text) 25%, transparent);
   font-size: 12px;
 }
 .jx-trs-dur {
   font-family: var(--font-family-number);
   font-size: 12.5px;
   font-variant-numeric: tabular-nums;
-  color: rgba(15, 23, 42, 0.5);
+  color: color-mix(in srgb, var(--color-text) 50%, transparent);
 }
 .jx-trs-steps {
   font-size: 12px;
-  color: rgba(15, 23, 42, 0.38);
+  color: color-mix(in srgb, var(--color-text) 38%, transparent);
 }
 /* Thin chevron, pushed to the right edge */
 .jx-trs-chev {
@@ -382,8 +382,8 @@
   height: 7px;
   margin-left: auto;
   flex-shrink: 0;
-  border-right: 1.5px solid rgba(15, 23, 42, 0.4);
-  border-bottom: 1.5px solid rgba(15, 23, 42, 0.4);
+  border-right: 1.5px solid color-mix(in srgb, var(--color-text) 40%, transparent);
+  border-bottom: 1.5px solid color-mix(in srgb, var(--color-text) 40%, transparent);
   transform: rotate(-45deg);
   transition: transform 0.2s ease;
 }
@@ -391,7 +391,7 @@
   transform: rotate(45deg);
 }
 .jx-trs-head:hover .jx-trs-chev {
-  border-color: rgba(15, 23, 42, 0.62);
+  border-color: color-mix(in srgb, var(--color-text) 62%, transparent);
 }
 
 /* ── Expanded body: grid-rows collapse animation + thin guide line ── */
@@ -412,7 +412,7 @@
   gap: 1px;
   margin: 3px 0 2px 17px;
   padding-left: 13px;
-  border-left: 1px solid rgba(15, 23, 42, 0.08);
+  border-left: 1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
 }
 
 /* Rows nested in the shell stay quiet; the shell owns the structure */
@@ -424,7 +424,7 @@
 }
 .jx-trs-body .jx-tcr-value {
   background: rgba(15, 23, 42, 0.04);
-  color: rgba(15, 23, 42, 0.7);
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -445,18 +445,18 @@
   gap: 6px;
   padding: 5px 10px;
   background: rgba(248, 250, 252, 0.9);
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
   border-radius: 7px;
   overflow: hidden;
 }
 .jx-tr-searchQueryIcon {
   font-size: 12px;
-  color: rgba(15, 23, 42, 0.40);
+  color: color-mix(in srgb, var(--color-text) 40%, transparent);
   flex-shrink: 0;
 }
 .jx-tr-searchQueryText {
   font-size: 12px;
-  color: rgba(15, 23, 42, 0.72);
+  color: color-mix(in srgb, var(--color-text) 72%, transparent);
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -466,7 +466,7 @@
 .jx-tr-searchQueryCount {
   font-size: 11px;
   font-weight: 700;
-  color: rgba(15, 23, 42, 0.38);
+  color: color-mix(in srgb, var(--color-text) 38%, transparent);
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
 }
@@ -505,8 +505,8 @@
   flex-shrink: 0;
   width: 160px;
   padding: 10px 12px;
-  background: #fff;
-  border: 1px solid rgba(15, 23, 42, 0.09);
+  background: var(--color-bg-container);
+  border: 1px solid color-mix(in srgb, var(--color-text) 9%, transparent);
   border-radius: 10px;
   text-decoration: none;
   color: inherit;
@@ -531,7 +531,7 @@
 .jx-tr-searchCardTitle {
   font-size: 12px;
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.88);
+  color: color-mix(in srgb, var(--color-text) 88%, transparent);
   line-height: 1.45;
   flex: 1;
   display: -webkit-box;
@@ -557,7 +557,7 @@
 }
 .jx-tr-searchCardDomain {
   font-size: 10.5px;
-  color: rgba(15, 23, 42, 0.38);
+  color: color-mix(in srgb, var(--color-text) 38%, transparent);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -569,8 +569,8 @@
   width:360px;
   min-width:300px;
   flex-shrink:0;
-  border-left:1px solid rgba(15,23,42,.08);
-  background:#fff;
+  border-left:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
+  background:var(--color-bg-container);
   display:flex;
   flex-direction:column;
   height:100%;
@@ -579,8 +579,8 @@
 }
 .jx-trp-header{
   padding:11px 14px 10px;
-  border-bottom:1px solid rgba(15,23,42,.07);
-  background:#fff;
+  border-bottom:1px solid color-mix(in srgb, var(--color-text) 7%, transparent);
+  background:var(--color-bg-container);
   flex-shrink:0;
 }
 .jx-trp-headerRow{
@@ -600,7 +600,7 @@
 .jx-trp-title{
   font-size:14px;
   font-weight:700;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -608,7 +608,7 @@
 }
 .jx-trp-summary{
   font-size:11px;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   margin-top:3px;
   padding-left:22px;
   white-space:nowrap;
@@ -625,14 +625,14 @@
   display:flex;
   align-items:center;
   justify-content:center;
-  color:rgba(15,23,42,.44);
+  color:color-mix(in srgb, var(--color-text) 44%, transparent);
   transition:background .15s,color .15s;
   flex-shrink:0;
   font-size:13px;
 }
 .jx-trp-close:hover{
   background:rgba(15,23,42,.07);
-  color:rgba(15,23,42,.8);
+  color:color-mix(in srgb, var(--color-text) 80%, transparent);
 }
 .jx-trp-body{
   flex:1;
@@ -659,7 +659,7 @@
   border-color:rgba(18,109,255,.22);
 }
 .jx-panelOpenIcon{
-  color:rgba(15,23,42,.36);
+  color:color-mix(in srgb, var(--color-text) 36%, transparent);
   font-size:12px !important;
   transition:color .15s;
 }
@@ -673,7 +673,7 @@
 
 /* Tool Calls Section */
 .jx-toolCallsSection{
-  background:linear-gradient(180deg, rgba(239,246,255,.92) 0%, rgba(255,255,255,.96) 100%);
+  background:linear-gradient(180deg, rgba(239,246,255,.92) 0%, color-mix(in srgb, var(--color-bg-container) 96%, transparent) 100%);
   border:1px solid rgba(18,109,255,.18);
   border-radius:14px;
   padding:10px;
@@ -701,7 +701,7 @@
   gap:8px;
 }
 .jx-toolCallItem{
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid rgba(18,109,255,.14);
   border-radius:12px;
   box-shadow:0 6px 18px rgba(17,24,39,.04);
@@ -729,7 +729,7 @@
   gap:8px;
   font-weight:700;
   font-size:13px;
-  color:rgba(31, 35, 40, 0.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
 }
 .jx-toolCallStatusIcon{
   font-size:14px;
@@ -776,7 +776,7 @@
 }
 .jx-expandIcon{
   font-size:10px;
-  color:rgba(31, 35, 40, 0.55);
+  color:color-mix(in srgb, var(--color-text) 55%, transparent);
 }
 
 /* ── 文件下载卡片 ─────────────────────────────── */
@@ -792,7 +792,7 @@
   justify-content:space-between;
   gap:16px;
   padding:12px 14px;
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid rgba(203,213,225,.72);
   border-radius:16px;
   box-shadow:0 6px 18px rgba(15,23,42,.05);
@@ -801,7 +801,7 @@
 }
 .jx-dlCard:hover{
   box-shadow:0 10px 24px rgba(15,23,42,.08);
-  border-color:rgba(148,163,184,.9);
+  border-color:color-mix(in srgb, var(--color-text-placeholder) 90%, transparent);
   transform:translateY(-1px);
 }
 .jx-dlCard-left{
@@ -844,7 +844,7 @@
 }
 .jx-dlCard-size{
   font-size:12px;
-  color:#7b8698;
+  color:var(--color-text-tertiary);
 }
 .jx-dlCard-actions{
   display:flex;
@@ -860,15 +860,15 @@
   padding:0 14px;
   border-radius:10px;
   border:1px solid rgba(191,219,254,.95);
-  background:#edf4ff;
-  color:#2563eb;
+  background:var(--color-primary-light);
+  color:var(--color-primary);
   font-size:14px;
   font-weight:500;
   text-decoration:none;
   transition:background .15s ease, border-color .15s ease, color .15s ease;
 }
 .jx-dlCard-btn:hover{
-  background:#e0edff;
+  background:var(--color-primary-bg);
   border-color:#93c5fd;
   color:#1d4ed8;
 }
@@ -885,7 +885,7 @@
   cursor:zoom-in;
 }
 .jx-imgCard:focus-visible{
-  outline:2px solid rgba(15,23,42,.30);
+  outline:2px solid color-mix(in srgb, var(--color-text) 30%, transparent);
   outline-offset:2px;
 }
 .jx-imgCard-img{
@@ -929,7 +929,7 @@
   backdrop-filter:blur(10px);
   -webkit-backdrop-filter:blur(10px);
   border:1px solid rgba(255,255,255,.18);
-  color:#fff;
+  color:var(--color-text-white);
   display:flex;
   align-items:center;
   justify-content:center;
@@ -941,7 +941,7 @@
 .jx-imgCard-overlayBtn:hover{
   background:rgba(0,0,0,.75);
   transform:scale(1.08);
-  color:#fff;
+  color:var(--color-text-white);
 }
 
 /* ── 图片全屏预览 ── */
@@ -1006,7 +1006,7 @@
   width:min(82vh, 90vw);
   height:auto;
   max-height:none;
-  background:#fff;
+  background:var(--color-bg-container);
   border-radius:8px;
   padding:16px;
   box-sizing:border-box;
@@ -1034,7 +1034,7 @@
   border-radius:8px;
   background:transparent;
   border:none;
-  color:#fff;
+  color:var(--color-text-white);
   display:flex;
   align-items:center;
   justify-content:center;
@@ -1053,7 +1053,7 @@
 .jx-imagePreviewZoomLabel{
   min-width:46px;
   text-align:center;
-  color:#fff;
+  color:var(--color-text-white);
   font-size:12px;
   font-variant-numeric:tabular-nums;
   user-select:none;
@@ -1095,7 +1095,7 @@
   max-height:400px;
   margin:0;
   font-family:'Consolas', 'Monaco', 'Courier New', monospace;
-  color:rgba(31, 35, 40, 0.92);
+  color:color-mix(in srgb, var(--color-text) 92%, transparent);
 }
 .jx-toolCode::-webkit-scrollbar{width:8px; height:8px}
 .jx-toolCode::-webkit-scrollbar-track{background:rgba(248, 250, 252, 1); border-radius:4px}
@@ -1108,7 +1108,7 @@
 /* 摘要行 — 显示在 header 折叠状态下 */
 .jx-toolCallSummary{
   font-size:11px;
-  color:rgba(15,23,42,.42);
+  color:color-mix(in srgb, var(--color-text) 42%, transparent);
   margin-left:6px;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -1121,7 +1121,7 @@
 /* 通用空态 */
 .jx-tr-empty{
   font-size:12px;
-  color:rgba(15,23,42,.40);
+  color:color-mix(in srgb, var(--color-text) 40%, transparent);
   padding:12px 4px;
   text-align:center;
 }
@@ -1133,11 +1133,11 @@
   border-radius:4px;
   margin-bottom:8px;
   background:rgba(248,250,252,1);
-  color:rgba(15,23,42,.72);
+  color:color-mix(in srgb, var(--color-text) 72%, transparent);
 }
-.jx-tr-dbHeader.success{color:rgba(15,23,42,.55);background:rgba(15,23,42,.035);border:1px solid rgba(15,23,42,.07);}
-.jx-tr-dbHeader.error{color:rgba(15,23,42,.72);background:rgba(15,23,42,.05);border:1px solid rgba(15,23,42,.12);}
-.jx-tr-dbText{font-size:12px;line-height:1.65;white-space:pre-wrap;color:rgba(15,23,42,.78);}
+.jx-tr-dbHeader.success{color:color-mix(in srgb, var(--color-text) 55%, transparent);background:rgba(15,23,42,.035);border:1px solid color-mix(in srgb, var(--color-text) 7%, transparent);}
+.jx-tr-dbHeader.error{color:color-mix(in srgb, var(--color-text) 72%, transparent);background:rgba(15,23,42,.05);border:1px solid color-mix(in srgb, var(--color-text) 12%, transparent);}
+.jx-tr-dbText{font-size:12px;line-height:1.65;white-space:pre-wrap;color:color-mix(in srgb, var(--color-text) 78%, transparent);}
 .jx-tr-dbText.error{color:#991b1b;}
 
 .jx-tr-tableWrap{overflow-x:auto;border-radius:6px;border:1px solid rgba(18,109,255,.14);}
@@ -1155,7 +1155,7 @@
 .jx-tr-table td{
   padding:5px 10px;
   border-bottom:1px solid rgba(18,109,255,.08);
-  color:rgba(15,23,42,.82);
+  color:color-mix(in srgb, var(--color-text) 82%, transparent);
   max-width:180px;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -1163,7 +1163,7 @@
 }
 .jx-tr-table tr:last-child td{border-bottom:none;}
 .jx-tr-table tr:nth-child(even) td{background:rgba(248,250,252,.6);}
-.jx-tr-moreHint{font-size:11px;color:rgba(15,23,42,.38);padding:6px 10px;text-align:center;border-top:1px solid rgba(18,109,255,.08);}
+.jx-tr-moreHint{font-size:11px;color:color-mix(in srgb, var(--color-text) 38%, transparent);padding:6px 10px;text-align:center;border-top:1px solid rgba(18,109,255,.08);}
 
 /* ── 知识库检索 ─────────────────────── */
 .jx-tr-kbList{display:flex;flex-direction:column;}
@@ -1181,7 +1181,7 @@
 .jx-tr-kbDocName{
   font-size:12.5px;
   font-weight:700;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   display:flex;
   align-items:center;
   gap:6px;
@@ -1195,14 +1195,14 @@
   height:18px;
   border-radius:50%;
   background:var(--color-primary);
-  color:#fff;
+  color:var(--color-text-white);
   font-size:10px;
   font-weight:700;
   flex-shrink:0;
 }
 .jx-tr-kbContent{
   font-size:12px;
-  color:rgba(15,23,42,.60);
+  color:color-mix(in srgb, var(--color-text) 60%, transparent);
   line-height:1.55;
   flex:1;
   min-width:0;
@@ -1266,13 +1266,13 @@
 .jx-tr-searchTitle{
   font-size:12.5px;
   font-weight:700;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   text-decoration:none;
   line-height:1.4;
   flex:1;
   min-width:0;
 }
-.jx-tr-searchSnippet{font-size:12px;color:rgba(15,23,42,.54);line-height:1.5;margin-bottom:5px;}
+.jx-tr-searchSnippet{font-size:12px;color:color-mix(in srgb, var(--color-text) 54%, transparent);line-height:1.5;margin-bottom:5px;}
 .jx-tr-searchFooter{display:flex;flex-wrap:wrap;gap:4px;margin-top:3px;}
 .jx-tr-searchDomain{
   font-size:10px;
@@ -1288,7 +1288,7 @@
 .jx-tr-detailBody{
   font-size:13px;
   line-height:1.75;
-  color:rgba(15,23,42,.82);
+  color:color-mix(in srgb, var(--color-text) 82%, transparent);
   white-space:pre-wrap;
   word-break:break-word;
   max-height:60vh;
@@ -1299,8 +1299,8 @@
 .jx-tr-detailScroll{max-height:62vh;overflow-y:auto;padding:2px 0;}
 .jx-tr-detailKV{display:flex;flex-direction:column;gap:5px;}
 .jx-tr-detailKVRow{display:flex;align-items:flex-start;gap:8px;font-size:12.5px;line-height:1.55;}
-.jx-tr-detailKVKey{color:rgba(15,23,42,.45);flex-shrink:0;min-width:110px;white-space:nowrap;}
-.jx-tr-detailKVValue{color:rgba(15,23,42,.82);flex:1;min-width:0;}
+.jx-tr-detailKVKey{color:color-mix(in srgb, var(--color-text) 45%, transparent);flex-shrink:0;min-width:110px;white-space:nowrap;}
+.jx-tr-detailKVValue{color:color-mix(in srgb, var(--color-text) 82%, transparent);flex:1;min-width:0;}
 
 /* ── 技能激活 ───────────────────────── */
 .jx-tr-skillBadge{
@@ -1318,7 +1318,7 @@
 /* 加载技能：能力中心同款的紧凑详情卡 */
 .jx-tr-skillCard{padding:10px 12px;display:flex;flex-direction:column;gap:8px;}
 .jx-tr-skillHead{display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;}
-.jx-tr-skillName{font-size:14px;font-weight:600;color:var(--color-text-primary);}
+.jx-tr-skillName{font-size:14px;font-weight:600;color:var(--color-text);}
 .jx-tr-skillVersion{font-size:12px;color:var(--color-text-tertiary);font-weight:400;}
 .jx-tr-skillDesc{margin:0;font-size:12px;color:var(--color-text-secondary);line-height:1.55;}
 .jx-tr-skillTags{display:flex;flex-wrap:wrap;gap:4px;}
@@ -1326,12 +1326,12 @@
 .jx-tr-skillBody{
   font-size:13px;
   line-height:1.65;
-  color:var(--color-text-primary);
+  color:var(--color-text);
   max-height:320px;
   overflow:auto;
   padding:8px 10px;
   background:rgba(15,23,42,.025);
-  border:1px solid rgba(15,23,42,.06);
+  border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   border-radius:6px;
 }
 .jx-tr-skillBody p:first-child{margin-top:0;}
@@ -1352,11 +1352,11 @@
   margin:0;
   padding:8px 10px;
   background:rgba(15,23,42,.025);
-  border:1px solid rgba(15,23,42,.06);
+  border:1px solid color-mix(in srgb, var(--color-text) 6%, transparent);
   border-radius:6px;
   font-size:12px;
   line-height:1.55;
-  color:var(--color-text-primary);
+  color:var(--color-text);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   white-space:pre-wrap;
   word-break:break-all;
@@ -1382,7 +1382,7 @@
 .jx-tr-capList{display:grid;grid-template-columns:1fr 1fr;gap:5px;}
 .jx-tr-capItem{
   font-size:12px;
-  color:rgba(15,23,42,.76);
+  color:color-mix(in srgb, var(--color-text) 76%, transparent);
   padding:4px 8px;
   background:rgba(248,250,252,.95);
   border:1px solid rgba(18,109,255,.12);
@@ -1405,7 +1405,7 @@
   max-height:280px;
   margin:0;
   font-family:'Consolas','Monaco','Courier New',monospace;
-  color:rgba(31,35,40,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   white-space:pre;
 }
 .jx-tr-jsonBlock::-webkit-scrollbar{width:6px;height:6px;}
@@ -1417,12 +1417,12 @@
 .jx-thinkingSection{
   background:transparent;
   border:none;
-  border-left:2px solid rgba(148,163,184,.34);
+  border-left:2px solid color-mix(in srgb, var(--color-text-placeholder) 34%, transparent);
   border-radius:0;
   padding:4px 0 4px 10px;
 }
 .jx-thinkingSection .jx-sectionHeader{
-  color:rgba(71,85,105,.88);
+  color:color-mix(in srgb, var(--color-text-secondary) 88%, transparent);
 }
 .jx-thinkingList{
   display:flex;
@@ -1446,19 +1446,19 @@
   user-select:none;
 }
 .jx-thinkingHeader:hover{
-  color:rgba(15,23,42,.92);
+  color:color-mix(in srgb, var(--color-text) 92%, transparent);
 }
 .jx-thinkingTitle{
   font-weight:600;
   font-size:13px;
-  color:rgba(71,85,105,.90);
+  color:color-mix(in srgb, var(--color-text-secondary) 90%, transparent);
 }
 .jx-thinkingBody{
   padding:4px 0 0;
   border-top:none;
   font-size:13px;
   line-height:1.7;
-  color:rgba(71,85,105,.90);
+  color:color-mix(in srgb, var(--color-text-secondary) 90%, transparent);
   white-space:pre-wrap;
   margin-top:0;
   font-style:normal;
@@ -1466,7 +1466,7 @@
 
 /* ── 新版思考块（DeepSeek 风格，内联展示） ── */
 .jx-thinkingBlock{
-  border-left:2px solid rgba(148,163,184,.34);
+  border-left:2px solid color-mix(in srgb, var(--color-text-placeholder) 34%, transparent);
   background:transparent;
   border-radius:0;
   overflow:visible;
@@ -1484,10 +1484,10 @@
   transition:color .18s ease;
 }
 .jx-thinkingBlockHeader:hover{
-  color:rgba(15,23,42,.90);
+  color:color-mix(in srgb, var(--color-text) 90%, transparent);
 }
 .jx-thinkingBlockHeader:focus-visible{
-  outline:2px solid rgba(15,23,42,.20);
+  outline:2px solid color-mix(in srgb, var(--color-text) 20%, transparent);
   outline-offset:2px;
   border-radius:6px;
 }
@@ -1498,15 +1498,15 @@
 }
 .jx-thinkingIcon{
   font-size:13px;
-  color:rgba(100,116,139,.88);
+  color:color-mix(in srgb, var(--color-text-tertiary) 88%, transparent);
 }
 .jx-thinkingLabel{
   font-size:13px;
   font-weight:500;
-  color:rgba(71,85,105,.90);
+  color:color-mix(in srgb, var(--color-text-secondary) 90%, transparent);
 }
 .jx-thinkingBlockHeader .jx-expandIcon{
-  color:rgba(100,116,139,.72);
+  color:color-mix(in srgb, var(--color-text-tertiary) 72%, transparent);
   font-size:10px;
 }
 /* ── Thinking body expand (uses .jx-expandWrap from variables.css) ── */
@@ -1515,7 +1515,7 @@
   padding:5px 0 0;
   font-size:13px;
   line-height:1.72;
-  color:rgba(71,85,105,.92);
+  color:color-mix(in srgb, var(--color-text-secondary) 92%, transparent);
   font-style:normal;
   white-space:pre-wrap;
   word-break:break-word;
@@ -1532,7 +1532,7 @@
 .jx-thinkingSpinner{
   width:12px;
   height:12px;
-  border:2px solid rgba(148,163,184,.50);
+  border:2px solid color-mix(in srgb, var(--color-text-placeholder) 50%, transparent);
   border-top-color:rgba(71,85,105,.86);
   border-radius:50%;
   animation:jxThinkSpin .8s linear infinite;
@@ -1581,11 +1581,11 @@
   border:none;
 }
 .jx-inlineSummary:hover .jx-inlineSummaryText{
-  color:rgba(51,65,85,.72);
+  color:color-mix(in srgb, var(--color-text-secondary) 72%, transparent);
 }
 .jx-inlineSummaryText{
   font-size:12.5px;
-  color:rgba(148,163,184,.85);
+  color:color-mix(in srgb, var(--color-text-placeholder) 85%, transparent);
   font-weight:400;
   white-space:nowrap;
   overflow:hidden;
@@ -1595,12 +1595,12 @@
 }
 .jx-inlineSummaryArrow{
   font-size:9px;
-  color:rgba(148,163,184,.60);
+  color:color-mix(in srgb, var(--color-text-placeholder) 60%, transparent);
   flex-shrink:0;
   transition:color .15s;
 }
 .jx-inlineSummary:hover .jx-inlineSummaryArrow{
-  color:rgba(100,116,139,.75);
+  color:color-mix(in srgb, var(--color-text-tertiary) 75%, transparent);
 }
 
 /* ── Tool timeline (Canvas panel body) ─── */
@@ -1640,7 +1640,7 @@
   left:-15px;top:12px;
   width:8px;height:8px;
   border-radius:50%;
-  border:2px solid #fff;
+  border:2px solid var(--color-bg-container);
   box-shadow:0 0 0 1px rgba(148,163,184,.30);
 }
 .jx-toolTimelineDot--running{
@@ -1661,19 +1661,19 @@
 .jx-toolTimelineName{
   font-size:12.5px;
   font-weight:600;
-  color:rgba(15,23,42,.88);
+  color:color-mix(in srgb, var(--color-text) 88%, transparent);
   margin-bottom:2px;
 }
 .jx-toolTimelineSummary{
   font-size:11px;
-  color:rgba(100,116,139,.75);
+  color:color-mix(in srgb, var(--color-text-tertiary) 75%, transparent);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
 }
 .jx-toolTimelineChevron{
   font-size:10px;
-  color:rgba(100,116,139,.45);
+  color:color-mix(in srgb, var(--color-text-tertiary) 45%, transparent);
   flex-shrink:0;
   margin-top:3px;
   transition:transform .2s ease;
@@ -1689,7 +1689,7 @@
 .jx-thinkingDetailBody{
   font-size:13px;
   line-height:1.72;
-  color:rgba(71,85,105,.92);
+  color:color-mix(in srgb, var(--color-text-secondary) 92%, transparent);
   white-space:pre-wrap;
   word-break:break-word;
 }
@@ -1701,7 +1701,7 @@
 .jx-tr-fallbackText{
   font-size:13px;
   line-height:1.6;
-  color:rgba(71,85,105,.85);
+  color:color-mix(in srgb, var(--color-text-secondary) 85%, transparent);
   white-space:pre-wrap;
   word-break:break-word;
   padding:6px 0;
@@ -1716,7 +1716,7 @@
 
 /* ── Card Container ── */
 .jx-ce-card{
-  background:#fff;
+  background:var(--color-bg-container);
   border:1px solid rgba(18,109,255,.14);
   border-radius:12px;
   box-shadow:0 2px 8px rgba(17,24,39,.03);
@@ -1818,7 +1818,7 @@
 .jx-ce-card,
 .jx-cap{
   --ce-mono:'Menlo','Consolas','Monaco','Liberation Mono','Courier New',monospace;
-  --ce-code-bg:#f6f8fa;
+  --ce-code-bg:var(--color-bg-layout);
   --ce-code-border:rgba(18,109,255,.10);
   --ce-line-num:#b0b8c4;
   --ce-line-border:rgba(18,109,255,.06);
@@ -1997,7 +1997,7 @@
   border-radius:var(--radius-sm);
   overflow:hidden;
   border:1px solid var(--color-border);
-  background:#fff;
+  background:var(--color-bg-container);
 }
 .jx-ce-outputBar{
   display:flex;
@@ -2064,7 +2064,7 @@
   border-radius:var(--radius-sm);
   overflow:hidden;
   border:1px solid var(--color-border);
-  background:#fff;
+  background:var(--color-bg-container);
   transition:box-shadow .15s,border-color .15s;
 }
 .jx-ce-imageCard:hover{
@@ -2359,12 +2359,12 @@
 .jx-confirmBar-btn:disabled{ opacity:.55; cursor:not-allowed; }
 .jx-confirmBar-btnIcon{ font-size:11px; }
 .jx-confirmBar-btn--primary{
-  color:#fff; background:var(--color-primary); border-color:var(--color-primary);
+  color:var(--color-text-white); background:var(--color-primary); border-color:var(--color-primary);
 }
 .jx-confirmBar-btn--primary:not(:disabled):hover{ background:var(--color-primary-hover); border-color:var(--color-primary-hover); }
 .jx-confirmBar-btn--primary:not(:disabled):active{ background:var(--color-primary-active); }
 .jx-confirmBar-btn--soft{
-  color:var(--color-primary); background:#fff; border-color:var(--color-primary-bg);
+  color:var(--color-primary); background:var(--color-bg-container); border-color:var(--color-primary-bg);
 }
 .jx-confirmBar-btn--soft:not(:disabled):hover{ background:var(--color-primary-light); border-color:var(--color-primary); }
 .jx-confirmBar-btn--ghost{
@@ -2422,7 +2422,7 @@
   border:1px solid var(--color-border);
   border-radius:var(--radius-sm);
   overflow:hidden;
-  background:#fff;
+  background:var(--color-bg-container);
   transition:border-color .15s, box-shadow .15s;
 }
 .jx-designPicker-option--selected .jx-designPicker-thumbWrap{
@@ -2436,14 +2436,14 @@
 .jx-designPicker-check{
   position:absolute; top:6px; right:6px;
   color:var(--color-primary); font-size:18px;
-  background:#fff; border-radius:50%; line-height:1;
+  background:var(--color-bg-container); border-radius:50%; line-height:1;
 }
 .jx-designPicker-pickBtn{
   font-size:13px; font-weight:500;
   padding:6px 10px;
   border-radius:var(--radius-sm);
   border:1px solid var(--color-primary-bg);
-  color:var(--color-primary); background:#fff;
+  color:var(--color-primary); background:var(--color-bg-container);
   cursor:pointer;
   overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
   transition:background .15s, border-color .15s;

--- a/src/frontend/src/styles/variables.css
+++ b/src/frontend/src/styles/variables.css
@@ -19,6 +19,18 @@
   --color-fill-hover:#EEF1F5;
   --color-bg-gray:#F4F6F9;
 
+  /* ── 背景语义层（深色模式的主开关：页面/容器/弹层/灰底布局四级） ── */
+  --color-bg-base:#FFFFFF;      /* 页面底色 */
+  --color-bg-container:#FFFFFF; /* 卡片、面板、输入区等容器 */
+  --color-bg-elevated:#FFFFFF;  /* 弹层、下拉、tooltip 等悬浮面（antd 侧对应 appTheme 的 colorBgElevated，自研浮层引用此令牌） */
+  --color-bg-layout:#F5F7FB;    /* 灰底布局区（侧边栏底、分区底） */
+
+  /* ── 滚动条（深浅只换令牌值，选择器共用下方全局规则） ── */
+  --scrollbar-tint:rgba(100,116,139,.14);
+  --scrollbar-thumb:rgba(100,116,139,.10);
+  --scrollbar-thumb-hover:rgba(100,116,139,.18);
+  --scrollbar-thumb-drag:rgba(100,116,139,.30);
+
   /* ── 文字 ── */
   --color-text:#101828;
   --color-text-secondary:#475467;
@@ -130,6 +142,89 @@
   --shadow1:0 10px 30px rgba(18,109,255,0.10);
 }
 
+/* ══════════════════════════════════════════
+   深色模式覆盖块
+   data-theme="dark" 由 index.html 防闪烁脚本 / src/theme.ts 打在 <html> 上。
+   只重定义颜色/阴影令牌，几何与 motion 令牌两个主题共用。
+   ══════════════════════════════════════════ */
+:root[data-theme="dark"]{
+  color-scheme:dark;
+
+  /* 主色在暗底上整体提亮一档，透明蓝替代浅蓝底 */
+  --color-primary:#3E8BFF;
+  --color-primary-hover:#5FA0FF;
+  --color-primary-active:#2E7BF0;
+  --color-primary-disabled:#28497E;
+  --color-primary-bg:rgba(62,139,255,.20);
+  --color-primary-light:rgba(62,139,255,.12);
+
+  --color-fill-heavy:#77828F;
+  --color-fill-deep:#66707E;
+  --color-fill:#333D4B;
+  --color-border:#2B3442;
+  --color-fill-hover:#252D39;
+  --color-bg-gray:#1B212B;
+
+  --color-bg-base:#0F141B;
+  --color-bg-container:#161C25;
+  --color-bg-elevated:#1C2330;
+  --color-bg-layout:#12171F;
+
+  --scrollbar-tint:rgba(148,163,184,.22);
+  --scrollbar-thumb:rgba(148,163,184,.16);
+  --scrollbar-thumb-hover:rgba(148,163,184,.26);
+  --scrollbar-thumb-drag:rgba(148,163,184,.40);
+
+  --color-text:#E8ECF4;
+  --color-text-secondary:#B3BDCD;
+  --color-text-tertiary:#8792A4;
+  --color-text-placeholder:#5F6B7D;
+
+  --color-success:#22C79D;
+  --color-success-hover:#3ADFB6;
+  --color-success-active:#12B58C;
+  --color-success-disabled:rgba(34,199,157,.35);
+  --color-success-bg:rgba(34,199,157,.16);
+  --color-success-light:rgba(34,199,157,.10);
+
+  /* warning 主三档与浅色相同，仅淡色底翻转 */
+  --color-warning-disabled:rgba(248,171,66,.35);
+  --color-warning-bg:rgba(248,171,66,.16);
+  --color-warning-light:rgba(248,171,66,.10);
+
+  --color-error:#FF6B6B;
+  --color-error-hover:#FF8585;
+  --color-error-disabled:rgba(255,107,107,.35);
+  --color-error-bg:rgba(255,107,107,.16);
+  --color-error-light:rgba(255,107,107,.10);
+
+  --color-icon-blue:#3E8BFF;
+  --color-icon-red:#FF6B6B;
+  --color-icon-purple:#9578FF;
+  --color-icon-green:#22C79D;
+
+  /* 暗底上阴影加深，靠边框分层为主 */
+  --shadow-card:
+    0 1px 2px rgba(0,0,0,.40),
+    0 8px 24px rgba(0,0,0,.32);
+  --shadow-card-hover:
+    0 2px 5px rgba(0,0,0,.45),
+    0 16px 38px rgba(0,0,0,.40);
+  --shadow-dropdown:
+    0 2px 8px rgba(0,0,0,.45),
+    0 20px 48px rgba(0,0,0,.55);
+
+  /* Legacy aliases：引用同块语义令牌，调色板改动自动跟随 */
+  --bg:var(--color-bg-container);
+  --text:var(--color-text);
+  --muted:rgba(232,236,244,.62);
+  --border:var(--color-border);
+  --primary:var(--color-primary);
+  --primary2:var(--color-primary-hover);
+  --accent:var(--color-primary-active);
+  --shadow1:0 10px 30px rgba(0,0,0,.35);
+}
+
 html,body,#root{height:100%}
 /* 全高 SPA 外壳：所有滚动都发生在内部容器（jx-content 等），文档本身不滚动。
  * 不锁 document 的话，附加到 <body> 的浮层（如下拉子菜单）超出视口时会让文档
@@ -139,28 +234,28 @@ body{
   margin:0;
   display:block !important;
   place-items:initial !important;
-  background:#FFFFFF;
+  background:var(--color-bg-base);
   color:var(--color-text);
   font-family:var(--font-family);
 }
 
-/* ── 全局滚动条基础样式 ── */
+/* ── 全局滚动条基础样式（深色由上方令牌翻转，不加选择器） ── */
 *{
   scrollbar-width:thin;
-  scrollbar-color:rgba(100,116,139,.14) transparent;
+  scrollbar-color:var(--scrollbar-tint) transparent;
 }
 *::-webkit-scrollbar{width:4px;height:4px;}
 *::-webkit-scrollbar-track{background:transparent;}
 *::-webkit-scrollbar-thumb{
-  background:rgba(100,116,139,.10);
+  background:var(--scrollbar-thumb);
   border-radius:999px;
   transition:background .3s;
 }
 *:hover::-webkit-scrollbar-thumb{
-  background:rgba(100,116,139,.18);
+  background:var(--scrollbar-thumb-hover);
 }
 *::-webkit-scrollbar-thumb:hover{
-  background:rgba(100,116,139,.30);
+  background:var(--scrollbar-thumb-drag);
 }
 /* 代码区域保留稍宽的滚动条 */
 pre::-webkit-scrollbar,

--- a/src/frontend/src/theme.ts
+++ b/src/frontend/src/theme.ts
@@ -1,0 +1,57 @@
+/**
+ * 主题模式唯一真源：system / light / dark 三档。
+ * - 持久化用全局 key（不做 userScopedKey）：防闪烁内联脚本在登录前运行，必须能直接读到；
+ *   index.html 里的 boot script 与本文件读同一个 key、同一套解析规则，两边同步改。
+ * - DOM 落地：documentElement 上打 data-theme="dark" + colorScheme（原生表单控件/滚动条跟随）。
+ *   CSS 侧由 variables.css 的 :root[data-theme="dark"] 覆盖块接管。
+ */
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'hugagent_theme_mode';
+
+export function loadThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'system';
+  try {
+    const raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return raw === 'light' || raw === 'dark' ? raw : 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+export function saveThemeMode(mode: ThemeMode): void {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch {
+    /* storage 不可用时静默降级为会话内生效 */
+  }
+}
+
+export function systemPrefersDark(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+}
+
+export function applyThemeToDom(isDark: boolean): void {
+  // 幂等短路：boot 脚本通常已落好状态，挂载时避免多余的文档级样式失效
+  const rootEl = document.documentElement;
+  const hasDark = rootEl.getAttribute('data-theme') === 'dark';
+  if (isDark !== hasDark) {
+    if (isDark) rootEl.setAttribute('data-theme', 'dark');
+    else rootEl.removeAttribute('data-theme');
+  }
+  const scheme = isDark ? 'dark' : 'light';
+  if (rootEl.style.colorScheme !== scheme) rootEl.style.colorScheme = scheme;
+}
+
+/** 监听系统外观变化；返回取消函数。非浏览器环境（SSR/测试）为 no-op。 */
+export function watchSystemTheme(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  media.addEventListener('change', onChange);
+  return () => media.removeEventListener('change', onChange);
+}


### PR DESCRIPTION
## What

Adds full dark mode support to the frontend.

- **New Appearance setting** under Settings → Session settings with three options: **Follow system / Light / Dark**. Switching applies instantly — no reload.
- In *Follow system* mode the UI reacts live to OS appearance changes via a `prefers-color-scheme` subscription.
- An inline boot script in `index.html` applies the stored theme before first paint, so dark-mode users no longer get a white flash on load.
- Share preview pages intentionally stay light so shared content renders exactly as authored.

## How

- `src/theme.ts` is the single source of truth for mode parsing, persistence (`localStorage`), and DOM application (`<html data-theme="dark">` + `color-scheme`).
- `AppThemeProvider` wraps the antd `ConfigProvider`, switching between `defaultAlgorithm`/`darkAlgorithm` with matching token sets.
- `variables.css` gains semantic background layers (base/container/elevated/layout) and a complete dark override block; scrollbar colors are tokenized.
- ~1300 hardcoded colors across the stylesheets were migrated to design tokens / `color-mix()` derivations, so both themes resolve from a single palette. Translucent glass surfaces and scroll-edge fade masks adapt automatically.
- Dark-specific overrides are kept to the few spots where assets cannot flip via tokens: sidebar SVG icons are brightened, the hero artwork is dimmed, and the docx preview keeps its white paper.

## Testing

- `npm run build` passes (type-check + i18n check + vite) on this tree.
- Verified light mode is pixel-faithful to the previous rendering; dark mode checked across home, conversation, My Space, scheduled tasks, and settings via real-stack screenshots.
- Live OS light/dark flip verified in *Follow system* mode without reload.