### PR TITLE
Preserve context order and isolate sandbox sessions

### DIFF
--- a/document/en/modules/sandbox.md
+++ b/document/en/modules/sandbox.md
@@ -1,10 +1,12 @@
 # Sandbox Execution System
 
-> Last updated: 2026-08-11
+> Last updated: 2026-08-31
 
 The sandbox is the isolated environment where HugAgentOS's agents execute code: every `bash` call the model makes in a conversation, every [skill](agent-skills.md) script run, every generated deliverable happens inside the sandbox rather than the backend process. A single **provider protocol** abstracts three interchangeable execution backends — from the single-host lightweight script_runner, through OpenSandbox with persistent sessions and snapshot recovery, to a remote MicroVM fleet (Cube) — with the tool layer above completely agnostic to the choice.
 
 Edition split (see [editions](../editions/overview.md)): the **lightweight sandbox (script_runner) plus the sandbox tool / offload infrastructure are Community CE**; the **persistent sandboxes (opensandbox / cube — session retention, environment reuse, snapshot recovery) are Enterprise EE** — the CE derivation strips those two provider files and the factory transparently falls back to the lightweight implementation.
+
+All providers follow one boundary rule: **`session_id` (`chat_id` in a conversation) is the sole isolation key**. Different conversations use different sandboxes; the main agent, built-in subagents, user-defined subagents, and batch items in one conversation share the same `/workspace`. Model context, tool permissions, and execution threads may remain independent, but no second file sandbox is created inside a conversation.
 
 ## The provider protocol (core/sandbox/protocol.py)
 
@@ -21,16 +23,16 @@ Every provider implements the same `SandboxProvider` Protocol, whose field contr
 | `health()` | Health probe |
 | `admin_*` family | Read-only views for the security console (capability declaration / instance listing / detail / pool stats); unsupported abilities raise `SandboxAdminNotSupported` and the UI greys them out |
 
-Two key optional fields on `ExecuteRequest`:
+Two key fields on `ExecuteRequest`:
 
-- **`session_id`**: persistent providers use it to bind multiple `execute` calls to the same underlying sandbox instance (variables, pip packages and `/workspace` files persist across calls); ephemeral providers ignore it;
+- **`session_id`**: every provider uses it to route the conversation workspace; calls with the same ID retain `/workspace` files, while different IDs cannot see each other. OpenSandbox and Cube additionally reuse the underlying container, MicroVM, or kernel;
 - **`user_id`**: enables myspace file visibility (bind-mount or seeding) — see Plan F below.
 
 ## The three provider implementations
 
 | Provider | File | Form | When to use | Edition |
 |---|---|---|---|---|
-| `script_runner` | `script_runner_provider.py` | Wraps HTTP calls to the `hugagent-script-runner` sidecar container (setrlimit subprocesses inside), stateless | Single-host deployments, one-shot code execution; the default | CE |
+| `script_runner` | `script_runner_provider.py` | One sidecar with persistent per-`session_id` filesystem directories; each command still runs in a setrlimit subprocess | Single-host lightweight execution; the default | CE |
 | `opensandbox` | `opensandbox_provider.py` + `_opensandbox_*.py` | Alibaba OpenSandbox (Docker containers + persistent Jupyter kernels): per-chat persistent sessions, warm pools, snapshots | Multi-turn iterative analysis, heavy skill workflows | **EE** |
 | `cube` | `cube_provider.py` | Tencent CubeSandbox (E2B-compatible MicroVMs) on a **remote node** — the backend reaches it over the network via the `e2b_code_interpreter` SDK, no local sidecar | Deployments where the backend host is resource-constrained, stronger (MicroVM-grade) isolation is required, or sandbox compute must scale independently | **EE** |
 
@@ -48,7 +50,7 @@ Cube's design trade-offs (the price of being remote): every language goes throug
 | `sandbox_put_artifact(artifact_id, dest_path)` | Copy a platform artifact's bytes (user uploads, chart-tool outputs, …) into a sandbox path — uploads are never auto-visible in the sandbox |
 | `sandbox_get_artifact(src_path)` | Stream a sandbox file into a downloadable artifact; the default per-file limit is 100 MiB — bash outputs never auto-appear in the attachment area |
 
-The sandbox session identity is resolved by `resolve_sandbox_session(sandbox_session_id, chat_id)`: main chat / plan execution → `chat_id` (per-chat persistent kernel); batch items / sub-agents → `""` (ephemeral).
+The sandbox identity is resolved by `resolve_sandbox_session(sandbox_session_id, chat_id)`: a non-empty explicit ID wins, while a missing or empty value falls back to `chat_id`. The main agent, plan execution, batch items, and every subagent therefore use one conversation sandbox, and a child run never destroys it when it finishes.
 
 **MySpace write-back loop**: when a `bash` command succeeds and its string mentions `myspace`, `_sync_myspace_changes` lists files modified in the last 10 minutes under the sandbox's `/workspace/myspace/{uid}`, md5-diffs them against the backend mirror cache, routes each changed file through the user-confirmation gate (`MYSPACE_WRITE_CONFIRM`; non-interactive contexts are denied outright), then writes approved changes back to "My Space" **in place under the same file_id** — download/preview links stay valid. This closes the gap where the model edits a docx with python-docx in the sandbox while the user's copy never changes.
 

--- a/document/zh-CN/modules/sandbox.md
+++ b/document/zh-CN/modules/sandbox.md
@@ -1,10 +1,12 @@
 # 沙箱执行系统
 
-> 最后更新：2026-08-11
+> 最后更新：2026-08-31
 
 沙箱是 HugAgentOS 中智能体执行代码的隔离环境：模型在对话里调用 `bash` 跑命令、运行[技能](agent-skills.md)脚本、生成可下载产物，全部发生在沙箱里而非后端主进程。系统通过统一的 **Provider 协议**抽象出三种可切换的执行后端——从单机轻量的 script_runner 到带持久会话、快照恢复的 OpenSandbox，再到远端 MicroVM 集群的 Cube——上层工具代码对此完全无感。
 
 按[版本划分](../editions/overview.md)：**轻量沙箱（script_runner）+ 沙箱工具/offload 基础设施属社区版 CE**；**持久沙箱（opensandbox / cube，会话保持、环境复用、快照恢复）属商业版 EE**——社区版派生树剔除这两个 provider 文件，工厂自动回退轻量实现。
+
+沙箱遵循一个统一边界：**`session_id`（对话中即 `chat_id`）是唯一隔离键**。不同会话使用不同沙箱；同一会话的主智能体、内置子智能体、用户自建子智能体和批量项共享同一个 `/workspace`。智能体的模型上下文、工具权限和执行线程仍可独立，但不会再在会话内部创建第二个文件沙箱。
 
 ## Provider 协议（core/sandbox/protocol.py）
 
@@ -21,16 +23,16 @@
 | `health()` | 健康探测 |
 | `admin_*` 系列 | 安全管理台只读视图（能力声明 / 实例枚举 / 单实例详情 / 池统计），不支持的能力抛 `SandboxAdminNotSupported` 由 UI 置灰 |
 
-`ExecuteRequest` 的两个关键可选字段：
+`ExecuteRequest` 的两个关键字段：
 
-- **`session_id`**：持久型 provider 用它把多次 `execute` 绑定到同一个底层沙箱实例（= 跨调用保留变量、pip 包、/workspace 文件）；ephemeral provider 忽略；
+- **`session_id`**：所有 provider 都用它路由会话工作区；相同 ID 跨调用保留 `/workspace` 文件，不同 ID 互不可见。OpenSandbox / Cube 还会据此复用底层容器、MicroVM 或 kernel；
 - **`user_id`**：触发 myspace 文件可见性（bind-mount 或 seed），见下文 Plan F。
 
 ## 三个 Provider 实现
 
 | Provider | 文件 | 形态 | 适用场景 | 版本 |
 |---|---|---|---|---|
-| `script_runner` | `script_runner_provider.py` | 包装 `hugagent-script-runner` sidecar 容器的 HTTP 调用（容器内 setrlimit 子进程），无状态 | 单机部署、一次性代码执行，默认值 | CE |
+| `script_runner` | `script_runner_provider.py` | 单 sidecar + 按 `session_id` 分目录的持久文件工作区；每次命令仍由 setrlimit 子进程执行 | 单机部署、轻量代码执行，默认值 | CE |
 | `opensandbox` | `opensandbox_provider.py` + `_opensandbox_*.py` | 阿里 OpenSandbox（Docker 容器 + Jupyter 持久 kernel），per-chat 持久会话 + 预热池 + 快照 | 多轮迭代分析、技能重工作流 | **EE** |
 | `cube` | `cube_provider.py` | 腾讯 CubeSandbox（E2B 兼容 MicroVM），**远端节点**——后端通过 `e2b_code_interpreter` SDK 跨网访问，无本地 sidecar | 后端宿主机资源紧张 / 需要强隔离（MicroVM 级）/ 沙箱算力独立扩容的部署 | **EE** |
 
@@ -48,7 +50,7 @@ Cube 的设计取舍（远端节点版的代价）：所有语言统一走"写�
 | `sandbox_put_artifact(artifact_id, dest_path)` | 把平台 artifact（用户上传文件、图表工具产物等）的字节拷入沙箱路径——沙箱不会自动看到上传文件 |
 | `sandbox_get_artifact(src_path)` | 把沙箱内文件流式登记为可下载 artifact；默认单文件上限 100 MiB——bash 产物不会自动出现在附件区 |
 
-沙箱会话标识由 `resolve_sandbox_session(sandbox_session_id, chat_id)` 解析：主对话/计划执行 → `chat_id`（per-chat 持久 kernel）；批量项/子智能体 → `""`（ephemeral）。
+沙箱会话标识由 `resolve_sandbox_session(sandbox_session_id, chat_id)` 解析：非空显式 ID 优先，未传或传空值时统一回落到 `chat_id`。主智能体、计划执行、批量项和所有子智能体因此使用同一个会话沙箱；子智能体结束时不会销毁它。
 
 **MySpace 回写闭环**：`bash` 命令成功且命令串包含 `myspace` 时，`_sync_myspace_changes` 列出沙箱 `/workspace/myspace/{uid}` 下近 10 分钟修改的文件、与后端镜像缓存做 md5 比对，差异文件逐个过用户确认门（`MYSPACE_WRITE_CONFIRM`，非交互模式直接拒写）后以**同 file_id 就地回写**「我的空间」——下载/预览链接不变。这闭合了"模型用 python-docx 在沙箱改了 docx、用户空间却纹丝不动"的断链。
 

