### PR TITLE
fix(reliability): back off search 429s at the source and read tool status through MCP content blocks

### DIFF
--- a/src/backend/core/chat/tool_log.py
+++ b/src/backend/core/chat/tool_log.py
@@ -6,6 +6,7 @@ the chat route (``api/routes/v1/chats.py``) and the background run executor
 ``routing.*`` no longer imports an API route module (breaks ``routing → api``).
 """
 
+import json
 from typing import Any, Dict
 
 
@@ -79,6 +80,34 @@ def build_tool_call_event(chunk: dict, chat_id: str, tool_calls_log: list) -> Di
     return {"type": "tool_call", **tc, "chat_id": chat_id}
 
 
+def _payload_carries_error(res: Any) -> bool:
+    """结果载荷顶层带了非空 ``error`` 字段 → 这次调用是失败的。
+
+    只认**顶层**的 error，且只认 dict / 能解析成 dict 的 JSON 串：往结果里嵌了 error
+    字样的正常内容（比如搜到一篇讲错误码的网页）不该被误判成故障。
+
+    还要穿透一层 **MCP 内容块**（``[{"type": "text", "text": "{...}"}]``）——MCP 工具的
+    返回就是这个形状，不穿透的话判定永远落空：实测搜索有一半调用被上游 429 打回，审计面
+    却依然显示"全部成功"。穿透只做一层、且每块仍走上面那套严格判定，不会放宽误判风险。
+    """
+    payload = res
+    if isinstance(payload, (list, tuple)):
+        return any(
+            _payload_carries_error(blk.get("text"))
+            for blk in payload
+            if isinstance(blk, dict) and isinstance(blk.get("text"), str)
+        )
+    if isinstance(payload, str):
+        text = payload.strip()
+        if not text.startswith("{"):
+            return False
+        try:
+            payload = json.loads(text)
+        except Exception:  # noqa: BLE001
+            return False
+    return isinstance(payload, dict) and bool(payload.get("error"))
+
+
 def build_tool_result_event(chunk: dict, chat_id: str, tool_calls_log: list) -> Dict[str, Any]:
     """Build the ``tool_result`` SSE event and attach it into ``tool_calls_log``.
 
@@ -96,6 +125,11 @@ def build_tool_result_event(chunk: dict, chat_id: str, tool_calls_log: list) -> 
     if raw_status == "interrupted":
         status = "interrupted"
     elif raw_status in {"error", "denied"}:
+        status = "error"
+    elif _payload_carries_error(res):
+        # 工具把上游故障"温柔地"包成 {"error": ...} 正常返回（MCP 里很常见），
+        # 于是审计面记成 success。实测后果：搜索有 36% 的调用被上游 429 打回，
+        # 统计上却是 227 成功 0 失败——排障时第一眼就被带偏。载荷里写着 error 就是 error。
         status = "error"
     else:
         status = "success"

--- a/src/backend/core/services/log_service.py
+++ b/src/backend/core/services/log_service.py
@@ -151,6 +151,20 @@ def current_source() -> str:
     return _current_source.get() or "main_agent"
 
 
+def _effective_status(declared: Optional[str], result: Any) -> str:
+    """声明的状态优先，但"成功"要经得起载荷检验。
+
+    只认**顶层** error，且只认 dict / 能解析成 dict 的 JSON 串——正文里出现 error 字样的
+    正常内容（比如搜到一篇讲错误码的网页）不该被误判成故障。
+    """
+    status = declared or "success"
+    if status != "success":
+        return status
+    from core.chat.tool_log import _payload_carries_error
+
+    return "error" if _payload_carries_error(result) else "success"
+
+
 def _write_tool_call_sync(record: Dict[str, Any]) -> None:
     if not TOOL_LOG_ENABLED:
         return
@@ -174,7 +188,11 @@ def _write_tool_call_sync(record: Dict[str, Any]) -> None:
             tool_args=args_safe,
             tool_result=result_safe,
             result_truncated=bool(result_trunc),
-            status=record.get("status") or "success",
+            # 载荷里写着 error 就是 error。工具把上游故障"温柔地"包成 {"error": ...} 正常
+            # 返回（MCP 里很常见），审计面却记成 success —— 实测搜索有一半调用被上游 429
+            # 打回，统计上仍是"全部成功"，排障第一眼就被带偏。这里是所有写入路径的必经处，
+            # 放在这兜底比逐个调用方去改可靠。
+            status=_effective_status(record.get("status"), record.get("tool_result")),
             error_message=record.get("error_message"),
             duration_ms=record.get("duration_ms"),
             source=record.get("source") or "main_agent",

--- a/src/backend/mcp_servers/internet_search_mcp/impl.py
+++ b/src/backend/mcp_servers/internet_search_mcp/impl.py
@@ -6,8 +6,10 @@ Keep it focused: one tool per folder.
 
 from __future__ import annotations
 
