### PR TITLE
Import and export agents as frontmatter markdown

### DIFF
--- a/src/backend/api/openapi_data_schemas.py
+++ b/src/backend/api/openapi_data_schemas.py
@@ -237,28 +237,6 @@ DATA_COMPONENTS: Dict[str, Dict[str, Any]] = {
             "updated_at": {"type": "string", "format": "date-time"},
         },
     },
-    "AgentExportItem": {
-        "type": "object",
-        "properties": {
-            "name": {"type": "string"},
-            "description": {"type": "string"},
-            "system_prompt": {"type": "string"},
-            "welcome_message": {"type": "string"},
-            "suggested_questions": {"type": "array", "items": {"type": "string"}},
-            "mcp_server_ids": {"type": "array", "items": {"type": "string"}},
-            "skill_ids": {"type": "array", "items": {"type": "string"}},
-            "kb_ids": {"type": "array", "items": {"type": "string"}},
-            "model_provider_id": {"type": "string"},
-            "temperature": {"type": "number"},
-            "max_tokens": {"type": "integer"},
-            "max_iters": {"type": "integer"},
-            "timeout": {"type": "integer"},
-            "is_enabled": {"type": "boolean"},
-            "sort_order": {"type": "integer"},
-            "extra_config": {"type": "object", "additionalProperties": True},
-            "avatar": {"type": "string"},
-        },
-    },
     "AvailableResources": {
         "type": "object",
         "properties": {
@@ -635,6 +613,13 @@ DATA_SCHEMAS: Dict[Tuple[str, str], Dict[str, Any]] = {
     ("GET", "/v1/agents/available-resources"): _ref("AvailableResources"),
     ("GET", "/v1/agents/{agent_id}"): _ref("UserAgentItem"),
     ("POST", "/v1/agents"): _ref("UserAgentItem"),
+    ("POST", "/v1/agents/import"): {
+        "type": "object",
+        "properties": {
+            "created": {"type": "integer"},
+            "agents": {"type": "array", "items": _ref("UserAgentItem")},
+        },
+    },
     ("PUT", "/v1/agents/{agent_id}"): _ref("UserAgentItem"),
     ("DELETE", "/v1/agents/{agent_id}"): {
         "type": "object",
@@ -643,8 +628,15 @@ DATA_SCHEMAS: Dict[Tuple[str, str], Dict[str, Any]] = {
     # ===== Admin Agents =====
     ("GET", "/v1/admin/agents"): {"type": "array", "items": _ref("UserAgentItem")},
     ("POST", "/v1/admin/agents"): _ref("UserAgentItem"),
-    ("GET", "/v1/admin/agents/export"): {"type": "array", "items": _ref("AgentExportItem")},
     ("POST", "/v1/admin/agents/import"): {
+        "type": "object",
+        "properties": {
+            "created": {"type": "integer"},
+            "updated": {"type": "integer"},
+            "message": {"type": "string"},
+        },
+    },
+    ("POST", "/v1/admin/agents/import-file"): {
         "type": "object",
         "properties": {
             "created": {"type": "integer"},

--- a/src/backend/api/routes/v1/agents.py
+++ b/src/backend/api/routes/v1/agents.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 from core.auth.backend import UserContext, get_current_user
 from core.auth.capabilities import resolve_user_capabilities
 from core.db.engine import get_db
-from core.infra.exceptions import AccessDeniedError
+from core.infra.exceptions import AccessDeniedError, BadRequestError
 from core.infra.responses import error_response, success_response
+from core.services.agent_markdown import agent_filename, agent_to_markdown, parse_agents_upload
 from core.services.user_agent_service import UserAgentService
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, Response, UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -83,6 +85,103 @@ async def available_resources(
 ):
     data = UserAgentService(db).list_available_resources(owner_user_id=str(user.user_id))
     return success_response(data=data)
+
+
+_IMPORT_FIELDS = [
+    "name",
+    "avatar",
+    "description",
+    "system_prompt",
+    "welcome_message",
+    "suggested_questions",
+    "mcp_server_ids",
+    "skill_ids",
+    "plugin_ids",
+    "kb_ids",
+    "model_provider_id",
+    "temperature",
+    "max_tokens",
+    "max_iters",
+    "timeout",
+    "is_enabled",
+    "extra_config",
+]
+
+
+@router.post("/import", summary="导入子智能体（markdown / zip）")
+async def import_agents(
+    file: UploadFile = File(...),
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """从上传文件导入个人子智能体：单个 frontmatter markdown（.md）或批量 zip。
+
+    文件格式与导出一致（frontmatter 写配置、正文即 system prompt），也兼容旧版
+    JSON 数组文件。需 ``can_add_agent`` 权限。
+    """
+    _require_can_add_agent(str(user.user_id), db)
+    raw = await file.read()
+    try:
+        items = parse_agents_upload(file.filename or "", raw)
+    except ValueError as exc:
+        raise BadRequestError(str(exc))
+
+    svc = UserAgentService(db)
+    agents = []
+    for item in items:
+        data = {k: item[k] for k in _IMPORT_FIELDS if k in item}
+        try:
+            agents.append(
+                svc.create(
+                    user_id=user.user_id,
+                    operator_name=user.username,
+                    owner_type="user",
+                    data=data,
+                )
+            )
+        except ValueError as exc:
+            return error_response(code=400, message=f"{item.get('name')}: {exc}")
+    logger.info("user_agents_imported: user=%s created=%d", user.user_id, len(agents))
+    return success_response(data={"created": len(agents), "agents": agents})
+
+
+@router.get("/{agent_id}/export", summary="导出子智能体为 markdown")
+async def export_agent(
+    agent_id: str,
+    user: UserContext = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """把单个子智能体导出为 frontmatter markdown 文件（正文即 system prompt），
+    对齐 Claude Code / pi agent 一类 harness 的 subagent 文件格式，可直接重新导入。
+    """
+    from core.llm.builtin_subagents import list_builtin_subagents
+
+    agent = next(
+        (
+            item
+            for item in list_builtin_subagents(include_prompt=True)
+            if item["agent_id"] == agent_id
+        ),
+        None,
+    )
+    if agent is None:
+        svc = UserAgentService(db)
+        try:
+            agent = svc.get_by_id(agent_id, user_id=user.user_id)
+        except LookupError:
+            return error_response(code=404, message="Agent not found")
+        except PermissionError:
+            return error_response(code=403, message="Access denied")
+
+    text = agent_to_markdown(agent)
+    fname = agent_filename(str(agent.get("name") or "agent"))
+    return Response(
+        content=text,
+        media_type="text/markdown; charset=utf-8",
+        headers={
+            "Content-Disposition": f"attachment; filename=\"agent.md\"; filename*=UTF-8''{quote(fname)}"
+        },
+    )
 
 
 @router.get("/{agent_id}", summary="子智能体详情")

--- a/src/backend/core/services/agent_markdown.py
+++ b/src/backend/core/services/agent_markdown.py
@@ -1,0 +1,159 @@
+"""子智能体 <-> Markdown 互转（YAML frontmatter + 正文即 system prompt）。
+
+对齐 Claude Code / pi agent 一类 harness 的 subagent 文件格式：一个智能体一个
+``.md`` 文件，frontmatter 写 name/description/tools/skills 等配置，正文即系统
+提示词；批量导出打包为 zip。导入侧同时兼容旧版 JSON 数组导出文件。
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import zipfile
+from decimal import Decimal
+from typing import Any, Dict, List
+
+import yaml
+
+# frontmatter 键 <-> DB 字段（对齐 Claude Code / pi 的 tools / skills / model 惯例）
+_ALIAS_TO_FIELD = {
+    "tools": "mcp_server_ids",
+    "skills": "skill_ids",
+    "plugins": "plugin_ids",
+    "knowledge_bases": "kb_ids",
+    "model": "model_provider_id",
+    "enabled": "is_enabled",
+}
+_FIELD_TO_ALIAS = {v: k for k, v in _ALIAS_TO_FIELD.items()}
+
+_LIST_FIELDS = {"mcp_server_ids", "skill_ids", "plugin_ids", "kb_ids", "suggested_questions"}
+
+# 导出时 frontmatter 的键顺序（DB 字段名，写出时再映射为别名）
+_FRONTMATTER_FIELDS = [
+    "name",
+    "description",
+    "avatar",
+    "model_provider_id",
+    "mcp_server_ids",
+    "skill_ids",
+    "plugin_ids",
+    "kb_ids",
+    "temperature",
+    "max_tokens",
+    "max_iters",
+    "timeout",
+    "is_enabled",
+    "sort_order",
+    "welcome_message",
+    "suggested_questions",
+    "extra_config",
+]
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n?(.*)\Z", re.DOTALL)
+
+_MAX_ZIP_MEMBERS = 500
+_MAX_MEMBER_BYTES = 5 * 1024 * 1024
+
+
+def agent_to_markdown(item: Dict[str, Any]) -> str:
+    """把智能体字典序列化为 frontmatter markdown，正文为 system_prompt。"""
+    meta: Dict[str, Any] = {}
+    for field in _FRONTMATTER_FIELDS:
+        val = item.get(field)
+        if isinstance(val, Decimal):
+            val = float(val)
+        if val is None:
+            continue
+        if not isinstance(val, bool) and val in ("", [], {}):
+            continue
+        meta[_FIELD_TO_ALIAS.get(field, field)] = val
+    front = yaml.safe_dump(meta, allow_unicode=True, sort_keys=False, default_flow_style=False)
+    body = str(item.get("system_prompt") or "").strip()
+    return f"---\n{front}---\n\n{body}\n"
+
+
+def parse_agent_markdown(text: str) -> Dict[str, Any]:
+    """解析 frontmatter markdown 为导入用的智能体字典。"""
+    match = _FRONTMATTER_RE.match(text.strip())
+    if not match:
+        raise ValueError("Markdown 缺少 YAML frontmatter（--- 分隔块）")
+    try:
+        meta = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"frontmatter 不是合法 YAML: {exc}") from exc
+    if not isinstance(meta, dict):
+        raise ValueError("frontmatter 必须是键值映射")
+
+    item: Dict[str, Any] = {}
+    for key, val in meta.items():
+        field = _ALIAS_TO_FIELD.get(key, key)
+        if field in _LIST_FIELDS and isinstance(val, str):
+            val = [part.strip() for part in val.split(",") if part.strip()]
+        item[field] = val
+    if not item.get("name"):
+        raise ValueError("frontmatter 缺少 name 字段")
+    item["system_prompt"] = match.group(2).strip()
+    return item
+
+
+def _safe_filename(name: str, used: set) -> str:
+    base = re.sub(r"[^\w一-鿿.-]+", "_", name).strip("_") or "agent"
+    candidate = base
+    seq = 2
+    while candidate in used:
+        candidate = f"{base}-{seq}"
+        seq += 1
+    used.add(candidate)
+    return f"{candidate}.md"
+
+
+def agent_filename(name: str) -> str:
+    """单个智能体导出时的 .md 文件名。"""
+    return _safe_filename(str(name or ""), set())
+
+
+def agents_to_zip(items: List[Dict[str, Any]]) -> bytes:
+    """把一批智能体打包为 zip（每个智能体一个 .md 文件）。"""
+    buf = io.BytesIO()
+    used: set = set()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in items:
+            filename = _safe_filename(str(item.get("name") or ""), used)
+            zf.writestr(filename, agent_to_markdown(item))
+    return buf.getvalue()
+
+
+def parse_agents_upload(filename: str, data: bytes) -> List[Dict[str, Any]]:
+    """解析导入文件（.md / .zip / 旧版 .json）为智能体字典列表。"""
+    lower = (filename or "").lower()
+    if lower.endswith(".md"):
+        return [parse_agent_markdown(data.decode("utf-8"))]
+    if lower.endswith(".zip"):
+        items: List[Dict[str, Any]] = []
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            members = [
+                info
+                for info in zf.infolist()
+                if not info.is_dir()
+                and info.filename.lower().endswith(".md")
+                and not info.filename.startswith("__MACOSX")
+            ]
+            if len(members) > _MAX_ZIP_MEMBERS:
+                raise ValueError(f"zip 内 .md 文件超过 {_MAX_ZIP_MEMBERS} 个上限")
+            for info in members:
+                if info.file_size > _MAX_MEMBER_BYTES:
+                    raise ValueError(f"文件过大: {info.filename}")
+                try:
+                    items.append(parse_agent_markdown(zf.read(info).decode("utf-8")))
+                except ValueError as exc:
+                    raise ValueError(f"{info.filename}: {exc}") from exc
+        if not items:
+            raise ValueError("zip 中没有可导入的 .md 智能体文件")
+        return items
+    if lower.endswith(".json"):
+        parsed = json.loads(data.decode("utf-8"))
+        if not isinstance(parsed, list):
+            raise ValueError("JSON 格式错误：需要数组")
+        return parsed
+    raise ValueError("不支持的文件类型，仅支持 .md / .zip / .json")

--- a/src/backend/tests/test_agent_markdown.py
+++ b/src/backend/tests/test_agent_markdown.py
@@ -1,0 +1,105 @@
+"""子智能体 markdown 导入导出格式测试（agent_markdown 服务）。"""
+
+import io
+import json
+import zipfile
+from decimal import Decimal
+
+import pytest
+from core.services.agent_markdown import (
+    agent_to_markdown,
+    agents_to_zip,
+    parse_agent_markdown,
+    parse_agents_upload,
+)
+
+SAMPLE = {
+    "name": "数据分析师",
+    "description": "擅长统计与可视化",
+    "system_prompt": "你是一名数据分析师。\n\n## 职责\n- 清洗数据",
+    "welcome_message": "你好，我可以帮你分析数据",
+    "suggested_questions": ["帮我清洗CSV", "画个图"],
+    "mcp_server_ids": ["database_query", "generate_chart_tool"],
+    "skill_ids": ["data-analyst-cn"],
+    "plugin_ids": ["chart-plugin"],
+    "kb_ids": [],
+    "model_provider_id": "provider-xxx",
+    "temperature": Decimal("0.7"),
+    "max_tokens": 4096,
+    "max_iters": 10,
+    "timeout": 120,
+    "is_enabled": True,
+    "sort_order": 0,
+    "extra_config": {"ontology_tags": ["ontology:finance"]},
+    "avatar": "📈",
+}
+
+
+def test_markdown_round_trip():
+    text = agent_to_markdown(SAMPLE)
+    assert text.startswith("---\n")
+    item = parse_agent_markdown(text)
+    assert item["name"] == SAMPLE["name"]
+    assert item["system_prompt"] == SAMPLE["system_prompt"]
+    assert item["mcp_server_ids"] == SAMPLE["mcp_server_ids"]
+    assert item["skill_ids"] == SAMPLE["skill_ids"]
+    assert item["plugin_ids"] == SAMPLE["plugin_ids"]
+    assert item["model_provider_id"] == SAMPLE["model_provider_id"]
+    assert item["temperature"] == pytest.approx(0.7)
+    assert item["is_enabled"] is True
+    assert item["extra_config"] == SAMPLE["extra_config"]
+    assert item["avatar"] == SAMPLE["avatar"]
+    assert "kb_ids" not in item  # 空列表导出时省略
+
+
+def test_frontmatter_uses_harness_aliases():
+    text = agent_to_markdown(SAMPLE)
+    front = text.split("---")[1]
+    assert "tools:" in front and "mcp_server_ids" not in front
+    assert "skills:" in front and "skill_ids" not in front
+    assert "model:" in front and "model_provider_id" not in front
+    assert "enabled:" in front and "is_enabled" not in front
+
+
+def test_parse_accepts_raw_field_names_and_comma_lists():
+    text = "---\nname: 甲\nmcp_server_ids: [a, b]\nskills: x, y\n---\n提示词"
+    item = parse_agent_markdown(text)
+    assert item["mcp_server_ids"] == ["a", "b"]
+    assert item["skill_ids"] == ["x", "y"]
+    assert item["system_prompt"] == "提示词"
+
+
+def test_parse_rejects_missing_frontmatter_or_name():
+    with pytest.raises(ValueError):
+        parse_agent_markdown("没有 frontmatter 的正文")
+    with pytest.raises(ValueError):
+        parse_agent_markdown("---\ndescription: 无名\n---\n正文")
+
+
+def test_disabled_state_survives_round_trip():
+    item = parse_agent_markdown(agent_to_markdown({**SAMPLE, "is_enabled": False}))
+    assert item["is_enabled"] is False
+
+
+def test_zip_round_trip_and_name_dedup():
+    data = agents_to_zip([SAMPLE, {**SAMPLE, "name": "数据分析师/2"}])
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        names = zf.namelist()
+    assert len(names) == 2 and len(set(names)) == 2
+    assert all(n.endswith(".md") for n in names)
+
+    items = parse_agents_upload("agents.zip", data)
+    assert {i["name"] for i in items} == {"数据分析师", "数据分析师/2"}
+
+
+def test_upload_single_md_and_legacy_json():
+    md = agent_to_markdown(SAMPLE).encode("utf-8")
+    assert parse_agents_upload("agent.md", md)[0]["name"] == SAMPLE["name"]
+
+    legacy = json.dumps([{"name": "旧格式", "system_prompt": "p"}]).encode("utf-8")
+    assert parse_agents_upload("agents.json", legacy)[0]["name"] == "旧格式"
+
+    with pytest.raises(ValueError):
+        parse_agents_upload("agents.json", json.dumps({"name": "非数组"}).encode("utf-8"))
+    with pytest.raises(ValueError):
+        parse_agents_upload("agents.txt", b"whatever")

--- a/src/frontend/src/components/agent/AgentPanel.tsx
+++ b/src/frontend/src/components/agent/AgentPanel.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'motion/react';
 import { Button, Drawer, Input, Modal, Pagination, Skeleton, Switch, Tooltip, message, Select, Form, Tag, List, Empty, Dropdown } from 'antd';
-import { PlusOutlined, SearchOutlined, DeleteOutlined, EditOutlined, LeftOutlined, RightOutlined, RobotOutlined, AppstoreAddOutlined, UploadOutlined, DownOutlined } from '@ant-design/icons';
+import { PlusOutlined, SearchOutlined, DeleteOutlined, EditOutlined, LeftOutlined, RightOutlined, RobotOutlined, AppstoreAddOutlined, UploadOutlined, DownOutlined, ImportOutlined, ExportOutlined } from '@ant-design/icons';
 import { useAgentStore, type UserAgentItem } from '../../stores/agentStore';
 import { AgentMarketplaceModal } from './AgentMarketplaceModal';
 import {
@@ -205,7 +205,7 @@ interface AgentPanelProps {
 export function AgentPanel({ embedded = false }: AgentPanelProps = {}) {
   const {
     agents, loading, fetchAgents, deleteAgent, updateAgent, toggleBuiltinAgent, setCurrentAgent,
-    fetchAvailableResources, availableResources,
+    fetchAvailableResources, availableResources, importAgents, exportAgent,
   } = useAgentStore();
   const { panel, panelEntryNonce, setPanel } = useCatalogStore();
   const { setCurrentChatId, updateStore } = useChatStore();
@@ -333,6 +333,32 @@ export function AgentPanel({ embedded = false }: AgentPanelProps = {}) {
     setFormPageAgent(undefined);
     setSearch('');
   }, [homePanel, panel, panelEntryNonce]);
+
+  const importInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleImportFile(file: File) {
+    try {
+      const count = await importAgents(file);
+      message.success(t('已导入 {n} 个智能体', { n: count }));
+    } catch (err: unknown) {
+      message.error(t('导入失败：{msg}', { msg: (err as Error).message }));
+    }
+  }
+
+  async function handleExportAgent(agent: UserAgentItem) {
+    try {
+      const blob = await exportAgent(agent.agent_id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${agent.name}.md`;
+      a.click();
+      URL.revokeObjectURL(url);
+      message.success(t('智能体已导出：{name}.md', { name: agent.name }));
+    } catch (err: unknown) {
+      message.error(t('导出失败：{msg}', { msg: (err as Error).message }));
+    }
+  }
 
   function startAgentChat(agent: UserAgentItem) {
     setCurrentAgent(agent);
@@ -604,6 +630,14 @@ export function AgentPanel({ embedded = false }: AgentPanelProps = {}) {
                 >
                   {t('开始对话')}
                 </Button>
+                <Tooltip title={t('导出')}>
+                  <Button
+                    aria-label={t('导出')}
+                    icon={<ExportOutlined />}
+                    className="jx-agentDetail-iconBtn"
+                    onClick={() => void handleExportAgent(selectedAgent)}
+                  />
+                </Tooltip>
                 {canEdit && channelBotEnabled && (
                   <Tooltip title={t('绑定渠道机器人')}>
                     <Button
@@ -780,19 +814,33 @@ export function AgentPanel({ embedded = false }: AgentPanelProps = {}) {
             className="jx-agentPage-search"
           />
           {canAddAgent && (
-            <Dropdown
-              menu={{
-                items: [
-                  { key: 'create', icon: <PlusOutlined />, label: t('创建智能体'), onClick: () => setFormPageAgent(null) },
-                  { key: 'market', icon: <AppstoreAddOutlined />, label: t('从智能体市场获取'), onClick: () => setMarketOpen(true) },
-                  { key: 'mysubs', icon: <UploadOutlined />, label: t('我的上架申请'), onClick: openMySubs },
-                ],
-              }}
-            >
-              <Button type="primary" icon={<PlusOutlined />} className="jx-agentPage-createBtn">
-                {t('添加智能体')} <DownOutlined />
-              </Button>
-            </Dropdown>
+            <>
+              <input
+                ref={importInputRef}
+                type="file"
+                accept=".md,.zip,.json"
+                hidden
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) void handleImportFile(file);
+                  e.target.value = '';
+                }}
+              />
+              <Dropdown
+                menu={{
+                  items: [
+                    { key: 'create', icon: <PlusOutlined />, label: t('创建智能体'), onClick: () => setFormPageAgent(null) },
+                    { key: 'market', icon: <AppstoreAddOutlined />, label: t('从智能体市场获取'), onClick: () => setMarketOpen(true) },
+                    { key: 'import', icon: <ImportOutlined />, label: t('导入智能体'), onClick: () => importInputRef.current?.click() },
+                    { key: 'mysubs', icon: <UploadOutlined />, label: t('我的上架申请'), onClick: openMySubs },
+                  ],
+                }}
+              >
+                <Button type="primary" icon={<PlusOutlined />} className="jx-agentPage-createBtn">
+                  {t('添加智能体')} <DownOutlined />
+                </Button>
+              </Dropdown>
+            </>
           )}
         </div>
       </div>

--- a/src/frontend/src/i18n/en/agentMarket.ts
+++ b/src/frontend/src/i18n/en/agentMarket.ts
@@ -26,6 +26,9 @@ export const AGENT_MARKET_DICT: Record<string, string> = {
   // 用户侧（AgentPanel）
   '添加智能体': 'Add agent',
   '从智能体市场获取': 'Get from marketplace',
+  '导入智能体': 'Import agent',
+  '已导入 {n} 个智能体': 'Imported {n} agent(s)',
+  '智能体已导出：{name}.md': 'Agent exported: {name}.md',
   '从市场获取': 'Get from marketplace',
   '我的上架': 'My submissions',
   '我的上架申请': 'My marketplace submissions',

--- a/src/frontend/src/stores/agentStore.ts
+++ b/src/frontend/src/stores/agentStore.ts
@@ -59,6 +59,8 @@ interface AgentState {
   updateAgent: (agentId: string, data: Partial<UserAgentItem>) => Promise<UserAgentItem>;
   toggleBuiltinAgent: (agentId: string, enabled: boolean) => Promise<UserAgentItem>;
   deleteAgent: (agentId: string) => Promise<void>;
+  importAgents: (file: File) => Promise<number>;
+  exportAgent: (agentId: string) => Promise<Blob>;
   setCurrentAgent: (agent: UserAgentItem | null) => void;
 }
 
@@ -133,6 +135,39 @@ export const useAgentStore = create<AgentState>((set) => ({
       currentAgent: state.currentAgent?.agent_id === agentId ? agent : state.currentAgent,
     }));
     return agent;
+  },
+
+  importAgents: async (file) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response = await fetch(`${apiBase()}/v1/agents/import`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw createApiResponseError(response.status, payload, `HTTP ${response.status}`);
+    }
+    const payload: unknown = await response.json();
+    const data = (isRecord(payload) && 'data' in payload ? payload.data : payload) as {
+      created?: number;
+      agents?: UserAgentItem[];
+    };
+    const imported = data.agents ?? [];
+    set((state) => ({ agents: [...state.agents, ...imported] }));
+    return data.created ?? imported.length;
+  },
+
+  exportAgent: async (agentId) => {
+    const response = await fetch(`${apiBase()}/v1/agents/${agentId}/export`, {
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw createApiResponseError(response.status, payload, `HTTP ${response.status}`);
+    }
+    return response.blob();
   },
 
   deleteAgent: async (agentId) => {


### PR DESCRIPTION
## What

Agents can be moved between deployments as plain markdown files: the frontmatter carries the configuration, the body is the system prompt. This is the same on-disk shape used by Claude Code / pi-agent style harnesses, so a subagent file written for one of those can be dropped straight into the agent panel, and an agent exported here can be handed to one of them.

## Changes

**Backend**

- `core/services/agent_markdown.py` (new) — serialises an agent to frontmatter markdown, and parses an upload that is either a single `.md`, a `.zip` of several, or a legacy JSON array.
- `POST /v1/agents/import` — creates personal agents from an uploaded file. Gated on the existing `can_add_agent` capability; a malformed upload returns 400, and a rejected entry reports which agent failed.
- `GET /v1/agents/{agent_id}/export` — returns one agent as `text/markdown`, with an RFC 5987 `Content-Disposition` filename so non-ASCII agent names survive the download. Built-in subagents resolve too, not just user-owned ones.
- `api/openapi_data_schemas.py` — declares the response shapes for the new import endpoints and drops the now unused `AgentExportItem` component.

**Frontend**

- `AgentPanel.tsx` — an "Import agent" entry in the add-agent dropdown (hidden behind a file input accepting `.md` / `.zip` / `.json`), and an export button on the agent detail header.
- `stores/agentStore.ts` — `importAgents(file)` and `exportAgent(agentId)`; import appends the created agents to the store, export returns a `Blob`.
- `i18n/en/agentMarket.ts` — English strings for the new actions.

## Round-trip format

```markdown
---
name: Research assistant
description: Searches and summarises
skill_ids: [web-search]
temperature: 0.3
---

You are a research assistant. ...
```

## Testing

- `src/backend/tests/test_agent_markdown.py` (new) covers serialisation, single-file and zip parsing, legacy JSON compatibility, and the round trip.
- `tsc --noEmit` passes on the frontend tree.