--- a/src/backend/api/routes/v1/chats.py
+++ b/src/backend/api/routes/v1/chats.py
@@ -60,6 +60,7 @@ router = APIRouter(prefix="/v1/chats", tags=["Sessions"])
 # the route handlers below stay unchanged.
 from core.chat.display_bounds import bound_result_for_display, bound_result_for_history
 from core.chat.tool_log import (  # noqa: E402
+    StepSequencer,
     build_thinking_event,
     build_tool_call_delta_event,
     build_tool_call_event,
@@ -1638,6 +1639,9 @@ async def _stream_sse_response(
         _thinking_log: List[Dict[str, Any]] = []
         # 本轮已开的思考块；跨轮（工具调用边界）置 None 强制另起一块。
         _round_block: Optional[Dict[str, Any]] = None
+        # 思考块与工具卡片分两列存，光靠 offset 排不出先后（两次可见正文之间发生的
+        # 一切共用同一个 offset）。统一发号，回放时按 (offset, step_seq) 归并。
+        _steps = StepSequencer()
 
         def _flush_thinking() -> None:
             nonlocal _round_block
@@ -1651,7 +1655,7 @@ async def _stream_sse_response(
             if _round_block is not None:
                 _round_block["content"] += block
                 return
-            _round_block = {"content": block, "offset": len(full_response)}
+            _round_block = _steps.new_thinking_block(block, len(full_response))
             _thinking_log.append(_round_block)
 
         def _thinking_payload() -> Optional[List[Dict[str, Any]]]:
@@ -1715,19 +1719,17 @@ async def _stream_sse_response(
                 _thinking_log.clear()
                 # 整体替换后，先前记录的 content_offset 指向旧草稿坐标系，
                 # 已无意义——清掉，让历史重建走「合并正文」兜底而不是错切。
-                for _tc in tool_calls_log:
-                    _tc.pop("content_offset", None)
+                StepSequencer.clear_tool_positions(tool_calls_log)
                 event = {**chunk, "chat_id": chat_id}
                 yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
             elif chunk_type == "tool_call":
                 _flush_thinking()
                 _round_block = None
                 _tc_evt = build_tool_call_event(chunk, chat_id, tool_calls_log)
-                # 记录该工具卡片出现时正文的累计长度（与持久化 content 同一坐标系，
-                # 思考块的 offset 也是这个坐标系）：历史重建按此偏移把「文本 ↔ 思考
-                # ↔ 工具卡片」按流式原顺序交错（问题15：刷新后内容与实时不一致）。
-                for _tc in tool_calls_log:
-                    _tc.setdefault("content_offset", len(full_response))
+                # 记录该工具卡片出现时正文的累计长度，外加统一发的先后号：历史重建
+                # 按 (offset, step_seq) 把「文本 ↔ 思考 ↔ 工具卡片」按流式原顺序交错
+                # （问题15：刷新后内容与实时不一致）。
+                _steps.stamp_tools(tool_calls_log, len(full_response))
                 yield f"data: {json.dumps(_tc_evt, ensure_ascii=False)}\n\n"
             elif chunk_type == "tool_call_start":
                 _flush_thinking()
@@ -1740,10 +1742,9 @@ async def _stream_sse_response(
             elif chunk_type == "tool_result":
                 _tr_evt = build_tool_result_event(chunk, chat_id, tool_calls_log)
                 # attach_tool_result 可能刚补录了一个没有 tool_call 事件的条目：
-                # 此刻就补记 offset，否则它要等下一个 tool_call 才拿到（晚一个
+                # 此刻就补记位置，否则它要等下一个 tool_call 才拿到（晚一个
                 # 叙述段），最后一个工具则永远缺失 → 整条消息退化成堆叠展示。
-                for _tc in tool_calls_log:
-                    _tc.setdefault("content_offset", len(full_response))
+                _steps.stamp_tools(tool_calls_log, len(full_response))
                 yield f"data: {json.dumps(_tr_evt, ensure_ascii=False)}\n\n"
             elif chunk_type == "heartbeat":
                 yield ": heartbeat\n\n"

--- a/src/backend/core/chat/tool_log.py
+++ b/src/backend/core/chat/tool_log.py
@@ -7,8 +7,55 @@ the chat route (``api/routes/v1/chats.py``) and the background run executor
 """
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 from core.chat.display_bounds import bound_result_for_display
+
+
+class StepSequencer:
+    """Stamp one monotonic emission order across thinking blocks and tool cards.
+
+    ``content_offset`` alone cannot order them. It counts visible characters, so
+    everything a turn emits between two pieces of visible text lands on the same
+    offset — a turn that reasons, calls five sub-agents, reasons again and runs
+    bash stores ten items at one offset. Thinking and tool cards are also
+    persisted in two separate columns, so replay could only guess: it rendered
+    every thinking block first and every tool card after, instead of
+    interleaving them the way they ran.
+
+    The stamp is per-stream and strictly increasing, so replay merges the two
+    columns by ``(offset, step_seq)`` and reproduces the live order exactly.
+    """
+
+    def __init__(self) -> None:
+        self._next = 0
+
+    def take(self) -> int:
+        value = self._next
+        self._next += 1
+        return value
+
+    def stamp_tools(self, tool_calls_log: List[Dict[str, Any]], content_offset: int) -> None:
+        """Give every not-yet-placed tool card its offset and its order."""
+        for tool_call in tool_calls_log:
+            if "content_offset" in tool_call:
+                continue
+            tool_call["content_offset"] = content_offset
+            tool_call["step_seq"] = self.take()
+
+    @staticmethod
+    def clear_tool_positions(tool_calls_log: List[Dict[str, Any]]) -> None:
+        """Drop stale positions after ``content_replace`` rewrites the draft."""
+        for tool_call in tool_calls_log:
+            tool_call.pop("content_offset", None)
+            tool_call.pop("step_seq", None)
+
+    def new_thinking_block(self, content: str, content_offset: int) -> Dict[str, Any]:
+        """Open one persisted thinking block at the current position."""
+        return {
+            "content": content,
+            "offset": content_offset,
+            "step_seq": self.take(),
+        }
 
 
 def build_thinking_event(chunk: dict, chat_id: str) -> Dict[str, Any]:

--- a/src/backend/core/llm/context_adapter.py
+++ b/src/backend/core/llm/context_adapter.py
@@ -734,11 +734,14 @@ def next_context_sequence(messages: Sequence[Any]) -> int:
 
 
 def next_request_sequence(messages: Sequence[Any]) -> int:
-    """Reserve a small pre-reply lane, then place the user instruction last.
+    """Reserve a pre-reply lane above the context tail for the user instruction.
 
     AgentScope runs ``on_reply`` middleware before it appends ``inputs`` to
     state. File/project attachment middleware can therefore add a few explicit
-    context items first without colliding with, or sorting after, the request.
+    context items first without colliding with the request's sequence. The
+    sequence no longer decides message order — the assembler emits items in
+    context order — it only keeps identifiers distinct and marks recency for
+    budget eviction.
     """
     pre_reply_slots = 64
     return next_context_sequence(messages) + pre_reply_slots * CONTEXT_SEQUENCE_STRIDE

--- a/src/backend/core/llm/context_ir.py
+++ b/src/backend/core/llm/context_ir.py
@@ -40,19 +40,7 @@ POLICY_TAIL = "tail"
 VISIBILITY_MODEL = "model"
 VISIBILITY_MANIFEST_ONLY = "manifest_only"
 
-_SYSTEM_KINDS = {KIND_SYSTEM_RULE, KIND_PROJECT, KIND_REFERENCE}
 _TOOL_KINDS = {KIND_TOOL_CALL, KIND_TOOL_RESULT}
-_TRUST_RANK = {
-    "platform": 0,
-    "admin": 1,
-    "system": 2,
-    "memory": 3,
-    "tool": 4,
-    "assistant": 5,
-    "user": 6,
-    "external": 7,
-    "untrusted": 8,
-}
 
 
 class ContextAdapterProtocol(Protocol):
@@ -412,21 +400,18 @@ class ContextAssembly:
         return manifest
 
 
-def _canonical_key(item: ContextItem) -> tuple[Any, ...]:
-    phase = 0 if item.kind in _SYSTEM_KINDS else 1
-    if item.kind in {KIND_REMINDER, KIND_STEER}:
-        phase = 2
-    return (
-        phase,
-        item.created_seq,
-        _TRUST_RANK.get(item.trust, 99),
-        -item.priority,
-        item.item_id,
-    )
-
-
 class ContextAssembler:
-    """Canonical ordering, explicit truncation and explainable selection."""
+    """Explicit truncation and explainable selection, in context order.
+
+    Ordering is **not** the assembler's job: items arrive in the order the agent
+    context already holds them, and they leave in that same order. Deciding the
+    conversation's shape here used to reorder it — the live user instruction
+    carries a sequence 64 strides above the context tail (see
+    ``next_request_sequence``), so sorting by sequence moved it behind every tool
+    call and tool result of the turn it had just started. The model then read its
+    own finished work first and the user's request last, took that for a fresh
+    ask, and ran the whole turn again.
+    """
 
     def __init__(
         self,
@@ -519,7 +504,8 @@ class ContextAssembler:
         )
         if duplicates:
             raise ValueError(f"context item_id values must be unique: {duplicates}")
-        original_items = sorted(raw_items, key=_canonical_key)
+        original_items = list(raw_items)
+        arrival = {item.item_id: index for index, item in enumerate(original_items)}
         records: dict[str, dict[str, Any]] = {}
         capped: list[ContextItem] = []
         excluded: list[ContextItem] = []
@@ -558,7 +544,9 @@ class ContextAssembler:
             unit for unit in units if any(self._mandatory(item) for item in unit)
         ]
         optional = [unit for unit in units if unit not in mandatory]
-        mandatory.sort(key=lambda unit: _canonical_key(min(unit, key=_canonical_key)))
+        mandatory.sort(key=lambda unit: min(arrival[item.item_id] for item in unit))
+        # Selection order only: which optional units get the remaining budget.
+        # It never reaches the output, which is re-sorted into context order.
         optional.sort(key=self._unit_key)
 
         included: list[ContextItem] = []
@@ -632,9 +620,9 @@ class ContextAssembler:
             )
             excluded.append(item)
 
-        included.sort(key=_canonical_key)
+        included.sort(key=lambda item: arrival[item.item_id])
         excluded_by_id = {item.item_id: item for item in excluded}
-        excluded = sorted(excluded_by_id.values(), key=_canonical_key)
+        excluded = sorted(excluded_by_id.values(), key=lambda item: arrival[item.item_id])
 
         included_manifest = []
         excluded_manifest = []

--- a/src/backend/core/llm/manifest_agent.py
+++ b/src/backend/core/llm/manifest_agent.py
@@ -134,7 +134,16 @@ class ManifestBoundAgent(Agent):
             getattr(self, "_jx_execution_manifest", None),
         )
         if base_manifest is not None:
-            items.extend(adapter.reference_items_from_execution_manifest(base_manifest))
+            # Prompt-side material (live project content) belongs to the prefix,
+            # behind the system prompt and ahead of the conversation. The
+            # assembler emits items in the order it receives them, so place them
+            # here instead of appending and relying on a sort to hoist them back.
+            references = adapter.reference_items_from_execution_manifest(base_manifest)
+            if references:
+                head = 0
+                while head < len(items) and items[head].render_role == "system":
+                    head += 1
+                items[head:head] = references
 
         context_size = int(getattr(self.model, "context_size", 0) or 0)
         # Leave a deterministic 15% response reserve and separately account

--- a/src/backend/core/llm/subagent_tool.py
+++ b/src/backend/core/llm/subagent_tool.py
@@ -25,6 +25,7 @@ from core.llm.context_ir import (
     POLICY_NEVER,
     make_text_context_item,
 )
+from core.llm.tools._common import resolve_sandbox_session
 from core.services import log_service as log_writer
 
 logger = logging.getLogger(__name__)
@@ -270,20 +271,15 @@ def _run_subagent_in_thread(
                     user_agent.timeout,
                 )
 
-        # Platform built-ins share the main project's sandbox so they see the same live
-        # workspace. User-defined agents retain the existing independent, user-bound
-        # persistent sandbox: a unique session keeps concurrent custom agents isolated and
-        # is explicitly destroyed after the run. Conversation inheritance is an orthogonal
-        # policy controlled by shared_messages below.
+        # A conversation is the only sandbox boundary. Every built-in and user-defined
+        # child agent inherits the parent's sandbox session and therefore sees the same
+        # live workspace. Conversation/context inheritance remains an orthogonal policy
+        # controlled by shared_messages below.
         runtime = parent_runtime or {}
-        if builtin_spec is not None:
-            # Explorer/reviewer inspect the live workspace read-only; worker can continue
-            # the bounded implementation task there.
-            sub_session_id = runtime.get("sandbox_session_id") or runtime.get("chat_id")
-            should_close_sandbox = False
-        else:
-            sub_session_id = f"sub-{agent_id}-{uuid.uuid4().hex[:12]}"
-            should_close_sandbox = True
+        sub_session_id = resolve_sandbox_session(
+            runtime.get("sandbox_session_id"),
+            runtime.get("chat_id"),
+        )
         agent, mcp_clients = await create_agent_executor(
             user_agent=user_agent,
             current_user_id=current_user_id,
@@ -374,18 +370,8 @@ def _run_subagent_in_thread(
             response_text = (final_msg.get_text_content() if final_msg else "") or ""
             return True, strip_thinking(response_text), _ws.get_pinned()
         finally:
-            # Destroy only a custom agent's dedicated sandbox session. Platform built-ins
-            # share the parent session and therefore must never close it here.
-            # close_session is a SandboxProvider protocol method; each provider decides its
-            # own semantics (opensandbox/cube destroy; script_runner no-op), so no getattr
-            # fallback is needed.
-            if should_close_sandbox:
-                try:
-                    from core.sandbox import get_sandbox_provider
-
-                    await get_sandbox_provider().close_session(sub_session_id)
-                except BaseException as exc:
-                    logger.debug("subagent close_session error (ignored): %s", exc)
+            # Child agents share the parent conversation sandbox. Its lifecycle is owned
+            # by the conversation/session manager, never by an individual child run.
             try:
                 await close_clients(mcp_clients)
             except BaseException as exc:

--- a/src/backend/core/llm/tools/_common.py
+++ b/src/backend/core/llm/tools/_common.py
@@ -39,9 +39,13 @@ def resolve_sandbox_session(
     sandbox_session_id: Optional[str],
     chat_id: Optional[str],
 ) -> Optional[str]:
-    """``sandbox_session_id`` wins; ``None`` means 'unspecified' → fall back to
-    ``chat_id`` (legacy behavior). Explicit ``""`` stays ephemeral."""
-    return chat_id if sandbox_session_id is None else sandbox_session_id
+    """Resolve the one sandbox identity for the current conversation.
+
+    A non-empty explicit override wins. Missing or empty overrides fall back to
+    ``chat_id`` so callers cannot accidentally create a second sandbox inside
+    the same conversation.
+    """
+    return sandbox_session_id or chat_id
 
 
 async def myspace_write_guard(

--- a/src/backend/core/llm/tools/sandbox_tool.py
+++ b/src/backend/core/llm/tools/sandbox_tool.py
@@ -203,8 +203,8 @@ def register_bash(
 
     The sandbox session is bound to ``chat_id`` so OpenSandbox keeps a single
     persistent container per conversation (variables, pip packages, /workspace
-    files all persist between bash calls). script_runner provider ignores
-    ``session_id`` since its sidecar's /workspace is globally durable.
+    files all persist between bash calls). script_runner uses the same identity
+    to select a session-scoped workspace inside its sidecar.
     """
     if os.getenv("SANDBOX_TOOLS_ENABLED", "true").lower() != "true":
         return

--- a/src/backend/core/sandbox/protocol.py
+++ b/src/backend/core/sandbox/protocol.py
@@ -31,18 +31,15 @@ class ExecuteRequest:
     arguments appended after the interpreter invocation; the remaining keys
     are serialized as JSON and written to stdin.
 
-    ``user_id``: optional. When the opensandbox provider detects this field,
-    it automatically seeds every file under
+    ``user_id``: optional. Providers use it to expose the caller's files under
     ``STORAGE_PATH/myspace_cache/{user_id}/`` into the sandbox at
     ``/workspace/myspace/{user_id}/``, so that files staged via
-    ``stage_files`` are visible in subsequent execute calls. The
-    script_runner provider ignores this field.
+    ``stage_files`` are visible in subsequent execute calls.
 
-    ``session_id``: optional. Persistent-sandbox providers (e.g.
-    opensandbox) use this field to bind multiple ``execute`` calls to the
-    same underlying sandbox instance, so that Jupyter kernel state
-    (variables, imports, pip-installed packages) is reused across rounds.
-    Ephemeral providers ignore this field.
+    ``session_id``: the conversation-level sandbox identity. Every provider
+    uses it as the sole isolation boundary: main agents, child agents and
+    batch work in the same session workspace; different sessions do not.
+    Container providers additionally reuse their language/kernel state.
 
     ``expected_output_files``: optional. The caller declares in advance the
     list of output file names it expects to retrieve from the sandbox (file
@@ -171,10 +168,9 @@ class SandboxProvider(Protocol):
         """Write bytes to the given path in the sandbox (parent directories
         are created automatically if needed).
 
-        ``session_id``: persistent-session providers use this to bind to the
-        corresponding sandbox; ephemeral providers may ignore it (but must
-        guarantee that subsequent execute calls can see the written file —
-        e.g. script_runner satisfies this via the shared work_dir).
+        ``session_id``: binds the operation to the corresponding conversation
+        workspace; every provider must preserve visibility for later calls
+        carrying the same id and isolate calls carrying a different id.
         ``user_id``: if this call would create a **new** session, used to
         bind the sandbox to that user (mounting their myspace/credential
         volumes). Omitting it lets a file operation that precedes execute
@@ -229,9 +225,8 @@ class SandboxProvider(Protocol):
           ``sess.sandbox.id``; after the session is destroyed by
           ``_destroy_session`` and a new sandbox is created, the id is
           guaranteed to change.
-        - script_runner-like sidecars: ``/workspace`` is globally persistent
-          for the container's lifetime and there is no "per-session sandbox"
-          concept — return a constant (e.g. the provider name).
+        - script_runner-like sidecars: return a stable identity derived from
+          the logical session workspace.
         - If ``session_id`` is not bound to any sandbox (not yet created),
           return None; callers should treat this as "sandbox identity not
           yet determined" and query again after a real operation has created
@@ -244,13 +239,9 @@ class SandboxProvider(Protocol):
 
     async def close_session(self, session_id: Optional[str]) -> None:
         """Explicitly destroy a persistent-session sandbox (for
-        "run-and-discard" callers, e.g. a sub-agent that creates a unique
-        session per invocation and reclaims it on finish, avoiding sandbox
-        leaks).
+        conversation lifecycle cleanup or an explicit rebuild).
 
-        Providers with no session lifecycle concept (script_runner shared
-        sidecar) implement this as a no-op; an unknown session_id is also a
-        no-op. Never raises.
+        An unknown session_id is a no-op. Never raises.
         """
         ...
 

--- a/src/backend/core/sandbox/script_runner_provider.py
+++ b/src/backend/core/sandbox/script_runner_provider.py
@@ -71,6 +71,8 @@ class ScriptRunnerProvider:
             "resource_files": req.resource_files,
             "input_files": req.input_files,
             "input_files_b64": req.input_files_b64,
+            "session_id": req.session_id,
+            "user_id": req.user_id,
         }
 
         last_exc: Exception | None = None
@@ -129,14 +131,10 @@ class ScriptRunnerProvider:
         content: bytes,
         user_id: Optional[str] = None,
     ) -> None:
-        """Write bytes into the sandbox via the sidecar's /put_file.
-
-        ``session_id`` / ``user_id`` are ignored under the script_runner provider — the
-        sidecar's ``/workspace`` is globally shared for the container's lifetime, with no
-        notion of a "session"/user binding.
-        """
-        del session_id, user_id
+        """Write bytes into this conversation's sidecar workspace."""
         body = {
+            "session_id": session_id,
+            "user_id": user_id,
             "path": path,
             "content_b64": base64.b64encode(content).decode("ascii"),
         }
@@ -156,11 +154,13 @@ class ScriptRunnerProvider:
         path: str,
         user_id: Optional[str] = None,
     ) -> bytes:
-        """Read sandbox file bytes via the sidecar's /get_file. ``session_id`` / ``user_id`` ignored."""
-        del session_id, user_id
+        """Read bytes from this conversation's sidecar workspace."""
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                resp = await client.post(f"{self._base_url}/get_file", json={"path": path})
+                resp = await client.post(
+                    f"{self._base_url}/get_file",
+                    json={"session_id": session_id, "user_id": user_id, "path": path},
+                )
                 resp.raise_for_status()
                 payload = resp.json()
         except httpx.ConnectError as e:
@@ -183,7 +183,6 @@ class ScriptRunnerProvider:
         user_id: Optional[str] = None,
     ) -> int:
         """Stream a sandbox file from the sidecar into a local path."""
-        del session_id, user_id
         timeout = httpx.Timeout(
             float(settings.sandbox.max_timeout),
             connect=10.0,
@@ -194,7 +193,7 @@ class ScriptRunnerProvider:
                 async with client.stream(
                     "POST",
                     f"{self._base_url}/get_file_raw",
-                    json={"path": path},
+                    json={"session_id": session_id, "user_id": user_id, "path": path},
                 ) as resp:
                     if resp.status_code >= 400:
                         body = (await resp.aread()).decode("utf-8", errors="replace")
@@ -235,23 +234,37 @@ class ScriptRunnerProvider:
             raise SandboxError(f"get_file {path} 流式读取失败: {exc}") from exc
 
     async def close_session(self, session_id: Optional[str]) -> None:
-        """No-op: the sidecar's ``/workspace`` is globally shared; there is no per-session sandbox to destroy."""
-        del session_id
+        """Delete one conversation workspace without affecting other sessions."""
+        if not session_id:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    f"{self._base_url}/sessions/close",
+                    json={"session_id": session_id},
+                )
+                resp.raise_for_status()
+        except Exception as exc:  # protocol requires lifecycle cleanup to never raise
+            logger.warning("[script_runner] close_session failed sid=%s: %s", session_id, exc)
 
     async def touch_session(self, session_id: str) -> bool:
-        """No-op: no per-session lifecycle, nothing to keep alive."""
-        del session_id
-        return False
+        """Touch an existing conversation workspace."""
+        if not session_id:
+            return False
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    f"{self._base_url}/sessions/touch",
+                    json={"session_id": session_id},
+                )
+                resp.raise_for_status()
+                return bool(resp.json().get("touched"))
+        except Exception:
+            return False
 
     async def current_sandbox_id(self, session_id: Optional[str]) -> Optional[str]:
