### PR TITLE
feat(ui): gate dark mode at build time instead of chasing regressions

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/check-i18n.mjs && tsc -b && vite build",
+    "build": "node scripts/check-i18n.mjs && node scripts/check-dark-mode.mjs && tsc -b && vite build",
     "check:i18n": "node scripts/check-i18n.mjs",
+    "check:dark": "node scripts/check-dark-mode.mjs",
     "test:chat-stream": "esbuild scripts/test-chat-stream-segments.ts --bundle --platform=node --format=esm --outfile=node_modules/.tmp/test-chat-stream-segments.mjs && node node_modules/.tmp/test-chat-stream-segments.mjs",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/src/frontend/scripts/check-dark-mode.mjs
+++ b/src/frontend/scripts/check-dark-mode.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+/**
+ * 深色模式门禁（构建前执行，与 check-i18n 同级）。
+ *
+ * 背景：深色模式靠 `<html data-theme="dark">` 切换 variables.css 的令牌覆盖块实现。
+ * 只要新写的样式**绕过令牌**直接写死颜色，浅色下看着正常、深色下就是一块白斑——
+ * 而且没人会在提交前逐个组件切两次主题。历史上踩过的四类盲区：
+ *   1. CSS 声明里直接写 #fff / rgba(0,0,0,.06)；
+ *   2. 自定义属性里嵌硬编码色（`--jx-chip-bg:#fff`）——批量替换脚本只扫真实声明，扫不到它；
+ *   3. TSX 内联 style / SVG 属性写死颜色（`style={{ background:'#ffffff' }}`）；
+ *   4. `var(--never-defined, #fff)`——兜底永远生效，等于硬编码。
+ * 外加一条纪律：深色专项覆盖一律用 `:root[data-theme='dark']`，禁止 `@media (prefers-color-scheme:dark)`
+ * （会和手动三档打架）。
+ *
+ * 门禁形态是**棘轮**而不是一刀切：`dark-mode-baseline.json` 冻结存量债，
+ * 新增违规直接挂构建，修掉存量后跑 `npm run check:dark -- --update` 把基线收紧。
+ * 存量只能变少、不能变多。
+ *
+ * 逃生舱：确实要写死颜色（暗色代码台、品牌插画、第三方主题对象）在同一行或上一行标
+ * `dark-ok: 原因`（CSS 用 `/* dark-ok: … *\/`，TS 用 `// dark-ok: …`）即豁免。
+ *
+ * 用法：
+ *   node scripts/check-dark-mode.mjs            # 门禁，超基线即退出码 1
+ *   node scripts/check-dark-mode.mjs --list     # 打印全部违规明细（含基线内的）
+ *   node scripts/check-dark-mode.mjs --update   # 以当前实测重写基线
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, dirname, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = join(scriptDir, '..');
+const srcRoot = join(frontendRoot, 'src');
+const baselinePath = join(scriptDir, 'dark-mode-baseline.json');
+
+/* CE 派生树的 overlay：`ce/overlay/src/frontend/src/**` 会在 build_ce 时**整文件替换**
+   同名的 `src/frontend/src/**`。不一起扫，overlay 里的硬编码色在本仓库就完全没有反馈——
+   要等派生出去之后、在另一个仓库跑构建才炸，那正是本门禁要消灭的「无反馈回路」。
+   仓库根 = frontendRoot 的上两级（src/frontend → repo root）。 */
+const repoRoot = join(frontendRoot, '..', '..');
+const ceOverlayRoot = join(repoRoot, 'ce', 'overlay', 'src', 'frontend', 'src');
+
+const args = process.argv.slice(2);
+const UPDATE = args.includes('--update');
+const LIST = args.includes('--list');
+
+/* ── 允许写死颜色的文件：调色板真源与成对主题定义 ──────────────────────
+   这些文件**本身**就是「浅色一套 / 深色一套」的定义处，写死颜色是它们的职责。 */
+const ALLOWED_FILES = new Set([
+  'src/styles/variables.css',      // 令牌调色板真源（:root 与 :root[data-theme=dark] 两块）
+  'src/styles/code-highlight.css', // 代码高亮双主题（github / github-dark 两套 token 色）
+  'src/theme.ts',                  // antd ConfigProvider 的成对主题对象
+]);
+
+/* 目录级跳过 */
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'assets', 'i18n']);
+
+/* ── 颜色字面量识别 ───────────────────────────────────────────────
+   命名色只收「会造成明暗事故」的那批（白/黑/灰系）；rebeccapurple 之流不管。 */
+const NAMED_COLORS =
+  /\b(white|black|whitesmoke|snow|ivory|floralwhite|ghostwhite|gainsboro|lightgray|lightgrey|silver|darkgray|darkgrey|dimgray|dimgrey|gray|grey)\b/i;
+const HEX = /#[0-9a-fA-F]{3,8}\b/;
+const FUNC_COLOR = /\b(rgba?|hsla?|hwb|lab|lch|oklab|oklch)\s*\(/i;
+
+/** `var(--已定义令牌, #fff)` 的兜底永远走不到，是死代码不是深色事故——整段摘掉别报。
+ *  令牌未定义的那种由 undefined-var-fallback 规则单独抓。 */
+function stripSafeVarFallbacks(value) {
+  return value.replace(
+    /var\(\s*(--[A-Za-z0-9_-]+)\s*,([^()]*(?:\([^()]*\)[^()]*)*)\)/g,
+    (whole, name) => (definedVars.has(name) ? ' ' : whole),
+  );
+}
+
+function hasColorLiteral(value) {
+  // 先摘掉令牌名本身：--color-text-white / --color-bg-gray 里的 white/gray 是名字不是颜色。
+  // color-mix(in srgb, var(--x) 8%, transparent) 是推荐写法，摘完就不含任何字面色。
+  const v = stripSafeVarFallbacks(value).replace(/--[A-Za-z0-9_-]+/g, '');
+  if (HEX.test(v)) return true;
+  if (FUNC_COLOR.test(v)) return true;
+  if (NAMED_COLORS.test(v)) return true;
+  return false;
+}
+
+/* 承载颜色的 CSS 属性（含自定义属性，单独判断） */
+const COLOR_PROPS =
+  /^(color|background|background-color|background-image|border|border-(top|right|bottom|left)?-?color|border(-(top|right|bottom|left))?|outline|outline-color|box-shadow|text-shadow|fill|stroke|caret-color|accent-color|text-decoration-color|column-rule-color|text-emphasis-color|scrollbar-color|filter|backdrop-filter|stop-color|flood-color|lighting-color)$/;
+
+/* TSX 内联 style 的同类属性（camelCase） */
+const JS_COLOR_PROPS = new Set([
+  'color', 'background', 'backgroundColor', 'backgroundImage', 'border', 'borderColor',
+  'borderTop', 'borderRight', 'borderBottom', 'borderLeft', 'borderTopColor',
+  'borderRightColor', 'borderBottomColor', 'borderLeftColor', 'outline', 'outlineColor',
+  'boxShadow', 'textShadow', 'fill', 'stroke', 'caretColor', 'accentColor',
+  'textDecorationColor', 'columnRuleColor', 'scrollbarColor', 'filter', 'backdropFilter',
+  'stopColor', 'floodColor', 'lightingColor',
+]);
+
+/* 规则 id 与它的修法写在一处——分成两份列表迟早会对不上（改了 id 忘了改帮助文案）。 */
+const RULE_SPECS = {
+  CSS_LITERAL: {
+    id: 'css-literal-color',                    // 盲区 1
+    fix: '颜色改用令牌 var(--color-*)；半透明面用\n'
+       + '                           color-mix(in srgb, var(--color-bg-container) 60%, transparent)',
+  },
+  CSS_VAR_DEF: {
+    id: 'css-var-literal-color',                // 盲区 2
+    fix: '自定义属性的值本身也要引令牌，别把 #fff 藏进 --jx-xxx',
+  },
+  JS_INLINE: {
+    id: 'js-inline-color',                      // 盲区 3
+    fix: '内联 style 改 var(--color-*)，或把样式挪进 CSS 类',
+  },
+  VAR_FALLBACK: {
+    id: 'undefined-var-fallback',               // 盲区 4
+    fix: 'var(--x, #fff) 的兜底永远生效；补上 --x 定义或直接引已有令牌',
+  },
+  MEDIA_SCHEME: {
+    id: 'prefers-color-scheme',                 // 纪律：禁止绕开手动三档
+    fix: "深色覆盖统一写 :root[data-theme='dark'] 选择器，别用媒体查询\n"
+       + '                           （媒体查询会和手动 light/dark 三档打架）',
+  },
+};
+const RULES = Object.fromEntries(Object.entries(RULE_SPECS).map(([k, v]) => [k, v.id]));
+const FIX_HINTS = Object.values(RULE_SPECS);
+const RULE_ID_WIDTH = Math.max(...FIX_HINTS.map((r) => r.id.length));
+
+const findings = [];
+function report(rule, file, line, snippet) {
+  findings.push({ rule, file, line, snippet: snippet.replace(/\s+/g, ' ').trim().slice(0, 160) });
+}
+
+/* ── 文件遍历 ─────────────────────────────────────────────────── */
+/** 一次读盘读完：definedVars 与扫描两遍都用同一份内容，别把每个文件读两次。 */
+const sources = new Map(); // 展示用相对路径 → 文件内容
+function collect(root, relTo) {
+  if (!existsSync(root)) return;
+  (function walk(dir) {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (e.name.startsWith('.')) continue;
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (SKIP_DIRS.has(e.name)) continue;
+        walk(p);
+      } else if (/\.(css|ts|tsx)$/.test(e.name)) {
+        sources.set(relative(relTo, p).split(sep).join('/'), readFileSync(p, 'utf-8'));
+      }
+    }
+  })(root);
+}
+collect(srcRoot, frontendRoot);
+// overlay 以仓库根为基准展示（ce/overlay/src/frontend/src/…），与主树同名文件区分开：
+// 两边都要扫——FULL 用主树那份，CE 派生后用 overlay 那份，谁都不能漏。
+collect(ceOverlayRoot, repoRoot);
+
+/* ── 全仓自定义属性定义集合（供盲区 4 取差集）───────────────────── */
+const definedVars = new Set();
+for (const src of sources.values()) {
+  for (const m of src.matchAll(/(--[A-Za-z0-9_-]+)\s*:/g)) definedVars.add(m[1]);
+  // JS 侧 setProperty('--x', …) 也算定义
+  for (const m of src.matchAll(/setProperty\(\s*['"`](--[A-Za-z0-9_-]+)/g)) definedVars.add(m[1]);
+}
+
+/** 豁免标记，三种写法：
+ *  1. 本行带 `dark-ok`；
+ *  2. 紧邻其上的注释块里带 `dark-ok`（注释可跨多行）；
+ *  3. 整段包在 `dark-ok-begin` / `dark-ok-end` 之间——用于生成独立文档的大段模板
+ *     （导出 PDF/HTML、邮件正文），那种整块都不该跟随界面主题。 */
+const COMMENT_LINE = /^\s*(\/\*|\*|\/\/)|\*\/\s*$/;
+const regionCache = new WeakMap();
+function exemptRegions(lines) {
+  let flags = regionCache.get(lines);
+  if (flags) return flags;
+  flags = new Array(lines.length).fill(false);
+  let open = false;
+  lines.forEach((ln, i) => {
+    if (/dark-ok-begin/.test(ln)) open = true;
+    flags[i] = open;
+    if (/dark-ok-end/.test(ln)) open = false;
+  });
+  regionCache.set(lines, flags);
+  return flags;
+}
+function exempt(lines, idx) {
+  if (exemptRegions(lines)[idx]) return true;
+  if (/dark-ok/.test(lines[idx] || '')) return true;
+  for (let i = idx - 1; i >= 0 && idx - i <= 8; i--) {
+    const ln = lines[i] || '';
+    if (/dark-ok/.test(ln)) return true;
+    if (!COMMENT_LINE.test(ln) && ln.trim() !== '') return false;
+  }
+  return false;
+}
+
+/* 未定义令牌 + 含颜色兜底：`var(--x, #fff)` */
+function scanVarFallback(text, lines, file) {
+  for (const m of text.matchAll(/var\(\s*(--[A-Za-z0-9_-]+)\s*,([^()]*(?:\([^()]*\)[^()]*)*)\)/g)) {
+    const [, name, fallback] = m;
+    if (definedVars.has(name)) continue;
+    if (!hasColorLiteral(fallback)) continue;
+    const line = text.slice(0, m.index).split('\n').length;
+    if (exempt(lines, line - 1)) continue;
+    report(RULES.VAR_FALLBACK, file, line, m[0]);
+  }
+}
+
+/* ── CSS 扫描 ─────────────────────────────────────────────────── */
+function scanCss(file, raw) {
+  const lines = raw.split('\n');
+  // 注释掏空但保留换行，行号才不漂
+  const text = raw.replace(/\/\*[\s\S]*?\*\//g, (c) => c.replace(/[^\n]/g, ' '));
+
+  for (const m of text.matchAll(/@media[^{]*prefers-color-scheme/g)) {
+    const line = text.slice(0, m.index).split('\n').length;
+    if (exempt(lines, line - 1)) continue;
+    report(RULES.MEDIA_SCHEME, file, line, m[0]);
+  }
+
+  scanVarFallback(text, lines, file);
+  if (ALLOWED_FILES.has(file)) return;
+
+  // 声明扫描：跟踪 selector 栈，`:root[data-theme` 块内允许写死（那就是深色覆盖块本身）
+  const selStack = [];
+  let buf = '';
+  let pos = 0;
+  // 声明可能跨多行（多层 gradient）。行号一律报**起始行**，dark-ok 注释才好写在它正上方。
+  let declStart = 0;
+  const flushDecl = () => {
+    const decl = buf.trim();
+    const startIdx = declStart;
+    buf = '';
+    if (!decl || !decl.includes(':')) return;
+    const ci = decl.indexOf(':');
+    const prop = decl.slice(0, ci).trim().toLowerCase();
+    const value = decl.slice(ci + 1);
+    const isVarDef = prop.startsWith('--');
+    if (!isVarDef && !COLOR_PROPS.test(prop)) return;
+    if (!hasColorLiteral(value)) return;
+    // 深色覆盖块内部写死颜色是允许的（它只在 data-theme=dark 下生效）
+    if (selStack.some((s) => /\[data-theme/.test(s))) return;
+    const line = text.slice(0, startIdx).split('\n').length;
+    if (exempt(lines, line - 1)) return;
+    report(isVarDef ? RULES.CSS_VAR_DEF : RULES.CSS_LITERAL, file, line, decl);
+  };
+
+  for (; pos < text.length; pos++) {
+    const ch = text[pos];
+    if (!buf.trim() && !/\s/.test(ch)) declStart = pos;
+    if (ch === '{') {
+      selStack.push(buf.trim());
+      buf = '';
+    } else if (ch === '}') {
+      flushDecl();
+      selStack.pop();
+    } else if (ch === ';') {
+      if (selStack.length > 0) flushDecl();
+      else buf = ''; // 块外的 @import / @charset 之类，不是声明
+    } else {
+      buf += ch;
+    }
+  }
+}
+
+/* ── TS/TSX 扫描 ──────────────────────────────────────────────── */
+/** 从 `prop:` 后取一段值：到同层 `,` 或 `}` 为止，跨过嵌套括号与字符串。 */
+function readValue(src, start) {
+  let i = start;
+  let depth = 0;
+  let quote = '';
+  for (; i < src.length; i++) {
+    const c = src[i];
+    if (quote) {
+      if (c === '\\') { i++; continue; }
+      if (c === quote) quote = '';
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') { quote = c; continue; }
+    if ('([{'.includes(c)) { depth++; continue; }
+    if (')]}'.includes(c)) {
+      if (depth === 0) break;
+      depth--;
+      continue;
+    }
+    if (c === ',' && depth === 0) break;
+    if (c === '\n' && depth === 0 && /[,;}]\s*$/.test(src.slice(start, i))) break;
+  }
+  return src.slice(start, i);
+}
+
+function scanJs(file, raw) {
+  if (ALLOWED_FILES.has(file)) return;
+  const lines = raw.split('\n');
+  // 行注释/块注释掏空，避免注释里的示例色误报
+  const text = raw
+    .replace(/\/\*[\s\S]*?\*\//g, (c) => c.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, (m, p1) => p1 + ' '.repeat(m.length - p1.length));
+
+  scanVarFallback(text, lines, file);
+
+  // 对象字面量属性：{ color: …, background: … }
+  const propRe = /(?:^|[{,(\s])([A-Za-z]+)\s*:/g;
+  for (const m of text.matchAll(propRe)) {
+    const prop = m[1];
+    if (!JS_COLOR_PROPS.has(prop)) continue;
+    const value = readValue(text, m.index + m[0].length);
+    if (!hasColorLiteral(value)) continue;
+    const line = text.slice(0, m.index).split('\n').length;
+    if (exempt(lines, line - 1)) continue;
+    report(RULES.JS_INLINE, file, line, `${prop}:${value}`);
+  }
+
+  // JSX 属性：<circle fill="#fff" stroke="rgba(…)">
+  const attrRe = /\b(fill|stroke|stopColor|color|bgColor)\s*=\s*(["'])([^"']*)\2/g;
+  for (const m of text.matchAll(attrRe)) {
+    if (!hasColorLiteral(m[3])) continue;
+    const line = text.slice(0, m.index).split('\n').length;
+    if (exempt(lines, line - 1)) continue;
+    report(RULES.JS_INLINE, file, line, m[0]);
+  }
+}
+
+for (const [file, raw] of sources) {
+  if (file.endsWith('.css')) scanCss(file, raw);
+  else scanJs(file, raw);
+}
+
+/* ── 棘轮比对 ─────────────────────────────────────────────────── */
+/** 基线按 file → rule → 计数聚合：行号会漂，快照文本又太脆，计数最稳。
+ *  已知取舍：同一 file+rule 桶内「删一处、又新增一处」计数不变，门禁不会报——
+ *  但那种改动必然出现在 diff 里、由 review 兜住，而棘轮要保证的「存量只减不增」不受影响。
+ *  真要收严，可改成对 snippet 内容做哈希集合（对行号漂移免疫），代价是基线体积与噪声。 */
+function tally(list) {
+  const out = {};
+  for (const f of list) {
+    (out[f.file] ||= {});
+    out[f.file][f.rule] = (out[f.file][f.rule] || 0) + 1;
+  }
+  return out;
+}
+
+const current = tally(findings);
+
+if (UPDATE) {
+  const sorted = {};
+  for (const file of Object.keys(current).sort()) {
+    sorted[file] = Object.fromEntries(Object.entries(current[file]).sort());
+  }
+  writeFileSync(baselinePath, `${JSON.stringify(sorted, null, 2)}\n`, 'utf-8');
+  console.log(`[check-dark-mode] 基线已更新：${Object.keys(sorted).length} 个文件 / ${findings.length} 处存量`);
+  process.exit(0);
+}
+
+const baseline = existsSync(baselinePath) ? JSON.parse(readFileSync(baselinePath, 'utf-8')) : {};
+
+if (LIST) {
+  for (const f of findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
+    console.log(`${f.file}:${f.line}  [${f.rule}]  ${f.snippet}`);
+  }
+  console.log(`\n合计 ${findings.length} 处`);
+}
+
+/* 取 current 与 baseline 的键并集再逐条比：只走 current 会漏掉「已清零」的桶（它不再有键），
+   只走 baseline 会漏掉新出现的文件。一次遍历同时得出超标与改善。 */
+const buckets = new Map(); // file → Set(rule)；用嵌套结构而不是拼接字符串当键
+for (const source of [current, baseline]) {
+  for (const [file, rules] of Object.entries(source)) {
+    const set = buckets.get(file) ?? new Set();
+    for (const rule of Object.keys(rules)) set.add(rule);
+    buckets.set(file, set);
+  }
+}
+
+const regressions = [];
+let improved = 0;
+for (const [file, rules] of buckets) {
+  for (const rule of rules) {
+    const count = current[file]?.[rule] || 0;
+    const allowed = baseline[file]?.[rule] || 0;
+    if (count > allowed) regressions.push({ file, rule, count, allowed });
+    else if (count < allowed) improved += allowed - count;
+  }
+}
+
+if (regressions.length) {
+  console.error('\n[check-dark-mode] 深色模式门禁未通过——下列位置绕过了颜色令牌：\n');
+  for (const r of regressions) {
+    console.error(`  ${r.file}  [${r.rule}]  ${r.count} 处（基线允许 ${r.allowed} 处）`);
+    for (const f of findings.filter((x) => x.file === r.file && x.rule === r.rule).slice(0, 12)) {
+      console.error(`      ${f.file}:${f.line}  ${f.snippet}`);
+    }
+  }
+  const hints = FIX_HINTS.map((r) => `  ${r.id.padEnd(RULE_ID_WIDTH)} \u2192 ${r.fix}`).join('\n');
+  console.error(`
+\u4fee\u6cd5\uff08\u6309\u76f2\u533a\u5206\u7c7b\uff09\uff1a
+${hints}
+\u786e\u5b9e\u9700\u8981\u5199\u6b7b\u989c\u8272\uff08\u6697\u8272\u4ee3\u7801\u53f0\u3001\u54c1\u724c\u63d2\u753b\u3001\u6210\u5bf9\u4e3b\u9898\u5bf9\u8c61\uff09\u2192 \u8be5\u884c\u52a0 dark-ok: \u539f\u56e0 \u8c41\u514d\uff1b
+\u6574\u6bb5\u6a21\u677f\u7528 dark-ok-begin / dark-ok-end \u5305\u8d77\u6765\u3002
+\u660e\u7ec6\uff1anpm run check:dark -- --list
+`);
+  process.exit(1);
+}
+
+if (improved > 0) {
+  console.log(`[check-dark-mode] 通过（存量比基线少 ${improved} 处，可跑 npm run check:dark -- --update 收紧基线）`);
+} else {
+  console.log(`[check-dark-mode] 通过（存量 ${findings.length} 处，全部在基线内）`);
+}

--- a/src/frontend/scripts/dark-mode-baseline.json
+++ b/src/frontend/scripts/dark-mode-baseline.json
@@ -1,0 +1,262 @@
+{
+  "src/AdminApp.tsx": {
+    "js-inline-color": 9
+  },
+  "src/ApiDocApp.tsx": {
+    "js-inline-color": 1
+  },
+  "src/ConfigApp.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/admin/AdminAgentManager.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/admin/AppConfigEditor.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/admin/DataSourceManager.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/admin/IconPicker.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/admin/KnowledgeBaseManager.tsx": {
+    "js-inline-color": 10
+  },
+  "src/components/admin/LoginView.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/admin/ManualEditor.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/admin/McpServersEditor.tsx": {
+    "js-inline-color": 4
+  },
+  "src/components/admin/ModelsEditor.tsx": {
+    "js-inline-color": 5
+  },
+  "src/components/admin/PageConfigEditor.tsx": {
+    "js-inline-color": 3
+  },
+  "src/components/admin/PluginsEditor.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/admin/PromptVersionsEditor.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/admin/PromptsEditor.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/admin/SandboxDepsManager.tsx": {
+    "js-inline-color": 6
+  },
+  "src/components/admin/ServiceConfigsEditor.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/admin/SkillsEditor.tsx": {
+    "js-inline-color": 4
+  },
+  "src/components/agent/AgentFormFields.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/agent/AgentMarketplaceModal.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/agent/AgentPanel.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/apidoc/ApiDocPanel.tsx": {
+    "js-inline-color": 6
+  },
+  "src/components/batch/BatchProgressPanel.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/catalog/CatalogPanel.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/catalog/LarkAppInitCard.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/catalog/McpPage.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/catalog/PluginIconPicker.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/catalog/PluginsPage.tsx": {
+    "js-inline-color": 11
+  },
+  "src/components/catalog/SkillMarketplaceModal.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/catalog/SkillsPage.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/chat/PromptHubPanel.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/common/DshIcons.tsx": {
+    "js-inline-color": 4
+  },
+  "src/components/common/MarketPickerModal.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/config/ChatHistoryPanel.tsx": {
+    "js-inline-color": 5
+  },
+  "src/components/config/ConfigLoginView.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/config/SandboxInstanceManager.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/config/SecurityAuditLogsPanel.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/config/SkillCallLogsPanel.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/config/SubAgentLogsPanel.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/config/SystemHealthPanel.tsx": {
+    "js-inline-color": 4
+  },
+  "src/components/config/UsageLogsPanel.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/kb/ConceptGraph.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/kb/ReindexModal.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/kb/wikiGraphTheme.ts": {
+    "js-inline-color": 14
+  },
+  "src/components/lab/AutomationDetailPage.tsx": {
+    "js-inline-color": 3
+  },
+  "src/components/loop/loop.css": {
+    "css-literal-color": 4
+  },
+  "src/components/memory/FactsList.tsx": {
+    "js-inline-color": 4
+  },
+  "src/components/onboarding/FirstRunSetup.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/ontology/OntologyManager.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/projects/ProjectMemoriesModal.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/settings/SettingsModal.tsx": {
+    "js-inline-color": 5
+  },
+  "src/components/share/ShareRecordsPage.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/sidebar/SearchModal.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/sidebar/Sidebar.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/tool/ToolOutputRenderer.tsx": {
+    "js-inline-color": 8
+  },
+  "src/components/tool/ToolResultPanel.tsx": {
+    "js-inline-color": 2
+  },
+  "src/components/tool/renderers/KBRenderer.tsx": {
+    "js-inline-color": 1
+  },
+  "src/components/tool/renderers/MySpaceRenderer.tsx": {
+    "js-inline-color": 4
+  },
+  "src/components/tool/renderers/SearchRenderer.tsx": {
+    "js-inline-color": 1
+  },
+  "src/edition-ee/myspace/ImageGrid.tsx": {
+    "js-inline-color": 2
+  },
+  "src/edition-ee/myspace/TeamScopeTree.tsx": {
+    "js-inline-color": 1
+  },
+  "src/edition-ee/settings/TeamsSection.tsx": {
+    "js-inline-color": 1
+  },
+  "src/stores/authStore.ts": {
+    "js-inline-color": 1
+  },
+  "src/styles/admin.css": {
+    "css-literal-color": 1
+  },
+  "src/styles/automation-timeline.css": {
+    "css-literal-color": 6
+  },
+  "src/styles/automation.css": {
+    "css-literal-color": 8
+  },
+  "src/styles/canvas.css": {
+    "css-literal-color": 16
+  },
+  "src/styles/catalog.css": {
+    "css-literal-color": 115
+  },
+  "src/styles/chat.css": {
+    "css-literal-color": 89
+  },
+  "src/styles/common.css": {
+    "css-literal-color": 8
+  },
+  "src/styles/evolution.css": {
+    "css-literal-color": 7
+  },
+  "src/styles/kb-wiki.css": {
+    "css-literal-color": 5
+  },
+  "src/styles/mcp.css": {
+    "css-literal-color": 3
+  },
+  "src/styles/mobile.css": {
+    "css-literal-color": 34,
+    "css-var-literal-color": 1
+  },
+  "src/styles/myspace.css": {
+    "css-literal-color": 37
+  },
+  "src/styles/onboarding.css": {
+    "css-literal-color": 35
+  },
+  "src/styles/ontology.css": {
+    "css-literal-color": 36
+  },
+  "src/styles/plan.css": {
+    "css-literal-color": 9
+  },
+  "src/styles/search-modal.css": {
+    "css-literal-color": 4
+  },
+  "src/styles/settings.css": {
+    "css-literal-color": 22
+  },
+  "src/styles/sidebar.css": {
+    "css-literal-color": 34
+  },
+  "src/styles/sites.css": {
+    "css-literal-color": 1
+  },
+  "src/styles/skill-distill.css": {
+    "css-literal-color": 2
+  },
+  "src/styles/team-folder.css": {
+    "css-literal-color": 10
+  },
+  "src/styles/tool.css": {
+    "css-literal-color": 47,
+    "css-var-literal-color": 5
+  }
+}

--- a/src/frontend/src/ApiDocApp.tsx
+++ b/src/frontend/src/ApiDocApp.tsx
@@ -23,7 +23,7 @@ export default function ApiDocApp() {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Header style={{
-        background: '#fff',
+        background: 'var(--color-bg-container)',
         borderBottom: '1px solid #E3E6EA',
         display: 'flex',
         alignItems: 'center',
@@ -32,7 +32,7 @@ export default function ApiDocApp() {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
           <Title level={5} style={{ margin: 0 }}>
-            <ProfileOutlined style={{ marginRight: 8, color: '#126DFF' }} />
+            <ProfileOutlined style={{ marginRight: 8, color: 'var(--color-primary)' }} />
             {docTitle}
           </Title>
           <Divider type="vertical" />
@@ -69,7 +69,7 @@ export default function ApiDocApp() {
           </Button>
         </div>
       </Header>
-      <Content style={{ background: '#fff', height: 'calc(100vh - 64px)', overflow: 'hidden' }}>
+      <Content style={{ background: 'var(--color-bg-container)', height: 'calc(100vh - 64px)', overflow: 'hidden' }}>
         <ApiDocPanel onReloadRef={reloadRef} />
       </Content>
     </Layout>

--- a/src/frontend/src/components/apidoc/ApiDocPanel.tsx
+++ b/src/frontend/src/components/apidoc/ApiDocPanel.tsx
@@ -670,17 +670,17 @@ function AuthGuide() {
   return (
     <Collapse
       defaultActiveKey={['guide']}
-      style={{ margin: '12px 16px 0', background: '#F5F8FF', border: '1px solid #D6E4FF' }}
+      style={{ margin: '12px 16px 0', background: 'var(--color-primary-light)', border: '1px solid #D6E4FF' }}
       items={[{
         key: 'guide',
         label: (
           <Space>
-            <KeyOutlined style={{ color: '#126DFF' }} />
+            <KeyOutlined style={{ color: 'var(--color-primary)' }} />
             <Text strong>{t('接入指南 · 认证与调用约定')}</Text>
           </Space>
         ),
         children: (
-          <div style={{ fontSize: 13, color: '#4D4D4D' }}>
+          <div style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
             <Paragraph style={{ marginBottom: 8 }}>
               所有 <Text code>/v1/*</Text> 接口都需要身份认证。支持两种方式，二者皆无（或无效）时返回 <Tag color="orange">401</Tag>，
               <b>绝不会匿名放行</b>。
@@ -867,7 +867,7 @@ export function ApiDocPanel({ onReloadRef }: ApiDocPanelProps = {}) {
   const components = spec?.components || {};
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#fff' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: 'var(--color-bg-container)' }}>
       {/* Access guide: authentication and call conventions */}
       <AuthGuide />
 
@@ -878,7 +878,7 @@ export function ApiDocPanel({ onReloadRef }: ApiDocPanelProps = {}) {
         gap: 12,
         padding: '12px 16px',
         borderBottom: '1px solid #E3E6EA',
-        background: '#fff',
+        background: 'var(--color-bg-container)',
         flexShrink: 0,
       }}>
         <Input
@@ -916,7 +916,7 @@ export function ApiDocPanel({ onReloadRef }: ApiDocPanelProps = {}) {
           width: 240,
           borderRight: '1px solid #E3E6EA',
           overflow: 'auto',
-          background: '#FAFAFA',
+          background: 'var(--color-bg-gray)',
           flexShrink: 0,
         }}>
           {groups.map(g => (
@@ -943,7 +943,7 @@ export function ApiDocPanel({ onReloadRef }: ApiDocPanelProps = {}) {
           width: 420,
           borderRight: '1px solid #E3E6EA',
           overflow: 'auto',
-          background: '#fff',
+          background: 'var(--color-bg-container)',
           flexShrink: 0,
         }}>
           {groupEndpoints.map(ep => (
@@ -974,7 +974,7 @@ export function ApiDocPanel({ onReloadRef }: ApiDocPanelProps = {}) {
                 <div style={{
                   marginTop: 4,
                   marginLeft: 64,
-                  color: '#4D4D4D',
+                  color: 'var(--color-text-secondary)',
                   fontSize: 12,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -993,7 +993,7 @@ export function ApiDocPanel({ onReloadRef }: ApiDocPanelProps = {}) {
         </div>
 
         {/* Right: detail */}
-        <div style={{ flex: 1, overflow: 'auto', padding: 24, background: '#fff', minWidth: 0 }}>
+        <div style={{ flex: 1, overflow: 'auto', padding: 24, background: 'var(--color-bg-container)', minWidth: 0 }}>
           {activeEndpoint ? (
             /* Detail-switch keyed enter: animation plays only once on the outer container */
             <motion.div key={activeEndpoint.id} {...DETAIL_ENTER}>

--- a/src/frontend/src/components/batch/BatchProgressPanel.tsx
+++ b/src/frontend/src/components/batch/BatchProgressPanel.tsx
@@ -77,7 +77,7 @@ function BatchItemBubble({ item }: {
           {item.status === 'success' ? (
             <CheckCircleFilled style={{ color: '#52c41a' }} />
           ) : (
-            <CloseCircleFilled style={{ color: '#cf1322' }} />
+            <CloseCircleFilled style={{ color: 'var(--color-error)' }} />
           )}
           <span>{t('第 {n} 项', { n: item.index + 1 })}</span>
           {item.retry_count > 0 && (
@@ -114,7 +114,7 @@ function BatchItemBubble({ item }: {
           )}
         </Space>
       ) : (
-        <div style={{ color: '#cf1322' }}>{item.error || t('执行失败')}</div>
+        <div style={{ color: 'var(--color-error)' }}>{item.error || t('执行失败')}</div>
       )}
     </Card>
   );
@@ -242,7 +242,7 @@ export function BatchProgressPanel({ planId }: Props) {
           <span
             key={animEnabled ? `${done}-${success}-${failed}` : 'stats'}
             className={animEnabled ? 'jx-anim-fadeIn' : undefined}
-            style={{ color: '#666', fontSize: 12 }}
+            style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}
           >
             {t('{done}/{total}（成功 {success}，跳过 {failed}）', { done, total, success, failed })}
           </span>
@@ -261,7 +261,7 @@ export function BatchProgressPanel({ planId }: Props) {
       />
 
       {plan.errorMsg && (
-        <div style={{ color: '#cf1322', fontSize: 12, marginTop: 6 }}>
+        <div style={{ color: 'var(--color-error)', fontSize: 12, marginTop: 6 }}>
           {t('错误：{msg}', { msg: plan.errorMsg })}
         </div>
       )}

--- a/src/frontend/src/components/canvas/UniverSpreadsheet.tsx
+++ b/src/frontend/src/components/canvas/UniverSpreadsheet.tsx
@@ -255,7 +255,7 @@ export const UniverSpreadsheet = forwardRef<UniverSpreadsheetHandle, UniverSprea
             表格以柔和 cross-fade 呈现；禁止对 Univer canvas 本身做 transform。 */}
         <div
           className={`jx-canvas-loading jx-canvas-univerOverlay${loading ? '' : ' jx-canvas-univerOverlay--done'}`}
-          style={{ position: 'absolute', inset: 0, zIndex: 10, background: '#fff' }}
+          style={{ position: 'absolute', inset: 0, zIndex: 10, background: 'var(--color-bg-container)' }}
         >
           <div className="jx-canvas-spinner" />
           <span>{t('正在加载电子表格...')}</span>

--- a/src/frontend/src/components/catalog/CatalogPanel.tsx
+++ b/src/frontend/src/components/catalog/CatalogPanel.tsx
@@ -1021,8 +1021,8 @@ export function CatalogPanel({ embedded = false }: CatalogPanelProps = {}) {
                         <Tag
                           className="jx-kbEnabledTag"
                           style={item.enabled
-                            ? { background: '#DBE9FF', color: '#126DFF', border: 'none' }
-                            : { background: '#F5F6F7', color: '#B3B3B3', border: 'none' }
+                            ? { background: 'var(--color-primary-bg)', color: 'var(--color-primary)', border: 'none' }
+                            : { background: 'var(--color-bg-gray)', color: 'var(--color-text-placeholder)', border: 'none' }
                           }
                         >
                           {item.enabled ? t('已启用') : t('未启用')}
@@ -1067,8 +1067,8 @@ export function CatalogPanel({ embedded = false }: CatalogPanelProps = {}) {
                     <Tag
                       className="jx-kbEnabledTag"
                       style={selectedItem.enabled
-                        ? { background: '#DBE9FF', color: '#126DFF', border: 'none' }
-                        : { background: '#F5F6F7', color: '#B3B3B3', border: 'none' }
+                        ? { background: 'var(--color-primary-bg)', color: 'var(--color-primary)', border: 'none' }
+                        : { background: 'var(--color-bg-gray)', color: 'var(--color-text-placeholder)', border: 'none' }
                       }
                     >
                       {selectedItem.enabled ? t('已启用') : t('未启用')}
@@ -1646,11 +1646,11 @@ export function CatalogPanel({ embedded = false }: CatalogPanelProps = {}) {
                                   style={{
                                     flex: 1,
                                     fontSize: 12,
-                                    color: '#595959',
+                                    color: 'var(--color-text-secondary)',
                                     whiteSpace: 'pre-wrap',
                                     wordBreak: 'break-word',
-                                    background: '#FAFBFC',
-                                    border: '1px solid #EEF1F4',
+                                    background: 'var(--color-bg-gray)',
+                                    border: '1px solid var(--color-border)',
                                     borderRadius: 6,
                                     padding: '6px 8px',
                                     lineHeight: 1.6,

--- a/src/frontend/src/components/catalog/LarkAppInitCard.tsx
+++ b/src/frontend/src/components/catalog/LarkAppInitCard.tsx
@@ -105,7 +105,7 @@ export function LarkAppInitCard() {
               <img
                 src={status.qr_data_uri}
                 alt={t('飞书应用配置二维码')}
-                style={{ width: 160, height: 160, background: '#fff', padding: 8, borderRadius: 8 }}
+                style={{ width: 160, height: 160, background: 'var(--color-bg-container)', padding: 8, borderRadius: 8 }}
               />
             )}
             <Space direction="vertical" size={8} style={{ flex: 1, minWidth: 200 }}>

--- a/src/frontend/src/components/catalog/McpPage.tsx
+++ b/src/frontend/src/components/catalog/McpPage.tsx
@@ -253,8 +253,8 @@ export function McpPage({ embedded = false }: { embedded?: boolean }) {
           <span className="jx-mcp-detailName">{selectedItem.name}</span>
           <Tag className="jx-mcp-enabledTag"
             style={selectedItem.enabled
-              ? { background: '#DBE9FF', color: '#126DFF', border: 'none' }
-              : { background: '#F5F6F7', color: '#B3B3B3', border: 'none' }
+              ? { background: 'var(--color-primary-bg)', color: 'var(--color-primary)', border: 'none' }
+              : { background: 'var(--color-bg-gray)', color: 'var(--color-text-placeholder)', border: 'none' }
             }>
             {selectedItem.enabled ? t('已启用') : t('未启用')}
           </Tag>
@@ -352,13 +352,13 @@ export function McpPage({ embedded = false }: { embedded?: boolean }) {
                 <span className="jx-mcp-cardName">{item.name}</span>
                 <Tag className="jx-mcp-enabledTag"
                   style={item.enabled
-                    ? { background: '#DBE9FF', color: '#126DFF', border: 'none' }
-                    : { background: '#F5F6F7', color: '#B3B3B3', border: 'none' }
+                    ? { background: 'var(--color-primary-bg)', color: 'var(--color-primary)', border: 'none' }
+                    : { background: 'var(--color-bg-gray)', color: 'var(--color-text-placeholder)', border: 'none' }
                   }>
                   {item.enabled ? t('已启用') : t('未启用')}
                 </Tag>
                 {item.owner === 'self' && (
-                  <Tag style={{ background: '#EBF2FF', color: '#126DFF', border: 'none' }}>{t('我的')}</Tag>
+                  <Tag style={{ background: 'var(--color-primary-light)', color: 'var(--color-primary)', border: 'none' }}>{t('我的')}</Tag>
                 )}
                 {item.owner === 'self' && (() => {
                   const submission = submissionByServer.get(item.id);

--- a/src/frontend/src/components/catalog/PluginIconPicker.tsx
+++ b/src/frontend/src/components/catalog/PluginIconPicker.tsx
@@ -13,12 +13,12 @@ export function PluginAvatar({ icon, size = 36 }: { icon?: string | null; size?:
   if (value) {
     return (
       <img src={value} alt="" width={size} height={size}
-        style={{ borderRadius: 8, objectFit: 'contain', display: 'block', background: '#fff' }} />
+        style={{ borderRadius: 8, objectFit: 'contain', display: 'block', background: 'var(--color-bg-container)' }} />
     );
   }
   return (
     <div className="jx-mcp-iconWrap jx-mcp-iconFallback" style={{ width: size, height: size }}>
-      <AppstoreOutlined style={{ color: '#6366f1' }} />
+      <AppstoreOutlined style={{ color: 'var(--color-tint-purple)' }} />
     </div>
   );
 }

--- a/src/frontend/src/components/catalog/PluginMarketplaceModal.tsx
+++ b/src/frontend/src/components/catalog/PluginMarketplaceModal.tsx
@@ -128,7 +128,7 @@ export function PluginMarketplaceModal({
                 <div key={plugin.slug} className="jx-mcp-card">
                   <div className="jx-mcp-cardTop">
                     <div className="jx-mcp-iconWrap jx-mcp-iconFallback">
-                      <AppstoreOutlined style={{ color: '#6366f1' }} />
+                      <AppstoreOutlined style={{ color: 'var(--color-tint-purple)' }} />
                     </div>
                     <div className="jx-mcp-cardNameGroup">
                       <span className="jx-mcp-cardName">{plugin.name}</span>

--- a/src/frontend/src/components/catalog/PluginsPage.tsx
+++ b/src/frontend/src/components/catalog/PluginsPage.tsx
@@ -286,8 +286,8 @@ export function PluginsPage() {
           </div>
           <span className="jx-mcp-detailName">{name}</span>
           <Tag style={component.data.enabled
-            ? { background: '#DBE9FF', color: '#126DFF', border: 'none' }
-            : { background: '#F5F6F7', color: '#B3B3B3', border: 'none' }}>
+            ? { background: 'var(--color-primary-bg)', color: 'var(--color-primary)', border: 'none' }
+            : { background: 'var(--color-bg-gray)', color: 'var(--color-text-placeholder)', border: 'none' }}>
             {component.data.enabled ? t('已启用') : t('未启用')}
           </Tag>
           <div style={{ flex: 1 }} />
@@ -311,7 +311,7 @@ export function PluginsPage() {
                   {sk.files.length > 0 && (
                     <div style={{ marginTop: 16 }}>
                       <h4>{t('附带文件')}</h4>
-                      <ul style={{ paddingLeft: 20, color: '#4b5563', fontSize: 13 }}>
+                      <ul style={{ paddingLeft: 20, color: 'var(--color-text-secondary)', fontSize: 13 }}>
                         {sk.files.map((f) => <li key={f}>{f}</li>)}
                       </ul>
                     </div>
@@ -446,8 +446,8 @@ export function PluginsPage() {
                     onClick={() => openComponent({ kind: 'skill', data: s })}
                     tags={isInstalled && (
                       <Tag style={{ marginLeft: 8, ...(s.enabled
-                        ? { background: '#DBE9FF', color: '#126DFF', border: 'none' }
-                        : { background: '#F5F6F7', color: '#B3B3B3', border: 'none' }) }}>
+                        ? { background: 'var(--color-primary-bg)', color: 'var(--color-primary)', border: 'none' }
+                        : { background: 'var(--color-bg-gray)', color: 'var(--color-text-placeholder)', border: 'none' }) }}>
                         {s.enabled ? t('已启用') : t('未启用')}
                       </Tag>
                     )}
@@ -683,7 +683,7 @@ function ImportReportView({ report }: { report: PluginImportReport }) {
         rows={(report.imported || []).map((x) => `${x.type === 'skill' ? t('技能') : 'MCP'}：${x.name}`)} />
       <ReportGroup icon={<WarningOutlined style={{ color: '#f59e0b' }} />} title={t('已适配（降级）')}
         rows={(report.adapted || []).map((x) => `${x.name}：${x.note || t('已装上但默认禁用')}`)} />
-      <ReportGroup icon={<StopOutlined style={{ color: '#ef4444' }} />} title={t('已丢弃（本平台不支持）')}
+      <ReportGroup icon={<StopOutlined style={{ color: 'var(--color-error)' }} />} title={t('已丢弃（本平台不支持）')}
         rows={(report.dropped || []).map((x) => `${x.type}/${x.name}：${x.reason}`)} />
     </div>
   );
@@ -694,7 +694,7 @@ function ReportGroup({ icon, title, rows }: { icon: React.ReactNode; title: stri
   return (
     <div style={{ marginBottom: 14 }}>
       <div style={{ fontWeight: 600, marginBottom: 6, display: 'flex', alignItems: 'center', gap: 6 }}>{icon}{title}（{rows.length}）</div>
-      <ul style={{ margin: 0, paddingLeft: 22, color: '#4b5563', fontSize: 13 }}>
+      <ul style={{ margin: 0, paddingLeft: 22, color: 'var(--color-text-secondary)', fontSize: 13 }}>
         {rows.map((r, i) => <li key={i}>{r}</li>)}
       </ul>
     </div>

--- a/src/frontend/src/components/catalog/SkillsPage.tsx
+++ b/src/frontend/src/components/catalog/SkillsPage.tsx
@@ -637,7 +637,7 @@ export function SkillsPage({ embedded = false }: { embedded?: boolean }) {
                   <Tag className="jx-sk-tag" color="blue">{t('已启用')}</Tag>
                 )}
                 {item.owner === 'self' && (
-                  <Tag style={{ background: '#EBF2FF', color: '#126DFF', border: 'none' }}>{t('我的')}</Tag>
+                  <Tag style={{ background: 'var(--color-primary-light)', color: 'var(--color-primary)', border: 'none' }}>{t('我的')}</Tag>
                 )}
                 {item.owner === 'self' && (() => {
                   const sub = subBySkill.get(item.id);

--- a/src/frontend/src/components/catalog/skillIcons.tsx
+++ b/src/frontend/src/components/catalog/skillIcons.tsx
@@ -22,6 +22,9 @@ export interface PresetIcon {
   paths: ReactNode;
 }
 
+/* dark-ok-begin: 下面是每类技能的**身份色**（一个类别一个固定色相，属于品牌资产），
+   不是主题色。深浅两档的适配在 catalog.css 的 .jx-skillAvatar 规则里用 color-mix 完成，
+   组件只把色值当自定义属性传下去。 */
 export const PRESETS: Record<string, PresetIcon> = {
   doc: { key: 'doc', label: t('文档'), color: '#2F6BFF', paths: (<><path d="M6 3h8l4 4v14H6z" /><path d="M14 3v4h4" /><path d="M9 12h6M9 16h6" /></>) },
   pen: { key: 'pen', label: t('写作'), color: '#7C4DFF', paths: (<><path d="M14 4l6 6L9 21H3v-6z" /><path d="M12 6l6 6" /></>) },
@@ -66,6 +69,7 @@ export const PRESETS: Record<string, PresetIcon> = {
   shield_check: { key: 'shield_check', label: t('合规'), color: '#1E88E5', paths: (<><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z" /><path d="M9 11l2 2 4-4" /></>) },
   bell: { key: 'bell', label: t('通知'), color: '#F57C00', paths: (<><path d="M6 9a6 6 0 0112 0c0 5 2 6 2 6H4s2-1 2-6z" /><path d="M10 20a2 2 0 004 0" /></>) },
 };
+/* dark-ok-end */
 
 export const PRESET_LIST: PresetIcon[] = Object.values(PRESETS);
 
@@ -92,13 +96,6 @@ function hashStr(s: string): number {
   return Math.abs(h);
 }
 
-function tint(hex: string): string {
-  // Convert the accent color into a light background at 12% opacity
-  const n = hex.replace('#', '');
-  const r = parseInt(n.slice(0, 2), 16), g = parseInt(n.slice(2, 4), 16), b = parseInt(n.slice(4, 6), 16);
-  return `rgba(${r},${g},${b},0.12)`;
-}
-
 function resolvePresetKey(icon: string | undefined, seed: string): string {
   if (icon && icon.startsWith('preset:')) {
     const k = icon.slice(7);
@@ -121,8 +118,13 @@ export function SkillAvatar({
     return <img className="jx-skillAvatar" style={{ ...box, objectFit: 'cover' }} src={icon} alt="" loading="lazy" />;
   }
   const p = PRESETS[resolvePresetKey(icon, seed || name || '?')];
+  // 身份色只作为**输入**交给 CSS（自定义属性），底色与字色由 catalog.css 里的
+  // .jx-skillAvatar 规则用 color-mix 推导——深色档在那儿统一提亮，组件不必知道当前主题。
   return (
-    <div className="jx-skillAvatar" style={{ ...box, background: tint(p.color), color: p.color }}>
+    <div
+      className="jx-skillAvatar"
+      style={{ ...box, ['--jx-skillAvatar-accent' as string]: p.color } as CSSProperties}
+    >
       <svg {...SVG} width={Math.round(size * 0.56)} height={Math.round(size * 0.56)}>{p.paths}</svg>
     </div>
   );

--- a/src/frontend/src/components/chat/ContextGauge.tsx
+++ b/src/frontend/src/components/chat/ContextGauge.tsx
@@ -23,12 +23,12 @@ function levelOf(ratio: number): Level {
 
 // Category → display label + accent colour (aligned with design tokens).
 const CATEGORIES: Array<{ key: keyof ContextBreakdown; label: string; color: string }> = [
-  { key: 'messages', label: '对话消息', color: '#126DFF' },
-  { key: 'tools', label: '工具调用', color: '#8B5CF6' },
-  { key: 'thinking', label: '思考过程', color: '#02B589' },
-  { key: 'files', label: '文件', color: '#F8AB42' },
-  { key: 'input', label: '当前输入', color: '#22C55E' },
-  { key: 'system', label: '系统提示词与工具定义', color: '#808080' },
+  { key: 'messages', label: '对话消息', color: 'var(--color-primary)' },
+  { key: 'tools', label: '工具调用', color: 'var(--color-tint-purple)' },
+  { key: 'thinking', label: '思考过程', color: 'var(--color-success)' },
+  { key: 'files', label: '文件', color: 'var(--color-warning)' },
+  { key: 'input', label: '当前输入', color: 'var(--color-tint-green)' },
+  { key: 'system', label: '系统提示词与工具定义', color: 'var(--color-text-tertiary)' },
 ];
 
 interface GaugeContentProps {

--- a/src/frontend/src/components/common/MarketPickerModal.tsx
+++ b/src/frontend/src/components/common/MarketPickerModal.tsx
@@ -76,7 +76,7 @@ export function MarketPickerModal({
     >
       <Input
         allowClear
-        prefix={<SearchOutlined style={{ color: 'rgba(0,0,0,.3)' }} />}
+        prefix={<SearchOutlined style={{ color: 'var(--color-text-placeholder)' }} />}
         placeholder={t('搜索名称、简介或标识…')}
         value={q}
         onChange={(e) => setQ(e.target.value)}
@@ -104,12 +104,12 @@ export function MarketPickerModal({
               }}
             >
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontSize: 14, fontWeight: 500, color: '#1e293b' }}>
+                <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text)' }}>
                   {item.name || item.id}
                   {already && <Tag style={{ marginLeft: 8 }}>{t('已添加')}</Tag>}
                 </div>
                 <div style={{
-                  fontSize: 12, color: 'rgba(15,23,42,.45)',
+                  fontSize: 12, color: 'var(--color-text-tertiary)',
                   overflow: 'hidden', textOverflow: 'ellipsis',
                   display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
                 }}>
@@ -130,7 +130,7 @@ export function MarketPickerModal({
           );
         })}
       </div>
-      <div style={{ marginTop: 10, fontSize: 12, color: 'rgba(15,23,42,.45)' }}>
+      <div style={{ marginTop: 10, fontSize: 12, color: 'var(--color-text-tertiary)' }}>
         {t('选中的项会在保存模式时自动安装。')}
       </div>
     </Modal>

--- a/src/frontend/src/components/docs/AppCenterPanel.tsx
+++ b/src/frontend/src/components/docs/AppCenterPanel.tsx
@@ -114,7 +114,7 @@ export default function AppCenterPanel() {
                       width: 28,
                       height: 28,
                       borderRadius: '50%',
-                      background: '#E3E6EA',
+                      background: 'var(--color-border)',
                     }}
                   />
                 )}

--- a/src/frontend/src/components/loop/loop.css
+++ b/src/frontend/src/components/loop/loop.css
@@ -61,11 +61,11 @@
 .loop-list-item.active { border-color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 6%, transparent); }
 .loop-title { font-weight: 600; font-size: 13px; }
 .loop-status { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 10px; margin: 3px 0; background: var(--color-fill-hover); }
-.loop-status.s-completed { background: #dcfce7; color: #166534; }
-.loop-status.s-running { background: #dbeafe; color: #1e40af; }
-.loop-status.s-budget_exhausted { background: #fef9c3; color: #854d0e; }
-.loop-status.s-failed { background: #fee2e2; color: #991b1b; }
-.loop-status.s-awaiting_human { background: #fae8ff; color: #86198f; }
+.loop-status.s-completed { background: var(--color-tint-green-bg); color: var(--color-tint-green); }
+.loop-status.s-running { background: var(--color-tint-blue-bg); color: var(--color-tint-blue); }
+.loop-status.s-budget_exhausted { background: var(--color-tint-amber-bg); color: var(--color-tint-amber); }
+.loop-status.s-failed { background: var(--color-tint-red-bg); color: var(--color-tint-red); }
+.loop-status.s-awaiting_human { background: var(--color-tint-purple-bg); color: var(--color-tint-purple); }
 .loop-meta { font-size: 11px; color: var(--color-text-tertiary); }
 
 .loop-main { flex: 1; padding: 20px; overflow-y: auto; }
@@ -73,15 +73,17 @@
 .loop-header { display: flex; justify-content: space-between; align-items: center; }
 .loop-goal { background: var(--color-bg-layout); border-radius: 8px; padding: 10px 12px; margin: 10px 0; }
 .loop-budget { font-size: 12px; color: var(--color-text-secondary); margin-top: 4px; }
+/* dark-ok: 事件流是刻意的暗色终端台，两档主题下都保持深底浅字 */
 .loop-stream {
   background: #0d1117; color: #c9d1d9; border-radius: 8px; padding: 12px;
   font-family: ui-monospace, monospace; font-size: 12.5px; max-height: 300px; overflow-y: auto;
 }
 .loop-ev { padding: 2px 0; }
-.loop-reason { color: #8b949e; padding-left: 16px; font-size: 12px; }
-.loop-warn { color: #d29922; }
-.loop-done { color: #3fb950; font-weight: 600; }
-.loop-err { color: #f85149; }
+/* 下面四条是 .loop-stream 暗色终端台内的语法色，跟随终端底色而非主题 */
+.loop-reason { color: #8b949e; padding-left: 16px; font-size: 12px; } /* dark-ok */
+.loop-warn { color: #d29922; } /* dark-ok */
+.loop-done { color: #3fb950; font-weight: 600; } /* dark-ok */
+.loop-err { color: #f85149; } /* dark-ok */
 .loop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 12.5px; }
 .loop-table th, .loop-table td { border: 1px solid var(--color-border); padding: 5px 8px; text-align: left; }
 .loop-table th { background: var(--color-bg-layout); }
@@ -196,9 +198,9 @@
   padding: 1px 8px; border-radius: 20px;
   background: var(--color-primary-light); color: var(--color-primary);
 }
-.loop-status-completed { background: #dcfce7; color: #16a34a; }
-.loop-status-budget_exhausted { background: #fef3c7; color: #b45309; }
-.loop-status-cancelled, .loop-status-failed { background: #fee2e2; color: #dc2626; }
+.loop-status-completed { background: var(--color-tint-green-bg); color: var(--color-tint-green); }
+.loop-status-budget_exhausted { background: var(--color-tint-amber-bg); color: var(--color-tint-amber); }
+.loop-status-cancelled, .loop-status-failed { background: var(--color-tint-red-bg); color: var(--color-tint-red); }
 .loop-planbar-caret { flex-shrink: 0; color: var(--color-text-placeholder); font-size: 11px; }
 .loop-planbar-continue {
   flex-shrink: 0; border: none; cursor: pointer; white-space: nowrap;
@@ -225,7 +227,7 @@
 }
 .loop-planbar-mark { flex-shrink: 0; width: 14px; text-align: center; font-size: 12px; }
 .loop-planbar-desc { color: var(--color-text); }
-.loop-item-done .loop-planbar-mark { color: #16a34a; }
+.loop-item-done .loop-planbar-mark { color: var(--color-success); }
 .loop-item-done .loop-planbar-desc { color: var(--color-text-placeholder); text-decoration: line-through; }
 .loop-item-active .loop-planbar-mark { color: var(--color-primary); }
 .loop-item-active .loop-planbar-desc { font-weight: 600; }
@@ -237,7 +239,7 @@
 }
 @keyframes loop-review-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
 .loop-planbar-hint { padding: 4px 12px 10px; color: var(--color-text-placeholder); }
-.loop-status-interrupted { background: #fef3c7; color: #b45309; }
+.loop-status-interrupted { background: var(--color-tint-amber-bg); color: var(--color-tint-amber); }
 .loop-planbar-steer {
   display: flex; align-items: center; gap: 6px; padding: 4px 12px 10px;
 }

--- a/src/frontend/src/components/myspace/ImageGrid.tsx
+++ b/src/frontend/src/components/myspace/ImageGrid.tsx
@@ -74,7 +74,7 @@ export function ImageGrid({
         return (
           <div key={folder.folder_id} className="jx-mySpace-imgItem jx-mySpace-imgItem--folder" onDoubleClick={() => onEnterFolder?.(folder.folder_id)}>
             <div className="jx-mySpace-imgCell" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <FolderOutlined style={{ fontSize: 56, color: '#FFB72E' }} />
+              <FolderOutlined style={{ fontSize: 56, color: 'var(--color-warning)' }} />
             </div>
             <div style={{ padding: '4px 8px', textAlign: 'center' }}>{folder.name}</div>
             {menuItems.length > 0 && (

--- a/src/frontend/src/components/projects/ProjectCard.tsx
+++ b/src/frontend/src/components/projects/ProjectCard.tsx
@@ -44,7 +44,7 @@ export default function ProjectCard({ project, onOpen, onToggleFavorite, stagger
           animate={project.favorite ? { scale: [1, 1.25, 1] } : { scale: 1 }}
           transition={{ duration: 0.35, ease: EASE.brandOut }}
         >
-          {project.favorite ? <StarFilled style={{ color: '#F8AB42' }} /> : <StarOutlined />}
+          {project.favorite ? <StarFilled style={{ color: 'var(--color-warning)' }} /> : <StarOutlined />}
         </motion.div>
       </div>
       {project.description && <div className="jx-projectCard-desc">{project.description}</div>}

--- a/src/frontend/src/components/projects/ProjectDetailPanel.tsx
+++ b/src/frontend/src/components/projects/ProjectDetailPanel.tsx
@@ -140,7 +140,7 @@ export default function ProjectDetailPanel({ projectId, onBack, handleFileSelect
             <div className="jx-projectDetail-titleActions">
               <Button
                 type="text"
-                icon={project.favorite ? <StarFilled style={{ color: '#F8AB42' }} /> : <StarOutlined />}
+                icon={project.favorite ? <StarFilled style={{ color: 'var(--color-warning)' }} /> : <StarOutlined />}
                 onClick={() => void toggleFavorite(!project.favorite)}
               />
               {project.permission === 'admin' && (

--- a/src/frontend/src/components/settings/ChannelBotsPanel.tsx
+++ b/src/frontend/src/components/settings/ChannelBotsPanel.tsx
@@ -249,7 +249,7 @@ export function ChannelBotsPanel({ agentId, agentName }: ChannelBotsPanelProps =
                     {bot.channel_type === 'weixin' ? t('微信号') : 'App ID'}: {bot.app_id}
                   </div>
                   {bot.status === 'error' && bot.last_error && (
-                    <div className="jx-conn-desc" style={{ color: '#d4380d', fontSize: 12 }}>{bot.last_error}</div>
+                    <div className="jx-conn-desc" style={{ color: 'var(--color-error)', fontSize: 12 }}>{bot.last_error}</div>
                   )}
                   {canObserve && (
                     <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/src/frontend/src/components/settings/MyLogsPanel.tsx
+++ b/src/frontend/src/components/settings/MyLogsPanel.tsx
@@ -383,7 +383,7 @@ export function MyLogsPanel() {
                   <Tag color="blue">{stepItem.tool_calls_count ?? 0} {t('工具')}</Tag>
                 </Space>
                 {stepItem.output_content && (
-                  <Paragraph style={{ margin: 0, whiteSpace: 'pre-wrap', color: '#555' }}>
+                  <Paragraph style={{ margin: 0, whiteSpace: 'pre-wrap', color: 'var(--color-text-secondary)' }}>
                     {stepItem.output_content.slice(0, 400)}
                     {stepItem.output_content.length > 400 ? '…' : ''}
                   </Paragraph>

--- a/src/frontend/src/components/settings/SettingsModal.tsx
+++ b/src/frontend/src/components/settings/SettingsModal.tsx
@@ -1166,7 +1166,7 @@ function renderProfileTab(profile: import('../../types').MemoryProfile | null) {
       </div>
       <div
         style={{
-          padding: 12, background: '#FAFAFA', borderRadius: 6,
+          padding: 12, background: 'var(--color-bg-gray)', borderRadius: 6,
           maxHeight: 400, overflow: 'auto', fontSize: 13, lineHeight: 1.7,
         }}
         dangerouslySetInnerHTML={{ __html: mdToHtml(profile.content_md) }}

--- a/src/frontend/src/components/share/ShareRecordsPage.tsx
+++ b/src/frontend/src/components/share/ShareRecordsPage.tsx
@@ -348,7 +348,7 @@ export default function ShareRecordsPage({ embedded = false, hideEmbeddedDesc = 
                         {getShareStatusLabel(record)}
                       </Tag>
                     </motion.span>
-                    <Tag style={{ background: '#EBF2FF', borderColor: '#DBE9FF', color: '#126DFF' }}>
+                    <Tag style={{ background: 'var(--color-primary-light)', borderColor: '#DBE9FF', color: 'var(--color-primary)' }}>
                       {getShareExpiryLabel(record)}
                     </Tag>
                     <button

--- a/src/frontend/src/components/tool/renderers/MySpaceRenderer.tsx
+++ b/src/frontend/src/components/tool/renderers/MySpaceRenderer.tsx
@@ -16,9 +16,9 @@ function FileIcon({ mimeType }: { mimeType?: string }) {
   if (mimeType.startsWith('image/')) return <PictureOutlined style={{ color: '#6c8ebf' }} />;
   if (mimeType.includes('pdf')) return <FileTextOutlined style={{ color: '#e05c5c' }} />;
   if (mimeType.includes('word') || mimeType.includes('document'))
-    return <FileTextOutlined style={{ color: '#4472c4' }} />;
+    return <FileTextOutlined style={{ color: 'var(--color-primary)' }} />;
   if (mimeType.includes('sheet') || mimeType.includes('excel') || mimeType.includes('csv'))
-    return <FileTextOutlined style={{ color: '#217346' }} />;
+    return <FileTextOutlined style={{ color: 'var(--color-success)' }} />;
   return <FileTextOutlined style={{ color: '#888' }} />;
 }
 
@@ -76,7 +76,7 @@ function StageFileBody({ data }: { data: unknown }) {
     <div className="jx-ms-list">
       <div className="jx-ms-listItem" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4 }}>
         <span className="jx-ms-fileName">{info.name ?? t('未知文件')}</span>
-        <code style={{ fontSize: 11, color: '#6b7280', wordBreak: 'break-all' }}>{info.path ?? ''}</code>
+        <code style={{ fontSize: 11, color: 'var(--color-text-tertiary)', wordBreak: 'break-all' }}>{info.path ?? ''}</code>
         {info.size_bytes != null && (
           <span className="jx-ms-fileMeta">{formatBytes(info.size_bytes)}{info.mime_type ? ` · ${info.mime_type}` : ''}</span>
         )}

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -22,7 +22,7 @@ body {
   box-sizing: border-box;
   padding: 32px;
   background:
-    radial-gradient(circle at 15% 12%, rgba(69, 112, 255, 0.12), transparent 32%),
+    radial-gradient(circle at 15% 12%, color-mix(in srgb, var(--color-primary) 12%, transparent), transparent 32%),
     var(--color-bg-layout, #f6f8fc);
   color: var(--color-text, #182033);
 }

--- a/src/frontend/src/styles/apidoc.css
+++ b/src/frontend/src/styles/apidoc.css
@@ -10,7 +10,7 @@
     border-color var(--motion-duration-fast) var(--motion-ease-standard);
 }
 .jx-apidoc-navItem:hover {
-  background: #F5F7FA;
+  background: var(--color-fill-hover);
 }
 
 /* 左栏：分组 */
@@ -35,7 +35,7 @@
 }
 .jx-apidoc-epItem.active,
 .jx-apidoc-epItem.active:hover {
-  background: #F5F8FF;
+  background: var(--color-primary-light);
   border-left-color: var(--color-primary);
 }
 

--- a/src/frontend/src/styles/canvas.css
+++ b/src/frontend/src/styles/canvas.css
@@ -608,17 +608,39 @@
 }
 
 /* ══ DOCX Renderer ══ */
+
+/* dark-ok-begin: Word 预览是一张**纸**，不是界面的一部分——docx-preview 会把文档自带的
+   行内颜色（绝大多数是黑字）直接写在元素上，纸面因此必须恒为浅色，否则深色档下黑字压深底、
+   整份文档不可读。
+   做法是把纸张根做成「主题孤岛」：在这里把主题令牌就地钉回浅色值，纸内所有引用令牌的规则
+   （正文、表头、标题、链接……）随之自动解析成浅色。
+   这比逐条 background 上标 dark-ok 深一层——纸内新增样式不必再记得豁免，后续批量令牌化
+   改动也不会把纸内的某一条文字色悄悄翻成深色档的浅字（曾因此让表头白字压白底）。 */
 .jx-canvas-docx {
+  --color-text:#101828;
+  --color-text-secondary:#475467;
+  --color-text-tertiary:#667085;
+  --color-text-placeholder:#98A2B3;
+  --color-bg-base:#FFFFFF;
+  --color-bg-container:#FFFFFF;
+  --color-bg-elevated:#FFFFFF;
+  --color-bg-layout:#F5F7FB;
+  --color-bg-gray:#F4F6F9;
+  --color-border:#E3E8EF;
+  --color-fill:#DDE3EC;
+  --color-fill-hover:#EEF1F5;
+
   padding: 0;
   background: var(--color-bg-container);
   min-height: 100%;
 }
+/* dark-ok-end */
 .jx-canvas-docx .docx-wrapper,
 .jx-canvas-docx .jx-canvas-docx-wrapper,
 .jx-canvas-docx .jx-canvas-docx-wrapper-wrapper {
   padding: 0 !important;
   margin: 0 !important;
-  background: #fff !important;
+  background: var(--color-bg-container) !important;
 }
 /* section: library uses our className as the section class, so match both */
 .jx-canvas-docx section.docx,
@@ -628,7 +650,7 @@
   max-width: none;
   width: 100%;
   padding: 28px 36px 44px !important;
-  background: #fff !important;
+  background: var(--color-bg-container) !important;
   border: none !important;
   border-radius: 0;
   box-shadow: none !important;
@@ -790,8 +812,8 @@
 
 .jx-canvas-docx section.docx th,
 .jx-canvas-docx section.jx-canvas-docx-wrapper th {
-  background: rgba(248, 250, 252, .9) !important;
-  color: rgba(15, 23, 42, .9) !important; /* 纸面浅底固定，文字不随主题翻转 */
+  background: var(--color-bg-layout) !important;
+  color: var(--color-text) !important; /* 纸内令牌已被上面的主题孤岛钉成浅色值 */
   font-weight: 600 !important;
 }
 

--- a/src/frontend/src/styles/catalog.css
+++ b/src/frontend/src/styles/catalog.css
@@ -1758,12 +1758,12 @@
 }
 .jx-agentCard-badge.on {
   color: var(--color-primary);
-  background: #DBEAFE;
+  background: var(--color-tint-blue-bg);
 }
 
 .jx-agentCard-badge--builtin {
-  color: #8A5A00;
-  background: #FFF4D6;
+  color: var(--color-tint-amber);
+  background: var(--color-tint-amber-bg);
 }
 
 /* Edit / delete — visible on hover */
@@ -1879,7 +1879,7 @@
 }
 .jx-agentDetail-badge.on {
   color: var(--color-primary);
-  background: #DBEAFE;
+  background: var(--color-tint-blue-bg);
 }
 
 /* 启用 switch row — pushed to the right */
@@ -2216,8 +2216,8 @@
 }
 
 .jx-agentDetail-historyDetailTag.is-after {
-  background: #E6F4EA;
-  color: #2F7A4B;
+  background: var(--color-tint-green-bg);
+  color: var(--color-tint-green);
 }
 
 .jx-agentDetail-historyDetailText {
@@ -2291,16 +2291,16 @@
 }
 
 .jx-agentDetail-iconBtn.danger.ant-btn {
-  border-color: #F1D4D4;
-  color: #E07272;
-  background: #FFFDFD;
+  border-color: color-mix(in srgb, var(--color-error) 30%, transparent);
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 4%, transparent);
 }
 
 .jx-agentDetail-iconBtn.danger.ant-btn:hover,
 .jx-agentDetail-iconBtn.danger.ant-btn:focus {
-  border-color: #EAB8B8;
-  color: #D84E4E;
-  background: #FFF7F7;
+  border-color: color-mix(in srgb, var(--color-error) 45%, transparent);
+  color: var(--color-error-active);
+  background: var(--color-error-light);
 }
 
 .jx-agentCardSkeleton {
@@ -2827,19 +2827,19 @@
 .jx-kbPill-blue{
   background:var(--color-primary-light);
   border-color:var(--color-primary-bg);
-  color:#4f87c2;
+  color:var(--color-primary);
 }
 
 .jx-kbPill-green{
-  background:#f3fbf5;
-  border-color:#dbeedd;
-  color:#72a667;
+  background:var(--color-tint-green-bg);
+  border-color:color-mix(in srgb, var(--color-tint-green) 30%, transparent);
+  color:var(--color-tint-green);
 }
 
 .jx-kbPill-orange{
-  background:#fff4e8;
-  border-color:#ffdcbc;
-  color:#c97a2b;
+  background:var(--color-tint-amber-bg);
+  border-color:color-mix(in srgb, var(--color-tint-amber) 30%, transparent);
+  color:var(--color-tint-amber);
 }
 
 .jx-kbEnabledTag.ant-tag{
@@ -3052,7 +3052,7 @@
 
 .jx-kbDetailDescToggle.ant-btn:hover,
 .jx-kbDetailDescToggle.ant-btn:focus{
-  color:#4d6fb2;
+  color:var(--color-primary);
 }
 
 .jx-kbDetailActions{
@@ -3104,13 +3104,13 @@
 }
 
 .jx-kbSyncInlineStatus.is-active{
-  color:#c97a2b;
-  background:#fff4e8;
-  border-color:#ffdcbc;
+  color:var(--color-tint-amber);
+  background:var(--color-tint-amber-bg);
+  border-color:color-mix(in srgb, var(--color-tint-amber) 30%, transparent);
 }
 
 .jx-kbSyncInlineStatus.is-inactive{
-  color:#9a6b00;
+  color:var(--color-tint-amber);
   background:rgba(255,248,235,.92);
   border-color:rgba(245,158,11,.14);
 }
@@ -3225,14 +3225,14 @@
   font-size:13px;
   line-height:1.4;
   font-weight:600;
-  color:#8a5a20;
+  color:var(--color-tint-amber);
   margin-bottom:2px;
 }
 
 .jx-kbRulesPopoverItem{
   font-size:12px;
   line-height:1.6;
-  color:#6b4f2c;
+  color:var(--color-tint-amber);
   white-space:nowrap;
 }
 
@@ -3345,7 +3345,7 @@
   padding:0 8px;
   border-radius:999px;
   border-color:var(--color-primary-disabled);
-  color:#2f66f5;
+  color:var(--color-primary);
   background:var(--color-primary-light);
   box-shadow:none;
   font-size:12px;
@@ -3355,9 +3355,9 @@
 
 .jx-kbEditorPolishBtn:hover,
 .jx-kbEditorPolishBtn:focus{
-  color:#1d4ed8;
-  border-color:#9ebcff;
-  background:#e7efff;
+  color:var(--color-primary-active);
+  border-color:color-mix(in srgb, var(--color-primary) 45%, transparent);
+  background:var(--color-primary-bg);
 }
 
 .jx-kbEditorCount{
@@ -3402,12 +3402,12 @@
 }
 
 .jx-kbDocFilterTab.is-active{
-  background:#E8F0FF;
+  background:var(--color-primary-light);
   color:var(--color-primary);
 }
 
 .jx-kbDocFilterTab.is-active:hover{
-  background:#DBE6FF;
+  background:var(--color-primary-bg);
 }
 
 .jx-kbDocFilterTabLabel{
@@ -3484,7 +3484,7 @@
   justify-content:flex-end;
   padding:14px 18px 18px;
   border-top:1px solid var(--color-border);
-  background:linear-gradient(180deg, rgba(248,250,252,.92) 0%, #fff 55%);
+  background:linear-gradient(180deg, var(--color-bg-layout) 0%, var(--color-bg-container) 55%);
 }
 
 .jx-kbDocPagination .ant-pagination{
@@ -3612,8 +3612,8 @@
 }
 
 .jx-kbPagerSizeDropdown .ant-select-item-option-selected{
-  background:#edf4fc;
-  color:#5f7ea8;
+  background:var(--color-primary-light);
+  color:var(--color-primary);
   font-weight:500;
 }
 
@@ -3763,21 +3763,21 @@
 }
 
 .jx-kbStatusPill-success{
-  background:#f0fdf4;
-  border-color:#d9f5df;
-  color:#34a77a;
+  background:var(--color-tint-green-bg);
+  border-color:color-mix(in srgb, var(--color-tint-green) 30%, transparent);
+  color:var(--color-tint-green);
 }
 
 .jx-kbStatusPill-processing{
   background:var(--color-primary-light);
   border-color:var(--color-primary-bg);
-  color:#4f87c2;
+  color:var(--color-primary);
 }
 
 .jx-kbStatusPill-failed{
-  background:#fff1f0;
-  border-color:#ffd9d6;
-  color:#e76a61;
+  background:var(--color-tint-red-bg);
+  border-color:color-mix(in srgb, var(--color-tint-red) 30%, transparent);
+  color:var(--color-tint-red);
 }
 
 .jx-kbDocActions{
@@ -3915,8 +3915,8 @@
 
 .jx-kbUploadDragger.ant-upload-wrapper .ant-upload-drag{
   border-radius:16px;
-  border:1px dashed #d8e1ec;
-  background:linear-gradient(180deg,#fcfdff 0%,#f8fbff 100%);
+  border:1px dashed var(--color-border);
+  background:linear-gradient(180deg, var(--color-bg-container) 0%, var(--color-bg-layout) 100%);
   padding:16px 22px;
   min-height:150px;
   box-shadow:inset 0 1px 0 rgba(255,255,255,.75);
@@ -3990,7 +3990,7 @@
 }
 
 .jx-kbUploadSelectDropdown .ant-select-item-option-active{
-  background:#f7faff !important;
+  background:var(--color-bg-layout) !important;
 }
 
 .jx-kbUploadOption{
@@ -4028,8 +4028,8 @@
   min-height:24px;
   padding:0 8px;
   border-radius:999px;
-  background:#fff7db;
-  color:#9a6b00;
+  background:var(--color-tint-amber-bg);
+  color:var(--color-tint-amber);
   font-size:12px;
   line-height:1;
 }
@@ -4383,9 +4383,9 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  background: #FFF7E6;
-  color: #B26A00;
-  border: 1px solid #FFE7BA;
+  background: var(--color-tint-amber-bg);
+  color: var(--color-tint-amber);
+  border: 1px solid color-mix(in srgb, var(--color-tint-amber) 30%, transparent);
   border-radius: 8px;
   padding: 8px 12px;
   font-size: 12.5px;
@@ -4408,7 +4408,7 @@
   overflow-x: auto;
 }
 .jx-mk-detailBody pre {
-  background: #f4f5f7;
+  background: var(--color-bg-gray);
   border-radius: 6px;
   padding: 10px 12px;
   overflow-x: auto;
@@ -4466,7 +4466,7 @@
   border-radius: 9px;
   object-fit: cover;
   flex: 0 0 40px;
-  background: #F3F6FF;
+  background: var(--color-primary-light);
 }
 .jx-mk-icon--letter {
   display: flex;
@@ -4506,7 +4506,7 @@
   color: var(--color-text-tertiary);
 }
 .jx-mk-catTag {
-  background: #F2F4F8;
+  background: var(--color-bg-gray);
   color: var(--color-text-secondary);
   font-size: 11px;
 }
@@ -4555,7 +4555,18 @@
 }
 
 /* ── 技能图标选择器 ── */
-.jx-skillAvatar { user-select: none; }
+/* 技能头像：身份色由组件以 --jx-skillAvatar-accent 传入（每类技能一个固定色相，
+   属于品牌资产不随主题变），底色与字色在这里推导。深色档单独提亮一档——
+   #455A64 这类深板岩色直接压在暗底上等于看不见。 */
+.jx-skillAvatar {
+  user-select: none;
+  background: color-mix(in srgb, var(--jx-skillAvatar-accent, var(--color-primary)) 12%, transparent);
+  color: var(--jx-skillAvatar-accent, var(--color-primary));
+}
+:root[data-theme='dark'] .jx-skillAvatar {
+  background: color-mix(in srgb, var(--jx-skillAvatar-accent, var(--color-primary)) 24%, transparent);
+  color: color-mix(in srgb, var(--jx-skillAvatar-accent, var(--color-primary)) 40%, #FFFFFF);
+}
 .jx-iconPicker-trigger {
   display: inline-flex;
   align-items: center;
@@ -4592,7 +4603,7 @@
   cursor: pointer;
   transition: all .1s;
 }
-.jx-iconPicker-cell:hover { background: #F2F6FF; }
+.jx-iconPicker-cell:hover { background: var(--color-primary-light); }
 .jx-iconPicker-cell.active { border-color: var(--color-primary); background: var(--color-primary-light); }
 .jx-iconPicker-actions {
   display: flex;

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -821,8 +821,8 @@ a.jx-fileCard--link:hover{
   opacity:.58;
 }
 .jx-queuedMessage--applied .jx-queuedMessage-steer{
-  background:#dcfce7;
-  color:#15803d;
+  background:var(--color-success-bg);
+  color:var(--color-success);
 }
 .jx-queuedMessage-iconBtn{
   display:inline-flex;
@@ -2201,10 +2201,10 @@ textarea.jx-composer{
 .jx-followUpBtn:hover{
   border-color:var(--color-primary);
   color:var(--color-primary);
-  background:#f0f5ff;
+  background:var(--color-primary-light);
 }
 .jx-followUpBtn:active{
-  background:var(--color-primary-light);
+  background:var(--color-primary-bg);
 }
 .jx-followUpBtn:disabled{
   opacity:.5;
@@ -2591,7 +2591,7 @@ textarea.jx-composer{
   min-width:320px;
   flex-shrink:0;
   border:none;
-  background:linear-gradient(26deg, #FFFFFF 0%, #FFFFFF 100%);
+  background:var(--color-bg-container);
   display:flex;
   flex-direction:column;
   height:100%;
@@ -2642,7 +2642,7 @@ textarea.jx-composer{
   padding:12px 14px;
   border-radius:10px;
   border:1px solid color-mix(in srgb, var(--color-text) 8%, transparent);
-  background:#f8f9fa;
+  background:var(--color-bg-gray);
   cursor:pointer;
   transition:all .18s ease;
 }
@@ -2652,8 +2652,8 @@ textarea.jx-composer{
   box-shadow:0 2px 8px rgba(18,109,255,.08);
 }
 .jx-promptHub-card.selected{
-  border-color:rgba(18,109,255,.45);
-  background:#eff6ff;
+  border-color:color-mix(in srgb, var(--color-primary) 45%, transparent);
+  background:var(--color-primary-bg);
 }
 .jx-promptHub-cardTitle{
   font-size:14px;
@@ -2678,10 +2678,10 @@ textarea.jx-composer{
 .jx-promptHub-card--skeleton{
   pointer-events:none;
   cursor:default;
-  background:#f8f9fa;
+  background:var(--color-bg-gray);
 }
 .jx-promptHub-card--skeleton:hover{
-  background:#f8f9fa;
+  background:var(--color-bg-gray);
   border-color:color-mix(in srgb, var(--color-text) 8%, transparent);
   box-shadow:none;
 }
@@ -2724,6 +2724,8 @@ textarea.jx-composer{
     max(14px, env(safe-area-inset-right))
     max(24px, env(safe-area-inset-bottom))
     max(14px, env(safe-area-inset-left));
+  /* dark-ok: 分享页锁定浅色（forceLight + index.html boot script 的 share 判断），
+     对外分享链接不跟随访客主题，这里的浅色渐变是刻意的 */
   background:
     radial-gradient(circle at top, rgba(18,109,255,.08), transparent 34%),
     linear-gradient(180deg, #f8fbff 0%, #ffffff 42%, var(--color-bg-layout) 100%);
@@ -3207,7 +3209,7 @@ textarea.jx-composer{
 }
 .jx-slashPopup-item:hover,
 .jx-slashPopup-item.active {
-  background: #E0F2FE;
+  background: var(--color-tint-cyan-bg);
 }
 .jx-slashPopup-name {
   font-weight: 500;
@@ -3218,15 +3220,15 @@ textarea.jx-composer{
   line-height: 1;
   padding: 2px 6px;
   border-radius: 4px;
-  background: #EDE9FE;
-  color: #6D28D9;
+  background: var(--color-tint-purple-bg);
+  color: var(--color-tint-purple);
 }
 .jx-slashPopup-icon {
   font-size: 13px;
   flex-shrink: 0;
 }
-.jx-slashPopup-icon--plugin { color: #6D28D9; }
-.jx-slashPopup-icon--skill { color: #f59e0b; }
+.jx-slashPopup-icon--plugin { color: var(--color-tint-purple); }
+.jx-slashPopup-icon--skill { color: var(--color-warning); }
 
 
 /* ── ContentEditable editor — replaces textarea ── */
@@ -3288,13 +3290,13 @@ textarea.jx-composer{
   color: var(--color-primary);
 }
 .jx-editorChip--skill {
-  background: #e0f2fe;
+  background: var(--color-tint-cyan-bg);
   color: var(--color-primary);
 }
 /* 插件 chip 与技能 chip 视觉区分：紫色底 */
 .jx-editorChip--plugin {
-  background: #EDE9FE;
-  color: #6D28D9;
+  background: var(--color-tint-purple-bg);
+  color: var(--color-tint-purple);
 }
 .jx-editorChip-prefix {
   font-weight: 700;
@@ -3327,13 +3329,13 @@ textarea.jx-composer{
   color: var(--color-primary);
 }
 .jx-msgChip--skill {
-  background: #e0f2fe;
+  background: var(--color-tint-cyan-bg);
   color: var(--color-primary);
 }
 /* 插件 chip 与技能 chip 视觉区分：紫色底 */
 .jx-msgChip--plugin {
-  background: #EDE9FE;
-  color: #6D28D9;
+  background: var(--color-tint-purple-bg);
+  color: var(--color-tint-purple);
 }
 .jx-msgChip-prefix {
   font-weight: 700;
@@ -3606,12 +3608,13 @@ textarea.jx-composer{
   align-items: center;
   justify-content: center;
   padding: 20px;
+  /* 透明区棋盘格：格子与底色都走令牌，深色下自然翻成深灰棋盘 */
   background:
-    linear-gradient(45deg, #f3f4f6 25%, transparent 25%) 0 0 / 16px 16px,
-    linear-gradient(-45deg, #f3f4f6 25%, transparent 25%) 0 8px / 16px 16px,
-    linear-gradient(45deg, transparent 75%, #f3f4f6 75%) 8px -8px / 16px 16px,
-    linear-gradient(-45deg, transparent 75%, #f3f4f6 75%) 8px 0 / 16px 16px,
-    #fff;
+    linear-gradient(45deg, var(--color-fill-hover) 25%, transparent 25%) 0 0 / 16px 16px,
+    linear-gradient(-45deg, var(--color-fill-hover) 25%, transparent 25%) 0 8px / 16px 16px,
+    linear-gradient(45deg, transparent 75%, var(--color-fill-hover) 75%) 8px -8px / 16px 16px,
+    linear-gradient(-45deg, transparent 75%, var(--color-fill-hover) 75%) 8px 0 / 16px 16px,
+    var(--color-bg-container);
 }
 .jx-spaceImportPreview-image img {
   max-width: 100%;
@@ -3692,7 +3695,7 @@ textarea.jx-composer{
   overflow: auto;
 }
 .jx-spaceImportPreview-text--json {
-  color: #1e3a8a;
+  color: var(--color-primary);
 }
 
 /* markdown ------------------------------------------------------- */

--- a/src/frontend/src/styles/evolution.css
+++ b/src/frontend/src/styles/evolution.css
@@ -68,9 +68,9 @@
   line-height: 18px;
   white-space: nowrap;
 }
-.jx-evolutionCard-layer.is-l1 { background: rgba(37, 99, 235, .10); color: #1d4ed8; }
-.jx-evolutionCard-layer.is-l2 { background: rgba(16, 185, 129, .12); color: #047857; }
-.jx-evolutionCard-layer.is-l3 { background: rgba(139, 92, 246, .12); color: #6d28d9; }
+.jx-evolutionCard-layer.is-l1 { background: rgba(37, 99, 235, .10); color: var(--color-primary); }
+.jx-evolutionCard-layer.is-l2 { background: rgba(16, 185, 129, .12); color: var(--color-success); }
+.jx-evolutionCard-layer.is-l3 { background: rgba(139, 92, 246, .12); color: var(--color-tint-purple); }
 
 .jx-evolutionCard-entryBody { flex: 1 1 auto; min-width: 0; }
 
@@ -193,7 +193,7 @@
   color: var(--color-text-tertiary);
 }
 .jx-evoContrib-chainNode.is-terminal {
-  background: rgba(37, 99, 235, .10); color: #1d4ed8; font-weight: 600;
+  background: rgba(37, 99, 235, .10); color: var(--color-primary); font-weight: 600;
 }
 .jx-evoContrib-chainArrow { color: var(--color-primary); }
 

--- a/src/frontend/src/styles/kb-wiki.css
+++ b/src/frontend/src/styles/kb-wiki.css
@@ -290,9 +290,9 @@
 }
 
 .jx-wikiTypeTag--entity { color: var(--color-primary); background: var(--color-primary-bg); }
-.jx-wikiTypeTag--concept { color: var(--color-success); background: #DFF5EE; }
-.jx-wikiTypeTag--summary { color: #C77B14; background: #FEF0DC; }
-.jx-wikiTypeTag--index { color: #7C5CFC; background: #EDE9FE; }
+.jx-wikiTypeTag--concept { color: var(--color-tint-teal); background: var(--color-tint-teal-bg); }
+.jx-wikiTypeTag--summary { color: var(--color-tint-amber); background: var(--color-tint-amber-bg); }
+.jx-wikiTypeTag--index { color: var(--color-tint-purple); background: var(--color-tint-purple-bg); }
 
 /* ── 阅读区 ───────────────────────────────────────────────────────────────── */
 

--- a/src/frontend/src/styles/mobile.css
+++ b/src/frontend/src/styles/mobile.css
@@ -734,7 +734,7 @@
 
   .jx-mobileHeroText h1{
     margin:0;
-    color:#090d15;
+    color:var(--color-text);
     font-size:clamp(42px, 14vw, 54px);
     font-weight:800;
     line-height:1.02;
@@ -743,7 +743,7 @@
 
   .jx-mobileHeroText p{
     margin:12px 0 0;
-    color:#5f6672;
+    color:var(--color-text-secondary);
     font-size:16px;
     font-weight:400;
     line-height:1.4;
@@ -784,7 +784,7 @@
     border:1px solid #d7deea;
     border-radius:7px;
     background:var(--color-bg-container);
-    color:#141923;
+    color:var(--color-text);
     font-size:13px;
     font-weight:400;
     line-height:1;
@@ -805,7 +805,7 @@
 
   .jx-mobileQuickTaskIcon{
     flex:none;
-    color:#0f6fff;
+    color:var(--color-primary);
     font-size:20px;
   }
 
@@ -1335,7 +1335,7 @@
   .jx-agentLibraryPage .jx-agentCard-badge{
     padding:2px 8px;
     border-radius:999px;
-    background:#F1F4F8;
+    background:var(--color-bg-gray);
     color:var(--color-text-tertiary);
     font-size:11px;
     line-height:18px;

--- a/src/frontend/src/styles/onboarding.css
+++ b/src/frontend/src/styles/onboarding.css
@@ -44,7 +44,7 @@
   border-left:1px solid #dedede;
 }
 .jx-firstRun-topbar .ant-btn{
-  color:#535353;
+  color:var(--color-text-secondary);
   font-size:13px;
 }
 
@@ -65,8 +65,8 @@
   position:relative;
   padding:56px 32px 34px;
   overflow:hidden;
-  background:#f7f7f8;
-  border-right:1px solid #ececec;
+  background:var(--color-bg-layout);
+  border-right:1px solid var(--color-border);
 }
 .jx-firstRun-railIntro{
   display:flex;
@@ -75,13 +75,13 @@
   margin-bottom:42px;
 }
 .jx-firstRun-railIntro span{
-  color:#6f6f6f;
+  color:var(--color-text-tertiary);
   font-size:12px;
   line-height:1.5;
 }
 .jx-firstRun-railIntro strong{
   max-width:180px;
-  color:#202020;
+  color:var(--color-text);
   font-size:16px;
   font-weight:600;
   line-height:1.45;
@@ -114,7 +114,7 @@
   background:transparent;
   transition:background-color var(--motion-duration-fast) var(--motion-ease-standard);
 }
-.jx-firstRun-rail li.is-active{color:#202020}
+.jx-firstRun-rail li.is-active{color:var(--color-text)}
 .jx-firstRun-rail li.is-active::after{background:#202020}
 .jx-firstRun-rail li.is-done{color:var(--color-text-secondary)}
 .jx-firstRun-stepIndex{
@@ -150,7 +150,7 @@
 .jx-firstRun-railFooter > div{
   height:2px;
   overflow:hidden;
-  background:#dedede;
+  background:var(--color-fill);
 }
 .jx-firstRun-railFooter i{
   display:block;
@@ -186,7 +186,7 @@
 }
 .jx-firstRun-cardHeader h1.ant-typography{
   margin:0 0 12px;
-  color:#202020;
+  color:var(--color-text);
   font-family:var(--font-family);
   font-size:clamp(29px,2.7vw,36px);
   font-weight:600;
@@ -195,7 +195,7 @@
 }
 .jx-firstRun-cardHeader .ant-typography{
   margin-bottom:0;
-  color:#6f6f6f;
+  color:var(--color-text-tertiary);
   font-size:14px;
   line-height:1.7;
 }
@@ -205,13 +205,13 @@
   overflow-x:hidden;
   overflow-y:auto;
   scrollbar-gutter:stable;
-  scrollbar-color:#b8b8b8 transparent;
+  scrollbar-color:var(--color-fill-deep) transparent;
   overscroll-behavior:contain;
 }
 .jx-firstRun-cardBody::-webkit-scrollbar{width:8px}
 .jx-firstRun-cardBody::-webkit-scrollbar-thumb{
-  background:#c4c4c4;
-  border:2px solid #fff;
+  background:var(--color-fill-deep);
+  border:2px solid var(--color-bg-container);
   border-radius:999px;
 }
 .jx-firstRun-cardBody::-webkit-scrollbar-thumb:hover{
@@ -263,7 +263,7 @@
   align-items:center;
   justify-content:space-between;
   gap:20px;
-  color:#202020;
+  color:var(--color-text);
   text-align:left;
   background:var(--color-bg-container);
   border:1px solid #dedede;
@@ -298,7 +298,7 @@
   display:grid;
   flex:none;
   place-items:center;
-  color:#202020;
+  color:var(--color-text);
   font-size:18px;
   border:1px solid #c9c9c9;
   border-radius:50%;
@@ -368,19 +368,19 @@
   border-color:var(--color-border);
   border-radius:10px;
 }
-.jx-firstRun-card .ant-alert-info .ant-alert-icon{color:#676767}
+.jx-firstRun-card .ant-alert-info .ant-alert-icon{color:var(--color-text-tertiary)}
 .jx-firstRun-note{
   padding:12px 14px;
   display:flex;
   align-items:center;
   gap:9px;
-  color:#5f5f5f;
+  color:var(--color-text-secondary);
   font-size:12px;
   line-height:1.5;
   background:var(--color-bg-gray);
   border-radius:10px;
 }
-.jx-firstRun-note .anticon{color:#535353}
+.jx-firstRun-note .anticon{color:var(--color-text-secondary)}
 .jx-firstRun-inlineFields{
   display:grid;
   grid-template-columns:repeat(2,minmax(0,1fr));
@@ -421,7 +421,7 @@
   place-items:center;
   color:var(--color-text);
   font-size:17px;
-  background:#f1f1f1;
+  background:var(--color-bg-gray);
   border-radius:50%;
 }
 .jx-firstRun-featureBody{min-width:0;flex:1}
@@ -438,7 +438,7 @@
   align-items:center;
   justify-content:space-between;
   gap:12px;
-  color:#5f5f5f;
+  color:var(--color-text-secondary);
   font-size:12px;
   border-top:1px solid #ececec;
 }

--- a/src/frontend/src/styles/ontology.css
+++ b/src/frontend/src/styles/ontology.css
@@ -266,8 +266,8 @@
   padding: 4px 9px;
   border: 1px solid rgba(21, 45, 74, .1);
   border-radius: 999px;
-  background: #f5f7f8;
-  color: #627083;
+  background: var(--color-bg-gray);
+  color: var(--color-text-secondary);
   font-size: 11px;
   font-weight: 600;
   white-space: nowrap;
@@ -315,7 +315,7 @@
 }
 
 .jx-ontologyReviewProgress strong {
-  color: #203a58;
+  color: var(--color-text);
   font-size: 13px;
 }
 
@@ -524,7 +524,7 @@
 .jx-ontologyRevision-text h2,
 .jx-ontologyRevision-text h3 {
   margin: 18px 0 8px;
-  color: #172e49;
+  color: var(--color-text);
   line-height: 1.4;
 }
 
@@ -543,9 +543,9 @@
 .jx-ontologyManualReview {
   margin: 0 14px 14px;
   padding: 12px;
-  border: 1px solid rgba(250, 173, 20, .24);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 24%, transparent);
   border-radius: 12px;
-  background: #fffdf7;
+  background: var(--color-warning-light);
 }
 
 .jx-ontologyManualReview.is-required {
@@ -564,13 +564,13 @@
 }
 
 .jx-ontologyManualReview-head strong {
-  color: #5f440e;
+  color: var(--color-tint-amber);
   font-size: 13px;
 }
 
 .jx-ontologyManualReview-head p {
   margin: 3px 0 0;
-  color: #796744;
+  color: var(--color-tint-amber);
   font-size: 11.5px;
   line-height: 1.55;
 }
@@ -601,7 +601,7 @@
 
 .jx-ontologyManualReview-card > strong {
   display: block;
-  color: #493a1d;
+  color: var(--color-tint-amber);
   font-size: 12px;
   line-height: 1.5;
   overflow-wrap: anywhere;
@@ -628,7 +628,7 @@
 
 .jx-ontologyManualReview-card dd {
   margin: 0;
-  color: #665536;
+  color: var(--color-tint-amber);
   word-break: break-word;
   overflow-wrap: anywhere;
 }
@@ -746,7 +746,7 @@
   padding: 12px 14px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: linear-gradient(145deg, #fff, var(--color-bg-gray));
+  background: linear-gradient(145deg, var(--color-bg-container), var(--color-bg-gray));
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -898,7 +898,7 @@
   border-radius: var(--radius-md);
   background:
     radial-gradient(circle at 92% 12%, rgba(118, 85, 250, .12), transparent 30%),
-    linear-gradient(135deg, #fff 24%, var(--color-primary-light));
+    linear-gradient(135deg, var(--color-bg-container) 24%, var(--color-primary-light));
   box-shadow: var(--shadow-card);
 }
 

--- a/src/frontend/src/styles/settings.css
+++ b/src/frontend/src/styles/settings.css
@@ -153,10 +153,10 @@
   border-radius: 50%;
   background: currentColor;
 }
-.jx-conn-badge--connected   { background: #E7F7EF; color: #0A9D52; }
-.jx-conn-badge--pending     { background: #FFF7E6; color: #D48806; }
-.jx-conn-badge--error       { background: #FFF1F0; color: #CF1322; }
-.jx-conn-badge--disconnected{ background: #F0F1F3; color: var(--color-text-tertiary); }
+.jx-conn-badge--connected   { background: var(--color-tint-green-bg); color: var(--color-tint-green); }
+.jx-conn-badge--pending     { background: var(--color-tint-amber-bg); color: var(--color-tint-amber); }
+.jx-conn-badge--error       { background: var(--color-tint-red-bg); color: var(--color-tint-red); }
+.jx-conn-badge--disconnected{ background: var(--color-bg-gray); color: var(--color-text-tertiary); }
 .jx-conn-account {
   font-size: 13px;
   color: var(--color-text-secondary);
@@ -281,14 +281,14 @@
   line-height: 1.6;
 }
 .jx-conn-note--warning {
-  background: #FFFBE6;
-  border: 1px solid #FFE58F;
-  color: #ad6800;
+  background: var(--color-tint-amber-bg);
+  border: 1px solid color-mix(in srgb, var(--color-tint-amber) 40%, transparent);
+  color: var(--color-tint-amber);
 }
 .jx-conn-note--error {
-  background: #FFF1F0;
-  border: 1px solid #FFCCC7;
-  color: #cf1322;
+  background: var(--color-tint-red-bg);
+  border: 1px solid color-mix(in srgb, var(--color-tint-red) 40%, transparent);
+  color: var(--color-tint-red);
 }
 
 /* API-Key 面板：card 本身 padding:0（由内部 row 自管），这里给面板留出内边距，

--- a/src/frontend/src/styles/sidebar.css
+++ b/src/frontend/src/styles/sidebar.css
@@ -753,7 +753,7 @@
 }
 .jx-settingsMenu.ant-dropdown .ant-dropdown-menu-item-danger:hover {
   background: rgba(252,93,93,.08) !important;
-  color: #E84040 !important;
+  color: var(--color-error) !important;
 }
 
 /* ── Legacy selectors ── */

--- a/src/frontend/src/styles/team-folder.css
+++ b/src/frontend/src/styles/team-folder.css
@@ -150,7 +150,7 @@
   padding: 5px 12px;
   border-radius: 999px;
   background: rgba(251, 191, 36, 0.14);
-  color: #b45309;
+  color: var(--color-tint-amber);
   font-size: 12px;
   font-weight: 500;
   line-height: 1.6;

--- a/src/frontend/src/styles/tool.css
+++ b/src/frontend/src/styles/tool.css
@@ -1892,9 +1892,10 @@
   background:var(--color-fill-deep);
   flex-shrink:0;
 }
-.jx-ce-langDot[data-lang="python"]{background:#3572A5;}
-.jx-ce-langDot[data-lang="javascript"]{background:#f1e05a;}
-.jx-ce-langDot[data-lang="bash"],.jx-ce-langDot[data-lang="sh"]{background:#4EAA25;}
+/* 语言点用 GitHub linguist 的语言身份色，是"这门语言的颜色"而不是主题色，两档一致 */
+.jx-ce-langDot[data-lang="python"]{background:#3572A5;} /* dark-ok */
+.jx-ce-langDot[data-lang="javascript"]{background:#f1e05a;} /* dark-ok */
+.jx-ce-langDot[data-lang="bash"],.jx-ce-langDot[data-lang="sh"]{background:#4EAA25;} /* dark-ok */
 .jx-ce-langLabel{
   font-size:11px;
   font-weight:600;

--- a/src/frontend/src/styles/variables.css
+++ b/src/frontend/src/styles/variables.css
@@ -69,6 +69,27 @@
   --color-icon-green:#02B589;
   --color-icon-orange:#F8AB42;
 
+  /* ── 分类色（tint pair：浅底 + 同色系深字）──
+   * 用途：技能 / 插件 / 模式 这类**只为区分类别**的胶囊、chip、徽标。
+   * 语义色（成功/警告/错误/主色）已有 --color-*-bg + --color-* 成对令牌，够用就别来这儿取。
+   * 为什么必须成对给：单给一个浅底色，深色模式下就是一块白斑——历史上 slash 命令面板、
+   * 技能/插件 chip 全踩过。深色档的对应值在文件末尾 :root[data-theme='dark'] 块里改写，
+   * 底变暗、字提亮，两边一起维护。 */
+  --color-tint-purple-bg:#EDE9FE;
+  --color-tint-purple:#6D28D9;
+  --color-tint-cyan-bg:#E0F2FE;
+  --color-tint-cyan:#0369A1;
+  --color-tint-teal-bg:#CCFBF1;
+  --color-tint-teal:#0F766E;
+  --color-tint-amber-bg:#FEF3C7;
+  --color-tint-amber:#B45309;
+  --color-tint-green-bg:#DCFCE7;
+  --color-tint-green:#166534;
+  --color-tint-red-bg:#FEE2E2;
+  --color-tint-red:#991B1B;
+  --color-tint-blue-bg:#DBEAFE;
+  --color-tint-blue:#1E40AF;
+
   /* ── 圆角 (4 级) ── */
   --radius-xs:6px;
   --radius-sm:10px;
@@ -202,6 +223,24 @@
   --color-icon-red:#FF6B6B;
   --color-icon-purple:#9578FF;
   --color-icon-green:#22C79D;
+
+  /* 分类色深色档：底翻成低透明度同色（透出容器底、不做白斑），字提亮到暗底可读 */
+  --color-tint-purple-bg:rgba(149,120,255,.18);
+  --color-tint-purple:#B9A5FF;
+  --color-tint-cyan-bg:rgba(56,170,255,.18);
+  --color-tint-cyan:#7CC7FF;
+  /* teal 与 green 在浅色档是两个可分辨的色相（青绿 vs 正绿），深色档也必须分开——
+     否则两个不同类别的胶囊在暗底下变成同一个颜色，令牌名给的区分承诺就落空了。 */
+  --color-tint-teal-bg:rgba(45,212,191,.18);
+  --color-tint-teal:#5EE7D5;
+  --color-tint-amber-bg:rgba(248,171,66,.18);
+  --color-tint-amber:#FFC97A;
+  --color-tint-green-bg:rgba(74,222,128,.18);
+  --color-tint-green:#86E5A0;
+  --color-tint-red-bg:rgba(255,107,107,.18);
+  --color-tint-red:#FF9A9A;
+  --color-tint-blue-bg:rgba(62,139,255,.20);
+  --color-tint-blue:#8FB9FF;
 
   /* 暗底上阴影加深，靠边框分层为主 */
   --shadow-card:

--- a/src/frontend/src/utils/export.ts
+++ b/src/frontend/src/utils/export.ts
@@ -37,6 +37,8 @@ export function getMessageExportText(msg: ChatMessage): string {
   return String(msg.content || '').trim();
 }
 
+/* dark-ok-begin: 下面生成的是导出的 PDF / HTML 文稿，脱离应用主题独立存在——
+   打印与外发一律白纸黑字，不能跟随界面深浅档，整段模板不参与深色令牌化。 */
 function buildChatExportHtml(chatTitle: string, messages: ChatMessage[]): string {
   const title = chatTitle || t('对话记录');
   let html = `
@@ -83,6 +85,7 @@ function buildChatExportHtml(chatTitle: string, messages: ChatMessage[]): string
   html += '</div>';
   return html;
 }
+/* dark-ok-end */
 
 export function triggerPdfDownload(filename: string, chatTitle: string, messages: ChatMessage[], chatTimestamp?: number): void {
   const htmlContent = buildChatExportHtml(chatTitle, messages);


### PR DESCRIPTION
## Why

Dark mode kept regressing after every UI change. The root cause was a missing
feedback loop rather than a handful of missed spots: nothing failed when a
hard-coded light-only color was introduced, so regressions were only found by
looking at the app.

## What

- Adds `src/frontend/scripts/check-dark-mode.mjs`, a build-time checker that
  flags hard-coded light-only colors in styles and components.
- Adds `src/frontend/scripts/dark-mode-baseline.json`, a committed baseline so
  the existing debt is capped and can only shrink. New violations fail the build;
  the current backlog does not.
- Wires the check into `npm run build`, next to the existing i18n check, and
  exposes it as `npm run check:dark`.
- Clears the violations the checker surfaced, moving colors onto theme tokens
  across the catalog, chat, settings, onboarding, ontology, loop, canvas and
  apidoc styles.
- Turns the Word-style paper surface into an explicit light island instead of an
  untokenized leak.

## Notes

The baseline is currently looser than the tree (the build reports the tree is
102 violations below it). `npm run check:dark -- --update` tightens it once more
of the remaining debt is paid down.

## Verification

- `npm run build` passes end to end: i18n check, dark-mode check, `tsc -b`, and
  the vite production build.