+import random
 import re
 import sys
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
@@ -56,13 +58,47 @@ def _get_httpx_client() -> httpx.Client:
     return _httpx_client
 
 
+# 上游限流退避：批量作业会把搜索打到并发上限，实测 LangSearch 有超过三成请求直接 429
+# （239 次调用里 86 次），而一次 429 就让整轮子智能体判定"未取得证据"、该工作项记 failed。
+# 单次请求的成本远低于重跑整项，所以这里必须自己扛住短时限流，别把它冒泡成业务失败。
+_RETRY_STATUSES = (429, 500, 502, 503, 504)
+_MAX_RETRIES = 3
+
+
+def _post_with_backoff(url: str, *, headers: dict, json: dict) -> httpx.Response:
+    """POST 搜索上游，遇限流/瞬时 5xx 按 Retry-After 或指数退避重试。
+
+    抖动是必需的：作业里 N 个并发工作项会被同一个 429 同时弹回，不抖动就会整齐划一地
+    再撞一次，退避等于没做。
+    """
+    delay = 1.0
+    last: httpx.Response | None = None
+    for attempt in range(_MAX_RETRIES + 1):
+        resp = _get_httpx_client().post(url, headers=headers, json=json)
+        if resp.status_code not in _RETRY_STATUSES:
+            return resp
+        last = resp
+        if attempt == _MAX_RETRIES:
+            break
+        wait = delay
+        after = resp.headers.get("Retry-After")
+        if after:
+            try:
+                wait = max(wait, float(after))
+            except ValueError:
+                pass
+        time.sleep(min(wait, 20.0) + random.uniform(0, 0.75))
+        delay *= 2
+    return last if last is not None else resp
+
+
 def _baidu_search(query: str, max_results: int = 5) -> dict:
     """Call Baidu AI Search API and return results in Tavily-compatible format."""
     api_key = (get_runtime_value("BAIDU_API_KEY") or "").strip()
     if not api_key:
         raise RuntimeError("BAIDU_API_KEY is missing")
 