-        """The script_runner sidecar's ``/workspace`` is global to the container
-        and persists for the container's lifetime. There is no "per-session
-        sandbox" to invalidate, so we return a constant — callers tracking
-        sandbox identity will treat the value as stable and skill files
-        materialized once never need to be re-pushed.
-        """
-        del session_id
-        return "script_runner"
+        """Return the stable logical identity of one session workspace."""
+        return f"script_runner:{session_id}" if session_id else None
 
     async def health(self) -> bool:
         try:
@@ -262,15 +275,14 @@ class ScriptRunnerProvider:
             return False
 
     # ── Read-only admin interface ─────────────────────────────────────────────────────
-    # The sidecar is a single-container global /workspace with no notion of an "instance" —
-    # it only exposes a capability declaration; everything else raises
-    # SandboxAdminNotSupported, which the security admin backend downgrades to a single "shared sidecar" card.
+    # The sidecar is one container with session-scoped workspaces. It does not expose
+    # administrative enumeration, so the security UI still shows one sidecar card.
 
     def admin_capabilities(self) -> SandboxAdminCapabilities:
         return SandboxAdminCapabilities(provider=self.name)
 
     async def admin_list_sandboxes(self, include_server: bool = False) -> list[SandboxInfo]:
-        raise SandboxAdminNotSupported("script_runner 是共享 sidecar，无可枚举实例")
+        raise SandboxAdminNotSupported("script_runner 未开放会话工作区枚举")
 
     async def admin_get_sandbox(self, sandbox_id: str) -> Optional[SandboxInfo]:
         raise SandboxAdminNotSupported("script_runner 不支持实例详情")

--- a/src/backend/core/services/skill_deps_prober.py
+++ b/src/backend/core/services/skill_deps_prober.py
@@ -139,6 +139,7 @@ async def probe_still_missing(
                 script_name="skill_dep_probe.py",
                 language="python",
                 timeout=timeout,
+                session_id="system:skill-dependency-probe",
             )
         )
     except Exception as exc:  # noqa: BLE001 - a probe failure is always uncertain

--- a/src/backend/orchestration/batch_orchestrator.py
+++ b/src/backend/orchestration/batch_orchestrator.py
@@ -447,10 +447,8 @@ async def _run_item_via_workflow(
         isolated=True,
         max_iters=50,
         visible_subagents=sub_visible_agents if sub_visible_agents else None,
-        # Batch items run concurrently: force an ephemeral sandbox — each item gets its own
-        # temporary container, reclaimed on finish — so multiple items don't fight over the
-        # same persistent kernel state and cross-contaminate (docs §4.1).
-        sandbox_session_id="",
+        # The conversation is the only sandbox boundary. Batch items keep their own model,
+        # MCP and workspace-UI state, but share this chat's live sandbox filesystem.
         ontology_runtime=ontology_runtime,
     )
     # 证据锚点：发号器绑到 agent，中间件与本函数共享同一计数器