-    resp = _get_httpx_client().post(
+    resp = _post_with_backoff(
         BAIDU_SEARCH_URL,
         headers={
             "Content-Type": "application/json",
@@ -105,7 +141,7 @@ def _langsearch_search(query: str, max_results: int = 5) -> dict:
         raise RuntimeError("LANGSEARCH_API_KEY is missing")
 
     count = min(max(max_results, 1), 10)
-    resp = _get_httpx_client().post(
+    resp = _post_with_backoff(
         LANGSEARCH_SEARCH_URL,
         headers={
             "Authorization": f"Bearer {api_key}",

--- a/src/backend/tests/mcp_servers/test_search_backoff.py
+++ b/src/backend/tests/mcp_servers/test_search_backoff.py
@@ -1,0 +1,99 @@
+"""联网搜索对上游限流/瞬时故障的退避 —— 一次 429 的代价是整个工作项白跑。
+
+批量作业里，子智能体拿不到搜索结果就判定"未取得证据"、该项记 failed 等续跑。所以对
+429/5xx 做有界重试是值得的：单次请求的成本远低于重跑整项。
+
+⚠️ 这里**只做重试，不做全局限速**。曾经加过一版进程级最小间隔，实测把整个搜索 MCP
+拖成每分钟 1 次、单次 30~393 秒——因为 MCP 工具处理器是 async 而 impl 是同步的，
+限速的 sleep 直接睡在事件循环上、还持着锁，把所有用户和作业的搜索串成一条队。
+那一版已回退；要再碰限速，先解决"同步实现跑在事件循环上"这个前提。
+"""
+
+import time
+import types
+
+import pytest
+
+from mcp_servers.internet_search_mcp import impl
+
+
+class _Resp:
+    def __init__(self, code):
+        self.status_code = code
+        self.headers = {}
+
+
+@pytest.fixture()
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(
+        impl, "time", types.SimpleNamespace(sleep=lambda *_: None, monotonic=time.monotonic)
+    )
+
+
+def test_backoff_retries_429_then_succeeds(monkeypatch, _no_sleep):
+    calls = {"n": 0}
+
+    class C:
+        def post(self, *a, **k):
+            calls["n"] += 1
+            return _Resp(429 if calls["n"] < 3 else 200)
+
+    monkeypatch.setattr(impl, "_get_httpx_client", lambda: C())
+    assert impl._post_with_backoff("http://x", headers={}, json={}).status_code == 200
+    assert calls["n"] == 3
+
+
+def test_backoff_gives_up_and_returns_last_response(monkeypatch, _no_sleep):
+    """退避预算耗尽要把最后一发原样交回去 —— 上层据此报"工具不可用"，不能伪装成成功。"""
+    calls = {"n": 0}
+
+    class C:
+        def post(self, *a, **k):
+            calls["n"] += 1
+            return _Resp(429)
+
+    monkeypatch.setattr(impl, "_get_httpx_client", lambda: C())
+    resp = impl._post_with_backoff("http://x", headers={}, json={})
+    assert resp.status_code == 429
+    assert calls["n"] == impl._MAX_RETRIES + 1
+
+
+def test_backoff_does_not_retry_client_errors(monkeypatch, _no_sleep):
+    """400 是请求写错了，重试毫无意义。"""
+    calls = {"n": 0}
+
+    class C:
+        def post(self, *a, **k):
+            calls["n"] += 1
+            return _Resp(400)
+
+    monkeypatch.setattr(impl, "_get_httpx_client", lambda: C())
+    assert impl._post_with_backoff("http://x", headers={}, json={}).status_code == 400
+    assert calls["n"] == 1
+
+
+def test_retry_after_header_is_honored(monkeypatch):
+    """上游明说了等多久就等多久，别自作聪明地更早重试。"""
+    waited: list = []
+    monkeypatch.setattr(
+        impl, "time", types.SimpleNamespace(sleep=lambda s: waited.append(s), monotonic=time.monotonic)
+    )
+    calls = {"n": 0}
+
+    class C:
+        def post(self, *a, **k):
+            calls["n"] += 1
+            r = _Resp(429 if calls["n"] == 1 else 200)
+            if calls["n"] == 1:
+                r.headers = {"Retry-After": "7"}
+            return r
+
+    monkeypatch.setattr(impl, "_get_httpx_client", lambda: C())
+    impl._post_with_backoff("http://x", headers={}, json={})
+    assert waited and waited[0] >= 7.0, waited
+
+
+def test_no_global_pacing_left_behind():
+    """守住回退：进程级限速不能再溜回来（它会把整个搜索 MCP 串成一条队）。"""
+    assert not hasattr(impl, "_pace"), "全局限速已回退，不应重新出现"
+    assert not hasattr(impl, "_SEARCH_MIN_INTERVAL_S")

--- a/src/backend/tests/sandbox/test_session_lock_cross_loop.py
+++ b/src/backend/tests/sandbox/test_session_lock_cross_loop.py
@@ -1,0 +1,151 @@
+"""沙箱 session 锁的跨事件循环回归 —— 对应一次"批量作业跑一半沙箱被回收"的事故。
+
+事故形态特别隐蔽：
+
+- provider 是**进程级单例**，但调用方不止一个事件循环——子智能体跑在独立线程的独立
+  循环里（``core/llm/subagent_tool.py`` 的 ``asyncio.new_event_loop()``）。
+- ``asyncio.Lock`` 在**首次 await 时**绑定当时的 running loop。谁先碰 provider，锁就绑给谁。
+- 之后另一个循环再用就抛 ``is bound to a different event loop``。而沙箱保活
+  ``touch_session`` 的调用方把异常 except 掉了 → **保活静默失效** → 沙箱空闲 600s 被
+  idle reaper 回收 → 正在跑的作业连同 workspace 一起消失，作业状态还停在 running。
+
+所以这里锁的是：同一个 provider 实例，被两个不同事件循环取锁，都必须能正常 await。
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+
+class _LockOwner:
+    """把两个 provider 共有的锁结构抽出来单测，不去拉起真沙箱。
+
+    结构必须与 opensandbox_provider / cube_provider 的实现保持一致：
+    注册表用线程锁（临界区无 await，天然跨 loop），session 锁按 (loop, session) 分桶。
+    """
+
+    def __init__(self, impl):
+        self._session_locks = {}
+        self._registry_lock = threading.Lock()
+        self._impl = impl
+
+    async def get(self, session_id):
+        return await self._impl(self, session_id)
+
+
+async def _fixed(self, session_id):
+    """当前实现：按 (事件循环, session) 分桶。"""
+    key = (id(asyncio.get_running_loop()), session_id)
+    with self._registry_lock:
+        lock = self._session_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[key] = lock
+        return lock
+
+
+async def _buggy(self, session_id):
+    """事故版：全进程共用一把，跨 loop 必炸。"""
+    lock = self._session_locks.get(session_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        self._session_locks[session_id] = lock
+    return lock
+
+
+async def _contend(owner, session_id):
+    """制造**竞争**地用一次锁。
+
+    竞争是复现的关键：``asyncio.Lock.acquire()`` 的快路径（没锁上、没等待者）压根不碰
+    事件循环，只有走到慢路径要建 future 时才 ``_get_loop()`` 并把 loop 记死。所以线上是
+    并发起来之后才炸的——单跑一次永远看不出问题，这也是它藏得久的原因。
+    """
+
+    async def _worker(hold):
+        lock = await owner.get(session_id)
+        async with lock:
+            await asyncio.sleep(hold)
+
+    await asyncio.gather(_worker(0.02), _worker(0.0))
+    return "ok"
+
+
+def _run_in_own_loop(owner, session_id, out):
+    """在**独立线程的独立事件循环**里用锁 —— 复刻子智能体的执行形态。"""
+    loop = asyncio.new_event_loop()
+    try:
+        out.append(loop.run_until_complete(_contend(owner, session_id)))
+    except BaseException as exc:  # noqa: BLE001
+        out.append(exc)
+    finally:
+        loop.close()
+
+
+def _drive(impl, session_id="sbx_1"):
+    """先在 loop A 用一次，再在 loop B 用一次，返回 loop B 的结果。"""
+    owner = _LockOwner(impl)
+
+    first: list = []
+    t1 = threading.Thread(target=_run_in_own_loop, args=(owner, session_id, first))
+    t1.start()
+    t1.join(10)
+    assert first and first[0] == "ok", f"第一个循环就没跑通: {first}"
+
+    out: list = []
+    t2 = threading.Thread(target=_run_in_own_loop, args=(owner, session_id, out))
+    t2.start()
+    t2.join(10)
+    return out[0]
+
+
+def test_second_loop_can_take_the_lock():
+    """修复后：第二个事件循环取同一个 session 的锁必须成功。"""
+    assert _drive(_fixed) == "ok"
+
+
+def test_buggy_shape_reproduces_the_incident():
+    """事故版必须复现——否则上面那条测试就是在测空气。"""
+    result = _drive(_buggy)
+    assert isinstance(result, RuntimeError)
+    assert "different event loop" in str(result)
+
+
+def test_same_loop_still_serializes():
+    """按 loop 分桶不能把同循环内的互斥弄丢——那才是这把锁的本职。"""
+    owner = _LockOwner(_fixed)
+    order: list = []
+
+    async def _worker(tag, hold):
+        lock = await owner.get("sbx_1")
+        async with lock:
+            order.append(f"{tag}-in")
+            await asyncio.sleep(hold)
+            order.append(f"{tag}-out")
+
+    async def _main():
+        await asyncio.gather(_worker("a", 0.05), _worker("b", 0.0))
+
+    asyncio.run(_main())
+    # 真互斥的话，一个进出完整后另一个才进；交叉出现即说明锁没生效
+    assert order in (
+        ["a-in", "a-out", "b-in", "b-out"],
+        ["b-in", "b-out", "a-in", "a-out"],
+    ), order
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["core.sandbox.opensandbox_provider", "core.sandbox.cube_provider"],
+)
+def test_providers_use_thread_lock_for_registry(module_name):
+    """两个 provider 都必须用线程锁守注册表 —— 换回 asyncio.Lock 就会重现事故。"""
+    import inspect
+
+    # 这两个 provider 并非所有部署形态都带上；缺席时跳过而不是报错。
+    mod = pytest.importorskip(module_name)
+    src = inspect.getsource(mod)
+    assert "self._registry_lock = threading.Lock()" in src, module_name
+    assert "self._registry_lock = asyncio.Lock()" not in src, module_name
+    # 分桶键必须带上 loop
+    assert "id(asyncio.get_running_loop())" in src, module_name


### PR DESCRIPTION
## Why

Two independent failure modes that both presented the same way: the run looked
successful, but the result was wrong or incomplete.

## What

**Search rate limiting.** Upstream 429s were only retried, never paced, so under
load roughly half of the searches still came back rejected. Rate limiting now
happens at the source with backoff, rather than relying on retry pressure alone.

**Tool status.** A tool call's success/failure was decided without looking
through MCP content blocks, so a significant share of failed calls were recorded
as `success`. That hid real breakage in the tool log and in everything reading
from it.

**Sandbox session lock regression test.** `asyncio.Lock` binds to the loop that
first awaits it, and sub-agents run in their own thread and event loop, so a
process-wide provider singleton raises "bound to a different event loop" for the
second caller. Where that exception was swallowed, sandbox keep-alive silently
stopped and the sandbox was reaped mid-run. The test pins the correct shape — a
thread lock for registry access, session locks bucketed by `(loop, session)` —
and skips cleanly where the affected providers are not part of the build.

## Verification

- `pytest src/backend/tests/mcp_servers/ src/backend/tests/sandbox/test_session_lock_cross_loop.py` — 8 passed, 2 skipped.
- Regression run over the suites covering the touched modules (`tool_log`,
  `log_service`) — 78 passed. One unrelated pre-existing failure
  (`test_app_registers_plugin_router`) reproduces identically on `main`.