--- a/src/backend/orchestration/chat_run_executor.py
+++ b/src/backend/orchestration/chat_run_executor.py
@@ -828,6 +828,7 @@ async def _run_workflow(
     """
     from core.chat.context import now_iso, resolve_user_facing_error
     from core.chat.tool_log import (
+        StepSequencer,
         attach_subagent_step,
         build_thinking_event,
         build_tool_call_delta_event,
@@ -955,6 +956,9 @@ async def _run_workflow(
     # 每个思考块记录它出现时的正文偏移，历史重建按此原位还原。
     _thinking_parts: List[str] = []
     _thinking_log: List[Dict[str, Any]] = []
+    # 思考块与工具卡片分两列存，光靠 offset 排不出先后（两次可见正文之间发生的
+    # 一切共用同一个 offset）。统一发号，回放时按 (offset, step_seq) 归并。
+    _steps = StepSequencer()
     # 本轮已开的思考块；跨轮（工具调用边界）置 None 强制另起一块。不设边界的话，
     # 正文一旦出现，后面每一轮的思考都会并进同一块里无限膨胀。
     _round_block: Optional[Dict[str, Any]] = None
@@ -973,7 +977,7 @@ async def _run_workflow(
         if _round_block is not None:
             _round_block["content"] += block
             return
-        _round_block = {"content": block, "offset": len(full_response)}
+        _round_block = _steps.new_thinking_block(block, len(full_response))
         _thinking_log.append(_round_block)
 
     def _thinking_payload() -> Optional[List[Dict[str, Any]]]:
@@ -1178,8 +1182,7 @@ async def _run_workflow(
                 _thinking_log.clear()
                 # 整体替换后，先前记录的 content_offset 指向旧草稿坐标系，
                 # 已无意义——清掉，让历史重建走「合并正文」兜底而不是错切。
-                for _tc in tool_calls_log:
-                    _tc.pop("content_offset", None)
+                StepSequencer.clear_tool_positions(tool_calls_log)
                 await _emit(
                     {
                         "type": "content_replace",
@@ -1366,11 +1369,10 @@ async def _run_workflow(
                 _flush_thinking()
                 _round_block = None
                 _tc_evt = build_tool_call_event(chunk, chat_id, tool_calls_log)
-                # 记录该工具卡片出现时正文的累计长度（与持久化 content 同一坐标系，
-                # 思考块的 offset 也是这个坐标系）：历史重建按此偏移把「文本 ↔ 思考
-                # ↔ 工具卡片」按流式原顺序交错（问题15：刷新后内容与实时不一致）。
-                for _tc in tool_calls_log:
-                    _tc.setdefault("content_offset", len(full_response))
+                # 记录该工具卡片出现时正文的累计长度，外加统一发的先后号：历史重建
+                # 按 (offset, step_seq) 把「文本 ↔ 思考 ↔ 工具卡片」按流式原顺序交错
+                # （问题15：刷新后内容与实时不一致）。
+                _steps.stamp_tools(tool_calls_log, len(full_response))
                 await _emit(_tc_evt)
 
             elif chunk_type == "tool_call_start":
@@ -1384,10 +1386,9 @@ async def _run_workflow(
             elif chunk_type == "tool_result":
                 _tr_evt = build_tool_result_event(chunk, chat_id, tool_calls_log)
                 # attach_tool_result 可能刚补录了一个没有 tool_call 事件的条目：
-                # 此刻就补记 offset，否则它要等下一个 tool_call 才拿到（晚一个
+                # 此刻就补记位置，否则它要等下一个 tool_call 才拿到（晚一个
                 # 叙述段），最后一个工具则永远缺失 → 整条消息退化成堆叠展示。
-                for _tc in tool_calls_log:
-                    _tc.setdefault("content_offset", len(full_response))
+                _steps.stamp_tools(tool_calls_log, len(full_response))
                 await _emit(_tr_evt)
 
             elif chunk_type == "context_usage":

--- a/src/backend/services/script_runner_service/server.py
+++ b/src/backend/services/script_runner_service/server.py
@@ -8,6 +8,7 @@ database/Redis/API-key access.
 
 import asyncio
 import base64
+import hashlib
 import json
 import logging
 import mimetypes
@@ -45,8 +46,10 @@ MAX_MEMORY_MB = int(os.getenv("SCRIPT_MAX_MEMORY_MB", "256"))
 # ``/workspace`` (a mounted tmpfs). In the no-Docker local profile the runner is
 # a plain host subprocess, so the CLI points it at a real host dir such as
 # ``~/.hugagent/workspace`` via ``SCRIPT_RUNNER_WORKSPACE``. Everything under here
-# is created on first use; ``_validate_workspace_path`` confines writes to it.
+# is created on first use; ``.sessions/<hash>`` is the per-conversation boundary
+# and ``_validate_workspace_path`` confines file API access to that directory.
 WORKSPACE_ROOT = os.getenv("SCRIPT_RUNNER_WORKSPACE", "/workspace")
+SESSION_WORKSPACES_DIR = ".sessions"
 MAX_OUTPUT_BYTES = 1024 * 1024  # 1MB
 MAX_SCRIPT_SIZE = 512 * 1024  # 512KB
 MAX_ARTIFACT_EXPORT_BYTES = max(
@@ -158,14 +161,68 @@ def _execution_workspace_root(
     return f"/{drive.lower()}/{rest.replace(chr(92), '/')}"
 
 
-def _rewrite_execution_paths(value: str, language: str) -> str:
-    target_root = _execution_workspace_root(language)
-    if target_root != WORKSPACE_ROOT:
+def _rewrite_execution_paths(
+    value: str,
+    language: str,
+    workspace_root: str = WORKSPACE_ROOT,
+) -> str:
+    if WORKSPACE_ROOT != "/workspace" and workspace_root != WORKSPACE_ROOT:
+        # Native file tools may return the host-expanded root. Normalize it back
+        # to the canonical spelling before routing it into the session workspace.
+        value = value.replace(WORKSPACE_ROOT.rstrip("/\\"), "/workspace")
+    target_root = _execution_workspace_root(language, workspace_root)
+    if target_root != workspace_root:
         # File tools may already have expanded /workspace to the native root.
-        value = value.replace(WORKSPACE_ROOT, target_root)
+        value = value.replace(workspace_root, target_root)
     if language == "bash":
         return _rewrite_bash_workspace_refs(value, target_root)
     return _rewrite_workspace_refs(value, target_root)
+
+
+def _validate_session_id(session_id: str) -> str:
+    """Validate a logical conversation id before deriving its opaque path key."""
+    value = (session_id or "").strip()
+    if not value:
+        raise HTTPException(400, "session_id 不能为空")
+    if len(value) > 512:
+        raise HTTPException(400, "session_id 过长")
+    return value
+
+
+def _ensure_shared_dir_link(link: Path, target: Path) -> None:
+    """Expose a shared read-mostly directory inside one session workspace.
+
+    Linux/Docker uses a symlink, preserving the existing live skills/MySpace view.
+    Windows local mode may not permit symlink creation, so it degrades to a copy.
+    """
+    if link.exists() or link.is_symlink() or not target.exists():
+        return
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(target.resolve(), target_is_directory=True)
+    except OSError:
+        shutil.copytree(target, link, dirs_exist_ok=True)
+
+
+def _session_workspace(
+    session_id: str,
+    *,
+    create: bool = False,
+    user_id: Optional[str] = None,
+) -> Path:
+    """Return the durable filesystem root owned by one conversation session."""
+    value = _validate_session_id(session_id)
+    key = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    workspace = Path(WORKSPACE_ROOT) / SESSION_WORKSPACES_DIR / key
+    if create:
+        workspace.mkdir(parents=True, exist_ok=True)
+        _ensure_shared_dir_link(workspace / "skills", Path(WORKSPACE_ROOT) / "skills")
+        if user_id:
+            _validate_user_id(user_id)
+            shared_myspace = Path(WORKSPACE_ROOT) / "myspace" / user_id
+            shared_myspace.mkdir(parents=True, exist_ok=True)
+            _ensure_shared_dir_link(workspace / "myspace" / user_id, shared_myspace)
+    return workspace
 
 
 def _resolve_bash_executable() -> Optional[str]:
@@ -351,6 +408,8 @@ class ExecuteRequest(BaseModel):
     resource_files: Optional[Dict[str, str]] = None
     input_files: Optional[Dict[str, str]] = None
     input_files_b64: Optional[Dict[str, str]] = None
+    session_id: str
+    user_id: Optional[str] = None
 
 
 class FileOutput(BaseModel):
@@ -411,7 +470,7 @@ async def stage_files(req: StageRequest):
             raise HTTPException(400, f"文件 {f.name} 的 base64 内容无效")
         dest = base_dir / f.name
         dest.write_bytes(content)
-        staged.append({"name": f.name, "path": str(dest)})
+        staged.append({"name": f.name, "path": f"/workspace/myspace/{req.user_id}/{f.name}"})
 
     return StageResponse(staged=staged)
 
@@ -422,11 +481,15 @@ async def health():
 
 
 class PutFileRequest(BaseModel):
+    session_id: str
+    user_id: Optional[str] = None
     path: str
     content_b64: str
 
 
 class GetFileRequest(BaseModel):
+    session_id: str
+    user_id: Optional[str] = None
     path: str
 
 
@@ -435,33 +498,47 @@ class GetFileResponse(BaseModel):
     size: int
 
 
-def _canon_ws(path: str) -> str:
-    """Alias a container-canonical ``/workspace[/...]`` path to the real root.
-
-    No-op in Docker (root == /workspace); in the no-Docker local profile the model
-    and plugin backends pass /workspace paths that must map to SCRIPT_RUNNER_WORKSPACE.
+def _canon_ws(path: str, session_id: str, user_id: Optional[str] = None) -> str:
+    """Alias canonical ``/workspace[/...]`` to one session's physical root.
 
     Mirror of ``core.llm.tools._paths.canonicalize_ws_path`` — this sidecar imports
     nothing from ``core`` (it ships as a standalone image), so the logic is copied;
     keep the two in sync.
     """
-    if not isinstance(path, str) or WORKSPACE_ROOT == "/workspace":
+    if not isinstance(path, str):
         return path
+    workspace = str(_session_workspace(session_id, create=True, user_id=user_id))
     if path == "/workspace":
-        return WORKSPACE_ROOT
+        return workspace
     if path.startswith("/workspace/"):
-        return WORKSPACE_ROOT.rstrip("/") + path[len("/workspace") :]
+        return workspace.rstrip("/\\") + path[len("/workspace") :]
+    physical_root = WORKSPACE_ROOT.rstrip("/\\")
+    if path == physical_root:
+        return workspace
+    if path.startswith(physical_root + "/") or path.startswith(physical_root + "\\"):
+        return workspace.rstrip("/\\") + path[len(physical_root) :]
     return path
 
 
-def _validate_workspace_path(path: str) -> Path:
-    """Ensure the path is inside the workspace root and reject path traversal."""
-    p = Path(_canon_ws(path)).resolve()
-    workspace = Path(WORKSPACE_ROOT).resolve()
-    try:
-        p.relative_to(workspace)
-    except ValueError:
-        raise HTTPException(400, f"路径必须在 {WORKSPACE_ROOT} 下: {path}")
+def _validate_workspace_path(
+    path: str,
+    session_id: str,
+    user_id: Optional[str] = None,
+) -> Path:
+    """Confine file APIs to this session plus its explicitly bound MySpace."""
+    workspace = _session_workspace(session_id, create=True, user_id=user_id).resolve()
+    p = Path(_canon_ws(path, session_id, user_id)).resolve()
+    allowed_roots = [workspace]
+    if user_id:
+        allowed_roots.append((Path(WORKSPACE_ROOT) / "myspace" / user_id).resolve())
+    for allowed in allowed_roots:
+        try:
+            p.relative_to(allowed)
+            break
+        except ValueError:
+            continue
+    else:
+        raise HTTPException(400, f"路径必须在当前会话 /workspace 下: {path}")
     return p
 
 
@@ -473,7 +550,7 @@ async def put_file(req: PutFileRequest):
     **not** cleaned up when execute finishes, which suits multi-step flows like
     sandbox_put_artifact ("stage first, then call bash").
     """
-    p = _validate_workspace_path(req.path)
+    p = _validate_workspace_path(req.path, req.session_id, req.user_id)
     p.parent.mkdir(parents=True, exist_ok=True)
     try:
         content = base64.b64decode(req.content_b64)
@@ -494,7 +571,7 @@ MAX_FETCH_FILE_SIZE = 64 * 1024 * 1024
 @app.post("/get_file", response_model=GetFileResponse)
 async def get_file(req: GetFileRequest):
     """Read a file from the sandbox and return it base64-encoded."""
-    p = _validate_workspace_path(req.path)
+    p = _validate_workspace_path(req.path, req.session_id, req.user_id)
     if not p.is_file():
         raise HTTPException(404, f"文件不存在: {req.path}")
     data = p.read_bytes()
@@ -509,7 +586,7 @@ async def get_file(req: GetFileRequest):
 @app.post("/get_file_raw", response_class=FileResponse)
 async def get_file_raw(req: GetFileRequest) -> FileResponse:
     """Stream a sandbox file without Base64 expansion."""
-    p = _validate_workspace_path(req.path)
+    p = _validate_workspace_path(req.path, req.session_id, req.user_id)
     if not p.is_file():
         raise HTTPException(404, f"文件不存在: {req.path}")
     size = p.stat().st_size
@@ -566,19 +643,29 @@ async def execute(req: ExecuteRequest):
         raise HTTPException(400, f"脚本过大: {len(req.script_content)} > {MAX_SCRIPT_SIZE}")
     timeout = min(req.timeout, MAX_TIMEOUT)
 
-    # Local profile: the model writes container-canonical /workspace/... paths (from
-    # the system prompt, skills, and plugin scripts). Alias them to the real root so
-    # bash/python that touch /workspace resolve.  A callable replacement is
-    # essential on Windows because ``C:\\Users`` contains regex escape syntax.
-    if WORKSPACE_ROOT != "/workspace":
-        req.script_content = _rewrite_execution_paths(req.script_content, req.language)
-        if isinstance(req.params, dict) and req.params:
-            _args = req.params.get("_args")
-            if isinstance(_args, list):
-                req.params["_args"] = [
-                    _rewrite_execution_paths(a, req.language) if isinstance(a, str) else a
-                    for a in _args
-                ]
+    # The model always sees /workspace. Map that canonical path to the one durable
+    # directory owned by this conversation, in Docker and local profiles alike.
+    session_workspace = _session_workspace(
+        req.session_id,
+        create=True,
+        user_id=req.user_id,
+    )
+    req.script_content = _rewrite_execution_paths(
+        req.script_content,
+        req.language,
+        str(session_workspace),
+    )
+    if isinstance(req.params, dict) and req.params:
+        _args = req.params.get("_args")
+        if isinstance(_args, list):
+            req.params["_args"] = [
+                (
+                    _rewrite_execution_paths(a, req.language, str(session_workspace))
+                    if isinstance(a, str)
+                    else a
+                )
+                for a in _args
+            ]
 
     # ── Filename safety validation (prevent path traversal) ──
     _validate_filename(req.script_name)
@@ -587,13 +674,12 @@ async def execute(req: ExecuteRequest):
             _validate_filename(fname)
 
     # ── Prepare temporary working directory ──
-    Path(WORKSPACE_ROOT).mkdir(parents=True, exist_ok=True)
-    work_dir = Path(tempfile.mkdtemp(prefix="skill_", dir=WORKSPACE_ROOT))
+    work_dir = Path(tempfile.mkdtemp(prefix="skill_", dir=session_workspace))
     seeded_files: set[str] = set()
     # Snapshot existing files in the workspace root before execution
     _pre_existing_root_files: set = set()
     try:
-        for _f in Path(WORKSPACE_ROOT).iterdir():
+        for _f in session_workspace.iterdir():
             if _f.is_file():
                 _pre_existing_root_files.add(_f.name)
     except Exception:
@@ -638,7 +724,7 @@ async def execute(req: ExecuteRequest):
         total_size = 0
         seen_names: set = set()
         # Track files already present in the workspace root before execution, to avoid collecting them by mistake
-        workspace_root = Path(WORKSPACE_ROOT)
+        workspace_root = session_workspace
 
         def _collect_file(fpath: Path) -> bool:
             """Try to collect a file. Returns True if collected."""
@@ -701,10 +787,32 @@ async def execute(req: ExecuteRequest):
 
     finally:
         shutil.rmtree(work_dir, ignore_errors=True)
-        # Note: do NOT wipe /workspace root here. Files in /workspace are
-        # intentionally durable between calls: sandbox_put_artifact stages
-        # inputs and bash-emitted outputs are read back by sandbox_get_artifact.
-        # The sidecar container's lifecycle is the cleanup boundary.
+        # Do not wipe the session root here. Files remain durable for every main/
+        # child-agent call in the same conversation; close_session is the boundary.
+
+
+class SessionRequest(BaseModel):
+    session_id: str
+
+
+@app.post("/sessions/close")
+async def close_session(req: SessionRequest):
+    """Delete exactly one conversation workspace."""
+    workspace = _session_workspace(req.session_id)
+    existed = workspace.exists()
+    if existed:
+        shutil.rmtree(workspace, ignore_errors=True)
+    return {"closed": existed}
+
+
+@app.post("/sessions/touch")
+async def touch_session(req: SessionRequest):
+    """Refresh one existing conversation workspace's activity timestamp."""
+    workspace = _session_workspace(req.session_id)
+    if not workspace.is_dir():
+        return {"touched": False}
+    os.utime(workspace, None)
+    return {"touched": True}
 
 
 async def _execute_subprocess(cmd: list, stdin_data: str, timeout: int, cwd: str) -> Dict[str, Any]:

--- a/src/backend/tests/llm/test_context_adapter.py
+++ b/src/backend/tests/llm/test_context_adapter.py
@@ -119,7 +119,7 @@ def test_tool_blocks_roundtrip_and_remain_paired_after_assembly():
     ]
 
     items = adapter.items_from_messages(messages)
-    assembly = ContextAssembler(total_budget=200).assemble(reversed(items))
+    assembly = ContextAssembler(total_budget=200).assemble(items)
     rendered = adapter.messages_from_items(assembly.included)
 
     assert [item.kind for item in items] == [KIND_TOOL_CALL, KIND_TOOL_RESULT]

--- a/src/backend/tests/llm/test_context_ir.py
+++ b/src/backend/tests/llm/test_context_ir.py
@@ -98,13 +98,21 @@ def test_framework_neutral_fake_adapter_drives_canonical_assembly_and_rendering(
     )
     assembly = ContextAssembler(total_budget=100).assemble(candidates)
 
+    # Context order wins: a lower sequence does not jump the queue.
     assert adapter.messages_from_items(assembly.included) == [
-        {"id": "earlier", "text": "first"},
         {"id": "later", "text": "second"},
+        {"id": "earlier", "text": "first"},
     ]
 
 
-def test_different_input_order_produces_identical_canonical_output_and_manifest():
+def test_assembly_preserves_context_order_regardless_of_sequence():
+    """The assembler selects and truncates; it must never reorder.
+
+    Sorting by sequence here moved the live user instruction — parked 64 strides
+    above the context tail — behind the whole turn it had just started, and the
+    model re-ran that turn as if the request were new.
+    """
+
     items = [
         _item("u2", "second", created_seq=20),
         _item(
@@ -122,11 +130,16 @@ def test_different_input_order_produces_identical_canonical_output_and_manifest(
     ]
 
     left = ContextAssembler(total_budget=500).assemble(items)
-    right = ContextAssembler(total_budget=500).assemble(reversed(items))
+    right = ContextAssembler(total_budget=500).assemble(list(reversed(items)))
 
-    assert [item.item_id for item in left.included] == ["system", "u1", "u2"]
-    assert [item.item_id for item in right.included] == ["system", "u1", "u2"]
-    assert left.manifest_hash == right.manifest_hash
+    assert [item.item_id for item in left.included] == ["u2", "system", "u1"]
+    assert [item.item_id for item in right.included] == ["u1", "system", "u2"]
+
+    # The audit guarantee the canonical sort was introduced for: one input,
+    # one hash. Reproducibility never required reordering the conversation.
+    assert ContextAssembler(total_budget=500).assemble(items).manifest_hash == (
+        left.manifest_hash
+    )
 
 
 def test_low_trust_content_cannot_displace_critical_system_item():
@@ -211,11 +224,11 @@ def test_tool_call_and_result_are_kept_or_excluded_as_one_pair():
         pair_id="t1",
     )
 
-    fits = ContextAssembler(total_budget=90).assemble([result, call])
+    fits = ContextAssembler(total_budget=90).assemble([call, result])
     assert {item.kind for item in fits.included} == {"tool_call", "tool_result"}
     assert fits.included[1].content["output"].endswith("R" * 10)
 
-    dropped = ContextAssembler(total_budget=1).assemble([result, call])
+    dropped = ContextAssembler(total_budget=1).assemble([call, result])
     assert dropped.included == ()
     assert {entry["reason"] for entry in dropped.manifest["excluded"]} == {"paired_budget"}
 

--- a/src/backend/tests/llm/test_context_order_user_input.py
+++ b/src/backend/tests/llm/test_context_order_user_input.py
@@ -1,0 +1,123 @@
+"""The live user instruction must stay ahead of the turn it triggered.
+
+``next_request_sequence`` parks the request 64 strides above the context tail so
+pre-reply middleware can inject ahead of it. The positional fallback used for
+rows without an explicit sequence starts at ``message_index * STRIDE``, so every
+tool call and tool result of the current turn used to sort *before* the request.
+The model then read its own finished work first and the user's ask last, took
+that for a fresh request, and ran the whole turn again.
+"""
+
+from agentscope.message import Msg, ToolCallBlock, ToolResultBlock
+
+from core.llm.context_adapter import (
+    AgentScopeContextAdapter,
+    next_request_sequence,
+    render_context_item,
+)
+from core.llm.context_ir import (
+    KIND_USER_INPUT,
+    POLICY_NEVER,
+    ContextAssembler,
+    ContextItem,
+)
+
+USER_TEXT = "新建一个 test 文件夹，派 5 个子智能体各生成一份 html 放进去"
+
+
+def _user_message(context: list) -> Msg:
+    seq = next_request_sequence(context)
+    return render_context_item(
+        ContextItem.create(
+            item_id=f"request:user_input:{seq}",
+            kind=KIND_USER_INPUT,
+            origin="user:chat",
+            trust="user",
+            visibility="model",
+            priority=1_000,
+            token_budget=100_000,
+            truncation_policy=POLICY_NEVER,
+            content=USER_TEXT,
+            cache_class="dynamic",
+            created_seq=seq,
+            render_role="user",
+            render_name="user",
+            message_group=f"request:user_input:{seq}",
+        )
+    )
+
+
+def _react_trace() -> list[Msg]:
+    """What AgentScope appends while the turn runs."""
+    return [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[ToolCallBlock(type="tool_call", id="t1", name="bash", input="{}")],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ToolResultBlock(
+                    type="tool_result", id="t1", name="bash", output="(empty)"
+                )
+            ],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ToolCallBlock(
+                    type="tool_call", id=f"s{i}", name="call_subagent", input="{}"
+                )
+                for i in range(5)
+            ],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id=f"s{i}",
+                    name="call_subagent",
+                    output=f"已完成 report_{i}.html",
+                )
+                for i in range(5)
+            ],
+        ),
+    ]
+
+
+def _assembled_roles(context: list[Msg]) -> list[Msg]:
+    adapter = AgentScopeContextAdapter()
+    assembly = ContextAssembler(total_budget=200_000, budget_details={}).assemble(
+        adapter.items_from_messages(context)
+    )
+    return adapter.messages_from_items(assembly.included)
+
+
+def test_user_instruction_precedes_the_trace_it_triggered():
+    context = [_user_message([])]
+    context.extend(_react_trace())
+
+    out = _assembled_roles(context)
+
+    assert out[0].role == "user", "the request must open the turn, not close it"
+    assert USER_TEXT in str(out[0].content[0].text)
+    assert all(m.role == "assistant" for m in out[1:])
+
+
+def test_ordering_holds_for_a_second_turn():
+    context = [_user_message([])]
+    context.extend(_react_trace())
+    context.append(_user_message(context))
+    context.extend(_react_trace())
+
+    out = _assembled_roles(context)
+    user_positions = [i for i, m in enumerate(out) if m.role == "user"]
+
+    assert len(user_positions) == 2
+    # Each request opens its own turn: nothing from turn 2 may precede request 2.
+    assert user_positions == [0, len(out) // 2]

--- a/src/backend/tests/llm/test_sandbox_session_resolution.py
+++ b/src/backend/tests/llm/test_sandbox_session_resolution.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+from core.llm.subagent_tool import _run_subagent_in_thread
+from core.llm.tools._common import resolve_sandbox_session
+
+
+def test_empty_override_falls_back_to_chat_session():
+    assert resolve_sandbox_session(None, "chat-1") == "chat-1"
+    assert resolve_sandbox_session("", "chat-1") == "chat-1"
+    assert resolve_sandbox_session("explicit", "chat-1") == "explicit"
+
+
+def test_custom_subagent_reuses_parent_session(monkeypatch):
+    captured = {}
+
+    class FakeDbContext:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, *args):
+            return None
+
+    class FakeUserAgentService:
+        def __init__(self, db):
+            del db
+
+        def get_raw_by_id(self, agent_id, *, user_id):
+            assert agent_id == "custom-1"
+            assert user_id == "user-1"
+            return SimpleNamespace(
+                mcp_server_ids=[],
+                skill_ids=[],
+                kb_ids=[],
+                system_prompt="custom",
+                model_provider_id=None,
+                max_iters=3,
+                temperature=0.1,
+                max_tokens=100,
+                timeout=30,
+            )
+
+    class FakeReply:
+        def get_text_content(self):
+            return "done"
+
+    class FakeAgent:
+        state = SimpleNamespace(context=[])
+
+        async def reply(self, *, inputs):
+            assert inputs is not None
+            return FakeReply()
+
+    async def fake_create_agent_executor(**kwargs):
+        captured.update(kwargs)
+        return FakeAgent(), []
+
+    async def no_op(*args, **kwargs):
+        del args, kwargs
+
+    monkeypatch.setattr("core.db.engine.SessionLocal", lambda: FakeDbContext())
+    monkeypatch.setattr(
+        "core.services.user_agent_service.UserAgentService",
+        FakeUserAgentService,
+    )
+    monkeypatch.setattr("core.llm.builtin_subagents.get_builtin_subagent", lambda _id: None)
+    monkeypatch.setattr(
+        "core.llm.agent_factory.create_agent_executor",
+        fake_create_agent_executor,
+    )
+    monkeypatch.setattr("core.llm.mcp_manager.close_clients", no_op)
+    monkeypatch.setattr("core.infra.redis.close_redis", no_op)
+    ok, text, _pinned = _run_subagent_in_thread(
+        "custom-1",
+        "Custom",
+        "do work",
+        "",
+        "user-1",
+        parent_runtime={
+            "sandbox_session_id": "chat-sandbox-1",
+            "chat_id": "chat-1",
+        },
+    )
+
+    assert ok is True
+    assert text == "done"
+    assert captured["sandbox_session_id"] == "chat-sandbox-1"

--- a/src/backend/tests/orchestration/test_thinking_block_persistence.py
+++ b/src/backend/tests/orchestration/test_thinking_block_persistence.py
@@ -120,6 +120,54 @@ async def test_each_block_records_where_it_belongs_in_the_body(run_env, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_steps_between_two_bodies_keep_their_true_order(run_env, monkeypatch):
+    """同一个 offset 上的思考与工具卡片，先后必须可还原。
+
+    offset 数的是可见正文的字符，所以两次正文之间发生的一切共用同一个值；思考与
+    工具卡片又分两列存。没有 step_seq 时刷新后只能猜，实际是把思考全堆在前、卡片
+    全堆在后——真实顺序「想→跑→想→跑」被还原成「想想→跑跑」。
+    """
+
+    async def interleaved_workflow(**_kwargs):
+        yield {"type": "thinking", "delta": "先想想"}
+        yield {
+            "type": "tool_call",
+            "tool_name": "bash",
+            "tool_id": "call-0",
+            "tool_args": {"command": "ls"},
+        }
+        yield {"type": "tool_result", "tool_id": "call-0", "content": "ok"}
+        yield {"type": "thinking", "delta": "再想想"}
+        yield {
+            "type": "tool_call",
+            "tool_name": "bash",
+            "tool_id": "call-1",
+            "tool_args": {"command": "pwd"},
+        }
+        yield {"type": "tool_result", "tool_id": "call-1", "content": "ok"}
+        yield {"type": "ai_message", "delta": "答案"}
+        yield {"type": "meta"}
+
+    message_id = await _run_to_completion(interleaved_workflow, monkeypatch)
+    stored = _stored(run_env, message_id)
+
+    # 四个步骤全落在正文之前，offset 一律为 0——排序只能靠 step_seq。
+    assert [b["offset"] for b in stored.thinking] == [0, 0]
+    assert [tc["content_offset"] for tc in stored.tool_calls] == [0, 0]
+
+    replayed = sorted(
+        [(b["step_seq"], "think", b["content"]) for b in stored.thinking]
+        + [(tc["step_seq"], "tool", tc["tool_id"]) for tc in stored.tool_calls]
+    )
+    assert [(kind, label) for _, kind, label in replayed] == [
+        ("think", "先想想"),
+        ("tool", "call-0"),
+        ("think", "再想想"),
+        ("tool", "call-1"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_late_reasoning_tail_merges_into_the_same_round_block(run_env, monkeypatch):
     """同一轮里正文开头之后才到的思考尾巴，并回本轮的块，不另起一块、不改位置。"""
 
@@ -134,7 +182,7 @@ async def test_late_reasoning_tail_merges_into_the_same_round_block(run_env, mon
     stored = _stored(run_env, message_id)
 
     assert stored.content == "答案是42"
-    assert stored.thinking == [{"content": "想好了。", "offset": 0}]
+    assert stored.thinking == [{"content": "想好了。", "offset": 0, "step_seq": 0}]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/sandbox/test_artifact_streaming.py
+++ b/src/backend/tests/sandbox/test_artifact_streaming.py
@@ -57,19 +57,24 @@ async def test_stream_to_file_rejects_one_byte_over_and_removes_partial(tmp_path
 
 @pytest.mark.asyncio
 async def test_script_runner_raw_endpoint_enforces_limit(monkeypatch, tmp_path):
-    within = tmp_path / "within.pdf"
-    within.write_bytes(b"12345678")
-    over = tmp_path / "over.pdf"
-    over.write_bytes(b"123456789")
     monkeypatch.setattr(runner_server, "WORKSPACE_ROOT", str(tmp_path))
+    workspace = runner_server._session_workspace("chat-1", create=True)
+    within = workspace / "within.pdf"
+    within.write_bytes(b"12345678")
+    over = workspace / "over.pdf"
+    over.write_bytes(b"123456789")
     monkeypatch.setattr(runner_server, "MAX_ARTIFACT_EXPORT_BYTES", 8)
 
-    response = await runner_server.get_file_raw(runner_server.GetFileRequest(path=str(within)))
+    response = await runner_server.get_file_raw(
+        runner_server.GetFileRequest(session_id="chat-1", path="/workspace/within.pdf")
+    )
     assert Path(response.path) == within
     assert response.headers["x-artifact-size"] == "8"
 
     with pytest.raises(HTTPException) as exc_info:
-        await runner_server.get_file_raw(runner_server.GetFileRequest(path=str(over)))
+        await runner_server.get_file_raw(
+            runner_server.GetFileRequest(session_id="chat-1", path="/workspace/over.pdf")
+        )
     assert exc_info.value.status_code == 413
 
 
@@ -107,7 +112,11 @@ class _ScriptRunnerClient:
     def stream(self, method: str, url: str, json: dict):
         assert method == "POST"
         assert url.endswith("/get_file_raw")
-        assert json == {"path": "/workspace/report.pdf"}
+        assert json == {
+            "session_id": "chat-1",
+            "user_id": None,
+            "path": "/workspace/report.pdf",
+        }
         return _StreamContext()
 
 
@@ -119,7 +128,7 @@ async def test_script_runner_streams_file_to_path(monkeypatch, tmp_path):
     )
     destination = tmp_path / "script-runner.pdf"
     written = await ScriptRunnerProvider().get_file_to_path(
-        None,
+        "chat-1",
         "/workspace/report.pdf",
         destination,
         max_bytes=8,
@@ -158,7 +167,7 @@ async def test_script_runner_reports_sidecar_limit(monkeypatch, tmp_path):
     destination = tmp_path / "too-large.bin"
     with pytest.raises(SandboxFileTooLargeError) as exc_info:
         await ScriptRunnerProvider().get_file_to_path(
-            None,
+            "chat-1",
             "/workspace/too-large.bin",
             destination,
             max_bytes=10,

--- a/src/backend/tests/test_local_profile.py
+++ b/src/backend/tests/test_local_profile.py
@@ -555,16 +555,17 @@ def test_workspace_path_alias_in_local_mode(monkeypatch):
     assert p.canonicalize_ws_path("/workspace/site-src/foo") == "/workspace/site-src/foo"
 
 
-def test_runner_canon_ws_and_bash_rewrite(monkeypatch):
-    """The script_runner service must alias /workspace at its path chokepoint and in
-    the bash/python it executes, so model-written /workspace paths resolve locally."""
+def test_runner_canon_ws_and_bash_rewrite(monkeypatch, tmp_path):
+    """The runner maps canonical and expanded paths into the chat workspace."""
     import services.script_runner_service.server as srv
 
-    local_root = "/Users/test/Library/Application Support/HugAgentOS/workspace"
+    local_root = str(tmp_path / "Application Support" / "HugAgentOS" / "workspace")
     monkeypatch.setattr(srv, "WORKSPACE_ROOT", local_root)
-    assert srv._canon_ws("/workspace") == local_root
-    assert srv._canon_ws("/workspace/a.txt") == f"{local_root}/a.txt"
-    assert srv._canon_ws("/workspaces/x") == "/workspaces/x"
+    session_root = str(srv._session_workspace("chat-1", create=True))
+    assert srv._canon_ws("/workspace", "chat-1") == session_root
+    assert srv._canon_ws("/workspace/a.txt", "chat-1") == f"{session_root}/a.txt"
+    assert srv._canon_ws(f"{local_root}/a.txt", "chat-1") == f"{session_root}/a.txt"
+    assert srv._canon_ws("/workspaces/x", "chat-1") == "/workspaces/x"
 
     # Existing quotes remain intact, while an unquoted canonical path gains a
     # safely quoted prefix when the macOS Application Support mapping adds

--- a/src/backend/tests/test_script_runner_sessions.py
+++ b/src/backend/tests/test_script_runner_sessions.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+
+import pytest
+from fastapi import HTTPException
+from services.script_runner_service import server
+
+
+def test_session_workspaces_are_stable_and_isolated(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "WORKSPACE_ROOT", str(tmp_path))
+
+    first = server._session_workspace("chat-a", create=True)
+    again = server._session_workspace("chat-a", create=True)
+    second = server._session_workspace("chat-b", create=True)
+
+    assert first == again
+    assert first != second
+    assert first.parent == tmp_path / ".sessions"
+    assert server._canon_ws("/workspace/report.txt", "chat-a") == str(first / "report.txt")
+
+
+def test_file_endpoints_isolate_sessions(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "WORKSPACE_ROOT", str(tmp_path))
+    encoded = base64.b64encode(b"session-a").decode("ascii")
+
+    asyncio.run(
+        server.put_file(
+            server.PutFileRequest(
+                session_id="chat-a",
+                path="/workspace/report.txt",
+                content_b64=encoded,
+            )
+        )
+    )
+
+    response = asyncio.run(
+        server.get_file(
+            server.GetFileRequest(
+                session_id="chat-a",
+                path="/workspace/report.txt",
+            )
+        )
+    )
+    assert base64.b64decode(response.content_b64) == b"session-a"
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            server.get_file(
+                server.GetFileRequest(
+                    session_id="chat-b",
+                    path="/workspace/report.txt",
+                )
+            )
+        )
+    assert exc_info.value.status_code == 404
+
+
+def test_execute_reuses_files_only_inside_the_same_session(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "WORKSPACE_ROOT", str(tmp_path))
+
+    write_result = asyncio.run(
+        server.execute(
+            server.ExecuteRequest(
+                session_id="chat-a",
+                script_name="write.py",
+                script_content=(
+                    "from pathlib import Path\n"
+                    "Path('/workspace/shared.txt').write_text('visible')\n"
+                ),
+            )
+        )
+    )
+    same_session = asyncio.run(
+        server.execute(
+            server.ExecuteRequest(
+                session_id="chat-a",
+                script_name="read.py",
+                script_content=(
+                    "from pathlib import Path\n"
+                    "print(Path('/workspace/shared.txt').read_text())\n"
+                ),
+            )
+        )
+    )
+    other_session = asyncio.run(
+        server.execute(
+            server.ExecuteRequest(
+                session_id="chat-b",
+                script_name="probe.py",
+                script_content=(
+                    "from pathlib import Path\n" "print(Path('/workspace/shared.txt').exists())\n"
+                ),
+            )
+        )
+    )
+
+    assert write_result.exit_code == 0
+    assert same_session.stdout.strip() == "visible"
+    assert other_session.stdout.strip() == "False"
+
+
+def test_close_session_removes_only_the_target_workspace(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "WORKSPACE_ROOT", str(tmp_path))
+    first = server._session_workspace("chat-a", create=True)
+    second = server._session_workspace("chat-b", create=True)
+    (first / "a.txt").write_text("a", encoding="utf-8")
+    (second / "b.txt").write_text("b", encoding="utf-8")
+
+    result = asyncio.run(server.close_session(server.SessionRequest(session_id="chat-a")))
+
+    assert result == {"closed": True}
+    assert not first.exists()
+    assert second.is_dir()

--- a/src/frontend/src/hooks/useChatInit.ts
+++ b/src/frontend/src/hooks/useChatInit.ts
@@ -141,6 +141,9 @@ function parseHistoryMessage(m: any): ChatMessage {
         ...(typeof (tc.content_offset ?? tc.contentOffset) === 'number'
           ? { contentOffset: (tc.content_offset ?? tc.contentOffset) }
           : {}),
+        ...(typeof (tc.step_seq ?? tc.stepSeq) === 'number'
+          ? { stepSeq: (tc.step_seq ?? tc.stepSeq) }
+          : {}),
         // 历史列表只给了梗概；展开这张卡时 ToolCallRow 会按需回取完整结果。
         ...(tc.result_truncated === true ? { outputTruncated: true } : {}),
       }))
@@ -157,7 +160,15 @@ function parseHistoryMessage(m: any): ChatMessage {
   const rawContent = String(m.content || '');
   // 思考单独存一列（新消息）；老消息该字段为空，思考仍内联在 content 里。
   const storedThinking = Array.isArray(m.thinking)
-    ? (m.thinking as ThinkingBlock[]).filter((b) => b && typeof b.content === 'string')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ? (m.thinking as any[])
+        .filter((b) => b && typeof b.content === 'string')
+        .map((b): ThinkingBlock => ({
+          ...b,
+          ...(typeof (b.step_seq ?? b.stepSeq) === 'number'
+            ? { stepSeq: (b.step_seq ?? b.stepSeq) }
+            : {}),
+        }))
     : undefined;
   let { segments, cleanContent } = m.role === 'assistant'
     ? buildHistorySegments(rawContent, toolCalls, storedThinking)

--- a/src/frontend/src/types.ts
+++ b/src/frontend/src/types.ts
@@ -194,6 +194,8 @@ export interface ToolCall {
    * 历史重建按此偏移把「文本 ↔ 工具卡片」按流式原顺序交错还原。
    */
   contentOffset?: number;
+  /** 与思考块共用的先后号，同一 contentOffset 下靠它排序。见 ThinkingBlock.stepSeq。 */
+  stepSeq?: number;
   /** 历史列表只给了梗概，完整结果要展开时按需回取（后端 result_truncated）。 */
   outputTruncated?: boolean;
   /** 已经按需取回过完整结果，别重复请求。 */
@@ -271,6 +273,11 @@ export interface ThinkingBlock {
    * 实时流式的块没有它（位置由 segments 直接决定）。
    */
   offset?: number;
+  /**
+   * 落库时统一发的先后号，跨思考块与工具卡片单调递增。两次可见正文之间发生的
+   * 一切共用同一个 offset，只有这个号能排出它们真正的先后。老消息没有。
+   */
+  stepSeq?: number;
 }
 
 export interface OntologyActivationSummary {

--- a/src/frontend/src/utils/segments.ts
+++ b/src/frontend/src/utils/segments.ts
@@ -122,49 +122,58 @@ function parseHistoricalContent(content: string): {
   return { thinkingContents, visibleContent: visibleContent.trim() };
 }
 
+/** 一个待还原的过程步骤：思考块或工具卡片，带它在正文里的位置与先后号。 */
+type StoredStep =
+  | { kind: 'thinking'; at: number; seq: number | undefined; order: number; content: string }
+  | { kind: 'tool'; at: number; seq: number | undefined; order: number; toolIndex: number };
+
 /**
- * 把独立存储的思考块按 offset 插回正文原位，还原成历史重建认识的内联形态。
+ * 把两列结构化数据（thinking 与 toolCalls）归并成一条按发生顺序排列的步骤表。
  *
- * 落库时思考进 chat_messages.thinking 独立一列、正文进 content，两者互不挤占
- * 长度上限；展示时思考必须回到它当初出现的那个位置，顺序与实时流式一模一样。
- * 工具卡片的 contentOffset 与正文同坐标系，插入思考后要按插入长度整体右移。
- * offset 相同时思考排在工具卡片之前（落库顺序即如此：先 flush 思考再记卡片位置）。
+ * 思考早已单独存进 chat_messages.thinking，正文里不再有它——所以还原时不必把
+ * `<think>` 拼回正文再切一遍，直接按位置排就行。offset 与 contentOffset 都是
+ * 落库正文的字符偏移，同一坐标系，可直接比较。
+ *
+ * 两次可见正文之间发生的一切共用同一个 offset，光比 offset 排不出先后，得靠落库
+ * 时统一发的 step_seq。老消息没有这个号，退回旧规则：同一位置上思考排在工具卡片
+ * 之前（当时的落库顺序就是先 flush 思考再记卡片位置）。
  */
-function restoreThinkingInPlace(
-  content: string,
+function mergeStoredSteps(
+  contentLength: number,
   toolCalls: ChatMessage['toolCalls'],
-  thinking: ThinkingBlock[],
-): { content: string; toolCalls: ChatMessage['toolCalls'] } {
-  const blocks = thinking
-    .map((block, order) => ({
+  thinking: ThinkingBlock[] | undefined,
+): StoredStep[] {
+  const clamp = (value: unknown): number =>
+    typeof value === 'number' && value >= 0 ? Math.min(value, contentLength) : contentLength;
+
+  const steps: StoredStep[] = [];
+  (thinking ?? []).forEach((block, order) => {
+    if (!block?.content) return;
+    steps.push({
+      kind: 'thinking',
+      at: clamp(block.offset),
+      seq: typeof block.stepSeq === 'number' ? block.stepSeq : undefined,
       order,
-      text: block.content || '',
-      offset: typeof block.offset === 'number' && block.offset >= 0
-        ? Math.min(block.offset, content.length)
-        : content.length,
-    }))
-    .filter((block) => block.text)
-    .sort((a, b) => a.offset - b.offset || a.order - b.order);
-  if (blocks.length === 0) return { content, toolCalls };
-
-  const inserts: { at: number; len: number }[] = [];
-  let restored = '';
-  let cursor = 0;
-  blocks.forEach((block) => {
-    restored += content.slice(cursor, block.offset);
-    const wrapped = `<think>${block.text}</think>`;
-    restored += wrapped;
-    inserts.push({ at: block.offset, len: wrapped.length });
-    cursor = block.offset;
+      content: block.content,
+    });
   });
-  restored += content.slice(cursor);
-
-  const shifted = toolCalls?.map((tc) => {
-    if (typeof tc.contentOffset !== 'number') return tc;
-    const delta = inserts.reduce((sum, ins) => (ins.at <= tc.contentOffset! ? sum + ins.len : sum), 0);
-    return delta ? { ...tc, contentOffset: tc.contentOffset + delta } : tc;
+  (toolCalls ?? []).forEach((tc, toolIndex) => {
+    steps.push({
+      kind: 'tool',
+      at: clamp(tc.contentOffset),
+      seq: typeof tc.stepSeq === 'number' ? tc.stepSeq : undefined,
+      order: toolIndex,
+      toolIndex,
+    });
   });
-  return { content: restored, toolCalls: shifted };
+
+  const legacyKindRank = (step: StoredStep) => (step.kind === 'thinking' ? 0 : 1);
+  return steps.sort((a, b) => {
+    if (a.at !== b.at) return a.at - b.at;
+    if (a.seq !== undefined && b.seq !== undefined) return a.seq - b.seq;
+    if (a.kind !== b.kind) return legacyKindRank(a) - legacyKindRank(b);
+    return a.order - b.order;
+  });
 }
 
 export function buildHistorySegments(
@@ -172,18 +181,15 @@ export function buildHistorySegments(
   rawToolCalls?: ChatMessage['toolCalls'],
   thinking?: ThinkingBlock[]
 ): { segments: MessageSegment[] | undefined; cleanContent: string } {
-  // 思考单独存一列的新消息：先按 offset 插回原位，之后完全走原有重建逻辑，
-  // 展示与老的内联存储格式逐字一致。thinking 为空则是老消息，思考仍在 content 里。
+  // thinking 为空则是老消息，思考仍内联在 content 里，走下面的兜底解析。
   const hasStoredThinking = Array.isArray(thinking) && thinking.length > 0;
-  const restored = hasStoredThinking
-    ? restoreThinkingInPlace(rawContent, rawToolCalls, thinking!)
-    : { content: rawContent, toolCalls: rawToolCalls };
-  const content = restored.content;
-  const toolCalls = restored.toolCalls;
-  // ── 新历史（带 contentOffset）：按流式原顺序把文本与工具卡片交错还原 ──
-  // contentOffset = 工具卡片出现时持久化正文累计串（含 <think> 标记）的字符
-  // 偏移，与 content 同一坐标系。逐段切片，段内再按 </think> 拆 thinking /
-  // text。刷新后的历史与实时流式展示保持一致（问题15）。
+  const content = rawContent;
+  const toolCalls = rawToolCalls;
+  // ── 新历史：思考块与工具卡片都带位置，按发生顺序与正文交错还原 ──
+  // 思考存在 chat_messages.thinking 独立一列，正文里没有它；两列的 offset /
+  // contentOffset 是同一坐标系，直接归并即可，不必把 `<think>` 拼回正文再解析。
+  // 切出来的正文片段仍走 segmentTextSlice：内联 reasoning 的模型可能在正文里
+  // 留下 `<think>`，那部分照旧要剥离。刷新后与实时流式展示一致（问题15）。
   // 附件伪工具卡（attachArtifactsToToolCalls 追加的 artifact_*）没有 offset，
   // 视为「排在正文末尾」，不因它们把整条消息打回堆叠兜底。
   const isArtifactCard = (tc: NonNullable<ChatMessage['toolCalls']>[number]) =>
@@ -198,14 +204,18 @@ export function buildHistorySegments(
     const segments: MessageSegment[] = [];
     let cursor = 0;
     let visibleAll = '';
-    (toolCalls ?? []).forEach((tc, i) => {
-      const rawOff = typeof tc.contentOffset === 'number' ? tc.contentOffset : content.length;
-      const off = Math.min(Math.max(rawOff, cursor), content.length);
+    const takeVisibleUpTo = (at: number) => {
+      const off = Math.min(Math.max(at, cursor), content.length);
       const visible = segmentTextSlice(content.slice(cursor, off), segments);
       if (visible) visibleAll += (visibleAll ? '\n\n' : '') + visible;
       cursor = off;
-      segments.push({ type: 'tool', toolIndex: i });
-    });
+    };
+    mergeStoredSteps(content.length, toolCalls, hasStoredThinking ? thinking : undefined)
+      .forEach((step) => {
+        takeVisibleUpTo(step.at);
+        if (step.kind === 'tool') segments.push({ type: 'tool', toolIndex: step.toolIndex });
+        else segments.push({ type: 'thinking', content: step.content });
+      });
     const finalVisible = segmentTextSlice(content.slice(cursor), segments);
     if (finalVisible) visibleAll += (visibleAll ? '\n\n' : '') + finalVisible;
     // 与实时视图一致的碎片归并：思考型模型偶尔把下一句的首个汉字与工具调用


### PR DESCRIPTION
## Summary

- Preserve the original conversation order during context budgeting so the active user instruction cannot move behind tool history.
- Persist a monotonic step sequence across thinking blocks and tool cards, then replay them in the same interleaved order seen during streaming.
- Scope script-runner workspaces to the conversation while sharing that workspace across the main agent, sub-agents, and batch execution.
- Keep shared skills and user MySpace mounts available inside each session workspace and document the isolation model in English and Chinese.

## Testing

- CE derivation gates: required files, forbidden artifacts, binary allowlist, branding, license, import, OpenAPI, ORM, and CE release regression tests.
- Targeted backend suite: 73 passed, 4 skipped.
- CE web frontend production build on Node 22: i18n check, dark-mode check, TypeScript, Vite, and precompression.
- git diff --check.
