### PR TITLE
fix(chat): preserve display segment order across history reloads

### DIFF
--- a/src/backend/api/routes/v1/chats.py
+++ b/src/backend/api/routes/v1/chats.py
@@ -60,7 +60,7 @@ router = APIRouter(prefix="/v1/chats", tags=["Sessions"])
 # the route handlers below stay unchanged.
 from core.chat.display_bounds import bound_result_for_display, bound_result_for_history
 from core.chat.tool_log import (  # noqa: E402
-    StepSequencer,
+    SegmentRecorder,
     build_thinking_event,
     build_tool_call_delta_event,
     build_tool_call_event,
@@ -1639,9 +1639,9 @@ async def _stream_sse_response(
         _thinking_log: List[Dict[str, Any]] = []
         # 本轮已开的思考块；跨轮（工具调用边界）置 None 强制另起一块。
         _round_block: Optional[Dict[str, Any]] = None
-        # 思考块与工具卡片分两列存，光靠 offset 排不出先后（两次可见正文之间发生的
-        # 一切共用同一个 offset）。统一发号，回放时按 (offset, step_seq) 归并。
-        _steps = StepSequencer()
+        # 正文 / 思考 / 工具卡片的先后，在它们产生的那一刻就记下来，落进
+        # metadata.segments；刷新后照着渲染，不做任何反推。
+        _segments = SegmentRecorder()
 
         def _flush_thinking() -> None:
             nonlocal _round_block
@@ -1655,8 +1655,9 @@ async def _stream_sse_response(
             if _round_block is not None:
                 _round_block["content"] += block
                 return
-            _round_block = _steps.new_thinking_block(block, len(full_response))
+            _round_block = {"content": block}
             _thinking_log.append(_round_block)
+            _segments.add_thinking(len(_thinking_log) - 1)
 
         def _thinking_payload() -> Optional[List[Dict[str, Any]]]:
             blocks = [b for b in _thinking_log if b.get("content")]
@@ -1711,25 +1712,23 @@ async def _stream_sse_response(
                 if delta:
                     _flush_thinking()
                     full_response += delta
+                    _segments.add_text(delta)
                     yield f"data: {json.dumps({'type': 'content', 'event': 'ai_message', 'delta': delta, 'chat_id': chat_id}, ensure_ascii=False)}\n\n"
             elif chunk_type == "content_replace":
                 _thinking_parts.clear()
                 full_response = str(chunk.get("content") or "")
                 _round_block = None
                 _thinking_log.clear()
-                # 整体替换后，先前记录的 content_offset 指向旧草稿坐标系，
-                # 已无意义——清掉，让历史重建走「合并正文」兜底而不是错切。
-                StepSequencer.clear_tool_positions(tool_calls_log)
+                # 整体替换后，先前记下的段落描述的是旧草稿，已无意义——重记。
+                _segments.reset()
+                _segments.add_text(full_response)
                 event = {**chunk, "chat_id": chat_id}
                 yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
             elif chunk_type == "tool_call":
                 _flush_thinking()
                 _round_block = None
                 _tc_evt = build_tool_call_event(chunk, chat_id, tool_calls_log)
-                # 记录该工具卡片出现时正文的累计长度，外加统一发的先后号：历史重建
-                # 按 (offset, step_seq) 把「文本 ↔ 思考 ↔ 工具卡片」按流式原顺序交错
-                # （问题15：刷新后内容与实时不一致）。
-                _steps.stamp_tools(tool_calls_log, len(full_response))
+                _segments.add_tools(tool_calls_log)
                 yield f"data: {json.dumps(_tc_evt, ensure_ascii=False)}\n\n"
             elif chunk_type == "tool_call_start":
                 _flush_thinking()
@@ -1741,10 +1740,9 @@ async def _stream_sse_response(
                 yield f"data: {json.dumps(_td_evt, ensure_ascii=False)}\n\n"
             elif chunk_type == "tool_result":
                 _tr_evt = build_tool_result_event(chunk, chat_id, tool_calls_log)
-                # attach_tool_result 可能刚补录了一个没有 tool_call 事件的条目：
-                # 此刻就补记位置，否则它要等下一个 tool_call 才拿到（晚一个
-                # 叙述段），最后一个工具则永远缺失 → 整条消息退化成堆叠展示。
-                _steps.stamp_tools(tool_calls_log, len(full_response))
+                # attach_tool_result 可能刚补录了一个没有 tool_call 事件的条目，
+                # 此刻就把它排进段落表，否则它会缺席整条消息的展示顺序。
+                _segments.add_tools(tool_calls_log)
                 yield f"data: {json.dumps(_tr_evt, ensure_ascii=False)}\n\n"
             elif chunk_type == "heartbeat":
                 yield ": heartbeat\n\n"
@@ -1841,6 +1839,7 @@ async def _stream_sse_response(
                     extra_data={
                         **_persist_extra,
                         "message_id": pending_message_id,
+                        "segments": _segments.payload(),
                     },
                 )
                 if db and user_id:

--- a/src/backend/core/chat/tool_log.py
+++ b/src/backend/core/chat/tool_log.py
@@ -7,55 +7,66 @@ the chat route (``api/routes/v1/chats.py``) and the background run executor
 """
 
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from core.chat.display_bounds import bound_result_for_display
 
 
-class StepSequencer:
-    """Stamp one monotonic emission order across thinking blocks and tool cards.
+class SegmentRecorder:
+    """Record the assistant message's display shape while it streams.
 
-    ``content_offset`` alone cannot order them. It counts visible characters, so
-    everything a turn emits between two pieces of visible text lands on the same
-    offset — a turn that reasons, calls five sub-agents, reasons again and runs
-    bash stores ten items at one offset. Thinking and tool cards are also
-    persisted in two separate columns, so replay could only guess: it rendered
-    every thinking block first and every tool card after, instead of
-    interleaving them the way they ran.
+    The order of body text, reasoning and tool cards is already known the moment
+    each piece is emitted, so it is simply written down here and persisted as
+    ``metadata.segments``. Replay reads that list and renders it.
 
-    The stamp is per-stream and strictly increasing, so replay merges the two
-    columns by ``(offset, step_seq)`` and reproduces the live order exactly.
+    Nothing reconstructs the order afterwards. Reconstructing it from a
+    character offset into the body cannot work: the offset only moves when
+    visible text is emitted, so everything a turn does between two sentences
+    shares one value, and reasoning and tool cards live in separate columns —
+    replay could only guess, and it guessed "all the reasoning, then all the
+    cards" instead of the way they actually ran.
+
+    Body text is stored inline (it is capped alongside ``content``); reasoning
+    and tool cards are referenced by their index in ``thinking`` / ``tool_calls``
+    so a long reasoning block is never stored twice.
     """
 
     def __init__(self) -> None:
-        self._next = 0
+        self._segments: List[Dict[str, Any]] = []
+        self._pending_text = ""
+        self._placed_tools = 0
 
-    def take(self) -> int:
-        value = self._next
-        self._next += 1
-        return value
+    def reset(self) -> None:
+        """Start a fresh assistant message (steer split, or a redrafted body)."""
+        self._segments = []
+        self._pending_text = ""
+        self._placed_tools = 0
 
-    def stamp_tools(self, tool_calls_log: List[Dict[str, Any]], content_offset: int) -> None:
-        """Give every not-yet-placed tool card its offset and its order."""
-        for tool_call in tool_calls_log:
-            if "content_offset" in tool_call:
-                continue
-            tool_call["content_offset"] = content_offset
-            tool_call["step_seq"] = self.take()
+    def add_text(self, delta: str) -> None:
+        if delta:
+            self._pending_text += delta
 
-    @staticmethod
-    def clear_tool_positions(tool_calls_log: List[Dict[str, Any]]) -> None:
-        """Drop stale positions after ``content_replace`` rewrites the draft."""
-        for tool_call in tool_calls_log:
-            tool_call.pop("content_offset", None)
-            tool_call.pop("step_seq", None)
+    def _flush_text(self) -> None:
+        if self._pending_text:
+            self._segments.append({"type": "text", "text": self._pending_text})
+            self._pending_text = ""
 
-    def new_thinking_block(self, content: str, content_offset: int) -> Dict[str, Any]:
-        """Open one persisted thinking block at the current position."""
-        return {
-            "content": content,
-            "offset": content_offset,
-            "step_seq": self.take(),
-        }
+    def add_thinking(self, index: int) -> None:
+        """Place the reasoning block just appended at ``thinking[index]``."""
+        self._flush_text()
+        self._segments.append({"type": "thinking", "index": index})
+
+    def add_tools(self, tool_calls_log: List[Dict[str, Any]]) -> None:
+        """Place every card that has appeared since the last call, in order."""
+        if len(tool_calls_log) <= self._placed_tools:
+            return
+        self._flush_text()
+        for index in range(self._placed_tools, len(tool_calls_log)):
+            self._segments.append({"type": "tool", "index": index})
+        self._placed_tools = len(tool_calls_log)
+
+    def payload(self) -> Optional[List[Dict[str, Any]]]:
+        self._flush_text()
+        return list(self._segments) or None
 
 
 def build_thinking_event(chunk: dict, chat_id: str) -> Dict[str, Any]:

--- a/src/backend/core/db/models/chat.py
+++ b/src/backend/core/db/models/chat.py
@@ -142,14 +142,19 @@ class ChatMessage(Base):
     chat_seq = Column(BigInteger, nullable=False)
     content = Column(Text, nullable=False)
     model = Column(String(100))
-    # 思考过程，与正文分开存：``[{"content": str, "offset": int}]``，offset 是该思考块
-    # 出现时正文的字符位置。历史上思考是以 <think>…</think> 拼进 content 落库的，
-    # 结果思考把正文顶出 content 的 10 万字上限、截断切掉闭合标签后整段漏成正文。
-    # NULL = 老消息，仍按 content 里的内联标记解析。
+    # 思考过程，与正文分开存：``[{"content": str}]``。历史上思考是以 <think>…</think>
+    # 拼进 content 落库的，结果思考把正文顶出 content 的 10 万字上限、截断切掉闭合
+    # 标签后整段漏成正文。NULL = 老消息，思考仍内联在 content 里。
+    # 展示顺序不在这里——它记在 ``metadata.segments``（见下）。
     thinking = Column(JSONType)
     tool_calls = Column(JSONType)
     usage = Column(JSONType)
     error = Column(JSONType)
+    # ``metadata.segments`` 记这条消息的展示顺序，形如
+    # ``[{"type":"text","text":str} | {"type":"thinking","index":int}
+    #    | {"type":"tool","index":int}]``：顺序在实时流式的那一刻就已确定，原样记下，
+    # 刷新后照着渲染。正文片段内联，思考与工具卡片按下标引用上面两列，长推理不存两份。
+    # 缺失 = 段落表上线之前的老消息，展示退化成「正文 + 工具卡片」，不做顺序反推。
     extra_data = Column("metadata", JSONType, default={})
     created_at = Column(TIMESTAMP(timezone=True), default=datetime.utcnow)
 

--- a/src/backend/core/services/chat_service.py
+++ b/src/backend/core/services/chat_service.py
@@ -48,16 +48,23 @@ def clamp_message_content(content: str) -> str:
     return kept + _TRUNC_NOTE
 
 
-def clamp_thinking(blocks: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+def clamp_thinking(
+    blocks: Optional[List[Dict[str, Any]]],
+    segments: Optional[List[Dict[str, Any]]] = None,
+) -> tuple[Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
     """思考单独存一列，有自己的额度，不再和正文抢 content 的 10 万字上限。
 
     超额时从最早的块开始丢——最后几轮的推理离最终答案最近，对用户回看最有用。
+
+    ``metadata.segments`` 按下标引用思考块，丢块会让下标错位，所以两者必须一起夹取：
+    返回夹取后的块列表，以及下标已重映射、引用了被丢块的段落已剔除的段落表。
     """
     if not blocks:
-        return None
+        return None, segments or None
     kept: List[Dict[str, Any]] = []
+    kept_indices: List[int] = []
     budget = _THINKING_MAX
-    for block in reversed(blocks):
+    for offset, block in enumerate(reversed(blocks)):
         text = str(block.get("content") or "")
         if not text:
             continue
@@ -67,10 +74,34 @@ def clamp_thinking(blocks: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict
             break
         budget -= len(text)
         kept.append({**block, "content": text})
+        kept_indices.append(len(blocks) - 1 - offset)
         if budget <= 0:
             break
     kept.reverse()
-    return kept or None
+    kept_indices.reverse()
+    if not kept:
+        return None, _drop_thinking_segments(segments, {})
+    remap = {old: new for new, old in enumerate(kept_indices)}
+    return kept, _drop_thinking_segments(segments, remap)
+
+
+def _drop_thinking_segments(
+    segments: Optional[List[Dict[str, Any]]],
+    remap: Dict[int, int],
+) -> Optional[List[Dict[str, Any]]]:
+    """把段落表里的思考下标重映射到夹取后的位置，引用已丢块的段落直接剔除。"""
+    if not segments:
+        return segments or None
+    rebuilt: List[Dict[str, Any]] = []
+    for segment in segments:
+        if segment.get("type") != "thinking":
+            rebuilt.append(segment)
+            continue
+        new_index = remap.get(segment.get("index"))
+        if new_index is None:
+            continue
+        rebuilt.append({**segment, "index": new_index})
+    return rebuilt or None
 
 
 class CompactionCASConflict(RuntimeError):
@@ -392,6 +423,10 @@ class ChatService:
         chat_seq: Optional[int] = None,
     ) -> ChatMessage:
         """Add a message to a chat session."""
+        extra = dict(extra_data or {})
+        kept_thinking, kept_segments = clamp_thinking(thinking, extra.get("segments"))
+        if "segments" in extra:
+            extra["segments"] = kept_segments
         message_data = {
             "message_id": message_id or f"msg_{uuid.uuid4().hex[:16]}",
             "chat_id": chat_id,
@@ -399,11 +434,11 @@ class ChatService:
             "role": role,
             "content": clamp_message_content(content),
             "model": model,
-            "thinking": clamp_thinking(thinking),
+            "thinking": kept_thinking,
             "tool_calls": tool_calls,
             "usage": usage,
             "error": error,
-            "extra_data": extra_data or {},
+            "extra_data": extra,
         }
 
         message = self.message_repo.create(message_data, commit=commit)
@@ -446,16 +481,22 @@ class ChatService:
         existing = self.message_repo.get_by_id(message_id)
         if existing is not None:
             update: Dict[str, Any] = {"content": clamp_message_content(content)}
+            extra = dict(extra_data) if extra_data is not None else None
+            kept_thinking, kept_segments = clamp_thinking(
+                thinking, (extra or {}).get("segments")
+            )
             if model is not None:
                 update["model"] = model
             if thinking is not None:
-                update["thinking"] = clamp_thinking(thinking)
+                update["thinking"] = kept_thinking
             if tool_calls is not None:
                 update["tool_calls"] = tool_calls
             if usage is not None:
                 update["usage"] = usage
-            if extra_data is not None:
-                update["extra_data"] = extra_data
+            if extra is not None:
+                if "segments" in extra:
+                    extra["segments"] = kept_segments
+                update["extra_data"] = extra
             msg = self.message_repo.update(message_id, update, commit=commit)
             session = self.session_repo.get_by_id(chat_id)
             if session:

--- a/src/backend/orchestration/chat_run_executor.py
+++ b/src/backend/orchestration/chat_run_executor.py
@@ -828,7 +828,7 @@ async def _run_workflow(
     """
     from core.chat.context import now_iso, resolve_user_facing_error
     from core.chat.tool_log import (
-        StepSequencer,
+        SegmentRecorder,
         attach_subagent_step,
         build_thinking_event,
         build_tool_call_delta_event,
@@ -956,9 +956,9 @@ async def _run_workflow(
     # 每个思考块记录它出现时的正文偏移，历史重建按此原位还原。
     _thinking_parts: List[str] = []
     _thinking_log: List[Dict[str, Any]] = []
-    # 思考块与工具卡片分两列存，光靠 offset 排不出先后（两次可见正文之间发生的
-    # 一切共用同一个 offset）。统一发号，回放时按 (offset, step_seq) 归并。
-    _steps = StepSequencer()
+    # 正文 / 思考 / 工具卡片的先后，在它们产生的那一刻就记下来，落进
+    # metadata.segments；刷新后照着渲染，不做任何反推。
+    _segments = SegmentRecorder()
     # 本轮已开的思考块；跨轮（工具调用边界）置 None 强制另起一块。不设边界的话，
     # 正文一旦出现，后面每一轮的思考都会并进同一块里无限膨胀。
     _round_block: Optional[Dict[str, Any]] = None
@@ -977,8 +977,9 @@ async def _run_workflow(
         if _round_block is not None:
             _round_block["content"] += block
             return
-        _round_block = _steps.new_thinking_block(block, len(full_response))
+        _round_block = {"content": block}
         _thinking_log.append(_round_block)
+        _segments.add_thinking(len(_thinking_log) - 1)
 
     def _thinking_payload() -> Optional[List[Dict[str, Any]]]:
         blocks = [b for b in _thinking_log if b.get("content")]
@@ -1011,6 +1012,7 @@ async def _run_workflow(
             "artifacts": _ws_pinned,
             "workspace_files": _workspace_mod.get_pinned_file_ids(),
             "duration_ms": int((time.monotonic() - _run_started_monotonic) * 1000),
+            "segments": _segments.payload(),
         }
         if context.get("model_provider_id"):
             _extra["model_provider_id"] = context.get("model_provider_id")
@@ -1162,6 +1164,7 @@ async def _run_workflow(
                 if delta:
                     _flush_thinking()
                     full_response += delta
+                    _segments.add_text(delta)
                     await _emit(
                         {
                             "type": "content",
@@ -1180,9 +1183,9 @@ async def _run_workflow(
                 full_response = replacement
                 _round_block = None
                 _thinking_log.clear()
-                # 整体替换后，先前记录的 content_offset 指向旧草稿坐标系，
-                # 已无意义——清掉，让历史重建走「合并正文」兜底而不是错切。
-                StepSequencer.clear_tool_positions(tool_calls_log)
+                # 整体替换后，先前记下的段落描述的是旧草稿，已无意义——重记。
+                _segments.reset()
+                _segments.add_text(replacement)
                 await _emit(
                     {
                         "type": "content_replace",
@@ -1253,6 +1256,7 @@ async def _run_workflow(
                                     "duration_ms": int(
                                         (time.monotonic() - _run_started_monotonic) * 1000
                                     ),
+                                    "segments": _segments.payload(),
                                 },
                                 commit=False,
                             )
@@ -1357,6 +1361,7 @@ async def _run_workflow(
                 _thinking_parts.clear()
                 _round_block = None
                 _thinking_log.clear()
+                _segments.reset()
                 metadata = {}
                 try:
                     from core.services.log_service import set_current_message_id
@@ -1369,10 +1374,7 @@ async def _run_workflow(
                 _flush_thinking()
                 _round_block = None
                 _tc_evt = build_tool_call_event(chunk, chat_id, tool_calls_log)
-                # 记录该工具卡片出现时正文的累计长度，外加统一发的先后号：历史重建
-                # 按 (offset, step_seq) 把「文本 ↔ 思考 ↔ 工具卡片」按流式原顺序交错
-                # （问题15：刷新后内容与实时不一致）。
-                _steps.stamp_tools(tool_calls_log, len(full_response))
+                _segments.add_tools(tool_calls_log)
                 await _emit(_tc_evt)
 
             elif chunk_type == "tool_call_start":
@@ -1385,10 +1387,9 @@ async def _run_workflow(
 
             elif chunk_type == "tool_result":
                 _tr_evt = build_tool_result_event(chunk, chat_id, tool_calls_log)
-                # attach_tool_result 可能刚补录了一个没有 tool_call 事件的条目：
-                # 此刻就补记位置，否则它要等下一个 tool_call 才拿到（晚一个
-                # 叙述段），最后一个工具则永远缺失 → 整条消息退化成堆叠展示。
-                _steps.stamp_tools(tool_calls_log, len(full_response))
+                # attach_tool_result 可能刚补录了一个没有 tool_call 事件的条目，
+                # 此刻就把它排进段落表，否则它会缺席整条消息的展示顺序。
+                _segments.add_tools(tool_calls_log)
                 await _emit(_tr_evt)
 
             elif chunk_type == "context_usage":
@@ -1581,6 +1582,7 @@ async def _run_workflow(
                     "message_id": current_message_id,
                     "workspace_files": _ws_files,
                     "duration_ms": _duration_ms,
+                    "segments": _segments.payload(),
                 }
                 if isinstance(context_usage_payload, dict):
                     _persist_extra["context_usage"] = context_usage_payload

--- a/src/backend/tests/orchestration/test_thinking_block_persistence.py
+++ b/src/backend/tests/orchestration/test_thinking_block_persistence.py
@@ -68,6 +68,19 @@ def _stored(sessions, message_id: str) -> ChatMessage:
         return db.get(ChatMessage, message_id)
 
 
+def _shape(stored: ChatMessage) -> list:
+    """把落库的段落表翻译成一串可读的展示顺序。"""
+    out = []
+    for seg in (stored.extra_data or {}).get("segments") or []:
+        if seg["type"] == "text":
+            out.append(("text", seg["text"]))
+        elif seg["type"] == "thinking":
+            out.append(("think", stored.thinking[seg["index"]]["content"]))
+        else:
+            out.append(("tool", stored.tool_calls[seg["index"]]["tool_id"]))
+    return out
+
+
 @pytest.mark.asyncio
 async def test_reasoning_is_stored_out_of_the_body(run_env, monkeypatch):
     """多轮「思考 → 工具 → 正文」：正文一个思考标记都不许有，思考各自成块。"""
@@ -94,8 +107,8 @@ async def test_reasoning_is_stored_out_of_the_body(run_env, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_each_block_records_where_it_belongs_in_the_body(run_env, monkeypatch):
-    """offset 必须是该块出现时的正文长度——刷新后靠它插回原位，顺序不能乱。"""
+async def test_display_order_is_recorded_as_it_streams(run_env, monkeypatch):
+    """展示顺序在产生的那一刻就记下来，刷新后照着渲染，不做任何反推。"""
 
     async def multi_round_workflow(**_kwargs):
         for i in range(3):
@@ -113,19 +126,19 @@ async def test_each_block_records_where_it_belongs_in_the_body(run_env, monkeypa
     message_id = await _run_to_completion(multi_round_workflow, monkeypatch)
     stored = _stored(run_env, message_id)
 
-    # 每轮正文 2 字：第 0 块在正文最前，之后每块各推后一轮正文的长度。
-    assert [b["offset"] for b in stored.thinking] == [0, 2, 4]
-    # 工具卡片与思考共用正文坐标系，同一轮里思考在前、卡片在同一位置。
-    assert [tc["content_offset"] for tc in stored.tool_calls] == [0, 2, 4]
+    assert _shape(stored) == [
+        ("think", "想0"), ("tool", "call-0"), ("text", "正文"),
+        ("think", "想1"), ("tool", "call-1"), ("text", "正文"),
+        ("think", "想2"), ("tool", "call-2"), ("text", "正文"),
+    ]
 
 
 @pytest.mark.asyncio
 async def test_steps_between_two_bodies_keep_their_true_order(run_env, monkeypatch):
-    """同一个 offset 上的思考与工具卡片，先后必须可还原。
+    """两次可见正文之间发生的一串步骤，先后必须原样落库。
 
-    offset 数的是可见正文的字符，所以两次正文之间发生的一切共用同一个值；思考与
-    工具卡片又分两列存。没有 step_seq 时刷新后只能猜，实际是把思考全堆在前、卡片
-    全堆在后——真实顺序「想→跑→想→跑」被还原成「想想→跑跑」。
+    这是过去反推顺序失败的地方：靠正文字符偏移排序时，这些步骤全落在同一个偏移上，
+    刷新后被还原成「想想→跑跑」，而不是真实的「想→跑→想→跑」。
     """
 
     async def interleaved_workflow(**_kwargs):
@@ -151,19 +164,12 @@ async def test_steps_between_two_bodies_keep_their_true_order(run_env, monkeypat
     message_id = await _run_to_completion(interleaved_workflow, monkeypatch)
     stored = _stored(run_env, message_id)
 
-    # 四个步骤全落在正文之前，offset 一律为 0——排序只能靠 step_seq。
-    assert [b["offset"] for b in stored.thinking] == [0, 0]
-    assert [tc["content_offset"] for tc in stored.tool_calls] == [0, 0]
-
-    replayed = sorted(
-        [(b["step_seq"], "think", b["content"]) for b in stored.thinking]
-        + [(tc["step_seq"], "tool", tc["tool_id"]) for tc in stored.tool_calls]
-    )
-    assert [(kind, label) for _, kind, label in replayed] == [
+    assert _shape(stored) == [
         ("think", "先想想"),
         ("tool", "call-0"),
         ("think", "再想想"),
         ("tool", "call-1"),
+        ("text", "答案"),
     ]
 
 
@@ -182,7 +188,8 @@ async def test_late_reasoning_tail_merges_into_the_same_round_block(run_env, mon
     stored = _stored(run_env, message_id)
 
     assert stored.content == "答案是42"
-    assert stored.thinking == [{"content": "想好了。", "offset": 0, "step_seq": 0}]
+    assert stored.thinking == [{"content": "想好了。"}]
+    assert _shape(stored) == [("think", "想好了。"), ("text", "答案是42")]
 
 
 @pytest.mark.asyncio
@@ -209,21 +216,39 @@ async def test_runaway_reasoning_no_longer_evicts_the_answer(run_env, monkeypatc
 
 
 def test_thinking_has_its_own_budget_and_keeps_the_latest_rounds():
-    blocks = [
-        {"content": "旧" * _THINKING_MAX, "offset": 0},
-        {"content": "新", "offset": 10},
-    ]
+    blocks = [{"content": "旧" * _THINKING_MAX}, {"content": "新"}]
 
-    kept = clamp_thinking(blocks)
+    kept, _ = clamp_thinking(blocks)
 
     assert sum(len(b["content"]) for b in kept) <= _THINKING_MAX
     # 最后一轮离最终答案最近，必须留下；被裁的是最早那块。
-    assert kept[-1] == {"content": "新", "offset": 10}
+    assert kept[-1] == {"content": "新"}
+
+
+def test_clamping_thinking_keeps_the_segment_indices_pointing_at_the_right_block():
+    """段落表按下标引用思考块，丢块必须同步改下标，否则展示会错位。"""
+
+    # 最后一块就吃满额度 → 更早的那块整块被丢。
+    blocks = [{"content": "旧"}, {"content": "新" * _THINKING_MAX}]
+    segments = [
+        {"type": "thinking", "index": 0},
+        {"type": "text", "text": "答案"},
+        {"type": "thinking", "index": 1},
+    ]
+
+    kept, kept_segments = clamp_thinking(blocks, segments)
+
+    # 第 0 块被丢 → 引用它的段落一并剔除；第 1 块变成第 0 块，引用要跟着改。
+    assert len(kept) == 1 and kept[0]["content"].startswith("新")
+    assert kept_segments == [
+        {"type": "text", "text": "答案"},
+        {"type": "thinking", "index": 0},
+    ]
 
 
 def test_clamp_thinking_passes_small_payloads_through():
-    blocks = [{"content": "想", "offset": 0}, {"content": "再想", "offset": 3}]
+    blocks = [{"content": "想"}, {"content": "再想"}]
 
-    assert clamp_thinking(blocks) == blocks
-    assert clamp_thinking([]) is None
-    assert clamp_thinking(None) is None
+    assert clamp_thinking(blocks) == (blocks, None)
+    assert clamp_thinking([]) == (None, None)
+    assert clamp_thinking(None) == (None, None)

--- a/src/frontend/scripts/test-chat-stream-segments.ts
+++ b/src/frontend/scripts/test-chat-stream-segments.ts
@@ -150,9 +150,9 @@ function tool(toolIndex: number): MessageSegment {
 }
 
 {
-  // When there are more tool calls than persisted thinking blocks, every
-  // unmatched tool still happened before the final answer and must not be
-  // appended below it after refresh.
+  // Legacy history has no persisted segment table. Its original process order
+  // is unknowable, so history cleanup keeps only the visible body instead of
+  // guessing how thinking blocks and tool cards were interleaved.
   const toolCalls = [0, 1, 2].map((i) => ({
     id: `tool-${i}`,
     name: 'demo',
@@ -163,20 +163,12 @@ function tool(toolIndex: number): MessageSegment {
     toolCalls,
   );
 
-  assert.deepEqual(segments?.map((segment) => segment.type), [
-    'thinking',
-    'tool',
-    'tool',
-    'tool',
-    'text',
-  ]);
+  assert.equal(segments, undefined);
   assert.equal(cleanContent, '最终回答');
 }
 
 {
-  // Without persisted offsets (legacy history), there is no reliable cut
-  // point, so the fallback keeps the visible answer as one Markdown block
-  // instead of guessing splits around every tool call.
+  // Visible legacy narration remains intact even when old tool records exist.
   const phases = [
     '我来',
     '帮你查找最新的自进化相关文章。首先让我确认一下当前可访问的项目。',
@@ -193,24 +185,33 @@ function tool(toolIndex: number): MessageSegment {
   }));
   const { segments, cleanContent } = buildHistorySegments(content, toolCalls);
   assert.equal(cleanContent, content);
-  assert.deepEqual(segments?.map((segment) => segment.type), [
-    'tool', 'tool', 'tool', 'tool', 'tool', 'text',
-  ]);
-  assert.equal(segments?.at(-1)?.content, content);
+  assert.equal(segments, undefined);
 }
 
 {
-  // With persisted contentOffset, history restores the original streaming
-  // interleave: text ↔ tool cards in chronological order, thinking blocks
-  // split inside each slice.
-  const content = '<think>先想</think>先查一下。<think>再想</think>查到了，继续。最终结论。';
-  const off0 = content.indexOf('<think>再想');
-  const off1 = content.indexOf('最终结论。');
+  // The persisted segment table is the single source of truth for the original
+  // stream order. Text is inline; thinking and tools reference their columns.
+  const content = '先查一下。查到了，继续。最终结论。';
   const toolCalls = [
-    { id: 'tool-0', name: 'demo', status: 'success' as const, contentOffset: off0 },
-    { id: 'tool-1', name: 'demo', status: 'success' as const, contentOffset: off1 },
+    { id: 'tool-0', name: 'demo', status: 'success' as const },
+    { id: 'tool-1', name: 'demo', status: 'success' as const },
   ];
-  const { segments, cleanContent } = buildHistorySegments(content, toolCalls);
+  const thinking = [{ content: '先想' }, { content: '再想' }];
+  const storedSegments = [
+    { type: 'thinking' as const, index: 0 },
+    { type: 'text' as const, text: '先查一下。' },
+    { type: 'tool' as const, index: 0 },
+    { type: 'thinking' as const, index: 1 },
+    { type: 'text' as const, text: '查到了，继续。' },
+    { type: 'tool' as const, index: 1 },
+    { type: 'text' as const, text: '最终结论。' },
+  ];
+  const { segments, cleanContent } = buildHistorySegments(
+    content,
+    toolCalls,
+    thinking,
+    storedSegments,
+  );
   assert.deepEqual(segments, [
     { type: 'thinking', content: '先想' },
     { type: 'text', content: '先查一下。' },
@@ -224,15 +225,27 @@ function tool(toolIndex: number): MessageSegment {
 }
 
 {
-  // Offset path mirrors the live defer rule: a single Han character stranded
+  // Segment-table replay mirrors the live defer rule: a single Han character stranded
   // right before a tool card is merged into the narration after it, so the
   // refreshed history matches what the live stream rendered.
   const content = '第一步完成。数仓确认无误，输出结果。';
   const toolCalls = [
-    { id: 'tool-0', name: 'demo', status: 'success' as const, contentOffset: '第一步完成。'.length },
-    { id: 'tool-1', name: 'demo', status: 'success' as const, contentOffset: '第一步完成。数'.length },
+    { id: 'tool-0', name: 'demo', status: 'success' as const },
+    { id: 'tool-1', name: 'demo', status: 'success' as const },
   ];
-  const { segments, cleanContent } = buildHistorySegments(content, toolCalls);
+  const storedSegments = [
+    { type: 'text' as const, text: '第一步完成。' },
+    { type: 'tool' as const, index: 0 },
+    { type: 'text' as const, text: '数' },
+    { type: 'tool' as const, index: 1 },
+    { type: 'text' as const, text: '仓确认无误，输出结果。' },
+  ];
+  const { segments, cleanContent } = buildHistorySegments(
+    content,
+    toolCalls,
+    undefined,
+    storedSegments,
+  );
   assert.deepEqual(segments, [
     { type: 'text', content: '第一步完成。' },
     tool(0),
@@ -243,34 +256,54 @@ function tool(toolIndex: number): MessageSegment {
 }
 
 {
-  // Real-world corruption from structured reasoning: the tail of a thinking
-  // sentence ("。") arrives after the first answer token and was persisted as
-  // `答<think>。</think>案` — a think block puncturing the visible sentence.
-  // History rebuild must mirror the live merge rule: fold the late tail into
-  // the previous thinking block and rejoin the sentence seamlessly.
-  const content = '<think>整理今日资讯</think>内部<think>。</think>产业资讯数据源今日暂时无法返回。';
-  const toolCalls = [
-    { id: 'tool-0', name: 'demo', status: 'success' as const, contentOffset: 0 },
+  // Inline thinking markers inside a recorded text segment are still stripped,
+  // so a provider cannot leak structured reasoning into visible history.
+  const content = '内部产业资讯数据源今日暂时无法返回。';
+  const toolCalls = [{ id: 'tool-0', name: 'demo', status: 'success' as const }];
+  const thinking = [{ content: '整理今日资讯。' }];
+  const storedSegments = [
+    { type: 'thinking' as const, index: 0 },
+    { type: 'tool' as const, index: 0 },
+    {
+      type: 'text' as const,
+      text: '<think>不应显示的迟到尾巴</think>内部产业资讯数据源今日暂时无法返回。',
+    },
   ];
-  const { segments, cleanContent } = buildHistorySegments(content, toolCalls);
+  const { segments, cleanContent } = buildHistorySegments(
+    content,
+    toolCalls,
+    thinking,
+    storedSegments,
+  );
   assert.deepEqual(segments, [
-    tool(0),
     { type: 'thinking', content: '整理今日资讯。' },
+    tool(0),
+    { type: 'thinking', content: '不应显示的迟到尾巴' },
     { type: 'text', content: '内部产业资讯数据源今日暂时无法返回。' },
   ]);
   assert.equal(cleanContent, '内部产业资讯数据源今日暂时无法返回。');
 }
 
 {
-  // Artifact pseudo-cards (appended from metadata.artifacts without offsets)
-  // must not knock the whole message back to the stacked fallback — they sort
-  // to the end while real tool calls keep their recorded interleave.
+  // Artifact pseudo-cards appended after loading are absent from the stored
+  // table. They still render above the final answer without disturbing the
+  // recorded real-tool interleave.
   const content = '先查询。查询完成，结论如下。';
   const toolCalls = [
-    { id: 'tool-0', name: 'demo', status: 'success' as const, contentOffset: '先查询。'.length },
+    { id: 'tool-0', name: 'demo', status: 'success' as const },
     { id: 'artifact_f1', name: '附件', status: 'success' as const },
   ];
-  const { segments, cleanContent } = buildHistorySegments(content, toolCalls);
+  const storedSegments = [
+    { type: 'text' as const, text: '先查询。' },
+    { type: 'tool' as const, index: 0 },
+    { type: 'text' as const, text: '查询完成，结论如下。' },
+  ];
+  const { segments, cleanContent } = buildHistorySegments(
+    content,
+    toolCalls,
+    undefined,
+    storedSegments,
+  );
   // 工具/附件卡不允许落在正文末尾之后：排尾的附件卡挪到最终答案上方
   assert.deepEqual(segments, [
     { type: 'text', content: '先查询。' },
@@ -282,8 +315,8 @@ function tool(toolIndex: number): MessageSegment {
 }
 
 {
-  // Visible narration emitted between reasoning rounds must survive history
-  // cleanup, while still rendering as one answer block.
+  // Multiple inline reasoning blocks in legacy history are stripped from the
+  // body, but no process order is fabricated for them.
   const toolCalls = [0, 1].map((i) => ({
     id: `thinking-tool-${i}`,
     name: 'demo',
@@ -295,13 +328,7 @@ function tool(toolIndex: number): MessageSegment {
   );
 
   assert.equal(cleanContent, '第一段第二段第三段');
-  assert.deepEqual(segments, [
-    { type: 'thinking', content: '思考一' },
-    tool(0),
-    { type: 'thinking', content: '思考二' },
-    tool(1),
-    { type: 'text', content: '第一段第二段第三段' },
-  ]);
+  assert.equal(segments, undefined);
 }
 
 {
@@ -313,11 +340,7 @@ function tool(toolIndex: number): MessageSegment {
   );
 
   assert.equal(cleanContent, '这是最终回答。');
-  assert.deepEqual(segments, [
-    { type: 'thinking', content: '先分析用户问题，再决定调用工具' },
-    tool(0),
-    { type: 'text', content: '这是最终回答。' },
-  ]);
+  assert.equal(segments, undefined);
 }
 
 {
@@ -329,11 +352,7 @@ function tool(toolIndex: number): MessageSegment {
   );
 
   assert.equal(cleanContent, '这是结构化模型的正文。');
-  assert.deepEqual(segments, [
-    { type: 'thinking', content: '结构化 reasoning 字段里的内容' },
-    tool(0),
-    { type: 'text', content: '这是结构化模型的正文。' },
-  ]);
+  assert.equal(segments, undefined);
 }
 
 {

--- a/src/frontend/src/hooks/useChatInit.ts
+++ b/src/frontend/src/hooks/useChatInit.ts
@@ -10,7 +10,7 @@ import { stripMcpToolPrefix } from '../utils/constants';
 import { parseContextCompactionState, parseContextUsageSnapshot } from '../utils/contextUsage';
 import { shouldRestorePlanModeFromHistory } from '../utils/chatMode';
 import { LOGIN_LANDING_KEY, useAuthStore, useSettingsStore, useUIStore, useChatStore, useCatalogStore, useAutomationChatStore, useBatchStore, useSidebarOrderStore } from '../stores';
-import type { Catalog, ChatItem, ChatMessage, CitationItem, ContextCompactionState, ContextUsageSnapshot, EvolutionSummary, OntologyGovernanceSummary, ThinkingBlock, ToolCall, UpdateEntry, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
+import type { Catalog, ChatItem, ChatMessage, CitationItem, ContextCompactionState, ContextUsageSnapshot, EvolutionSummary, OntologyGovernanceSummary, StoredSegment, ThinkingBlock, ToolCall, UpdateEntry, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
 
 const effectiveApiUrl = (import.meta.env.VITE_API_BASE_URL as string || '').trim() || '/api';
 
@@ -138,12 +138,6 @@ function parseHistoryMessage(m: any): ChatMessage {
           ? { subagentName: tc.subagent_name ?? tc.subagentName }
           : {}),
         ...(typeof tc.scope === 'string' ? { scope: tc.scope } : {}),
-        ...(typeof (tc.content_offset ?? tc.contentOffset) === 'number'
-          ? { contentOffset: (tc.content_offset ?? tc.contentOffset) }
-          : {}),
-        ...(typeof (tc.step_seq ?? tc.stepSeq) === 'number'
-          ? { stepSeq: (tc.step_seq ?? tc.stepSeq) }
-          : {}),
         // 历史列表只给了梗概；展开这张卡时 ToolCallRow 会按需回取完整结果。
         ...(tc.result_truncated === true ? { outputTruncated: true } : {}),
       }))
@@ -160,18 +154,14 @@ function parseHistoryMessage(m: any): ChatMessage {
   const rawContent = String(m.content || '');
   // 思考单独存一列（新消息）；老消息该字段为空，思考仍内联在 content 里。
   const storedThinking = Array.isArray(m.thinking)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ? (m.thinking as any[])
-        .filter((b) => b && typeof b.content === 'string')
-        .map((b): ThinkingBlock => ({
-          ...b,
-          ...(typeof (b.step_seq ?? b.stepSeq) === 'number'
-            ? { stepSeq: (b.step_seq ?? b.stepSeq) }
-            : {}),
-        }))
+    ? (m.thinking as ThinkingBlock[]).filter((b) => b && typeof b.content === 'string')
+    : undefined;
+  // 展示顺序由后端在流式那一刻记下，落在 metadata.segments；这里原样取出。
+  const storedSegments = Array.isArray(m.metadata?.segments)
+    ? (m.metadata.segments as StoredSegment[])
     : undefined;
   let { segments, cleanContent } = m.role === 'assistant'
-    ? buildHistorySegments(rawContent, toolCalls, storedThinking)
+    ? buildHistorySegments(rawContent, toolCalls, storedThinking, storedSegments)
     : { segments: undefined, cleanContent: rawContent };
 
   // Reconstruct plan segment from saved plan_snapshot metadata

--- a/src/frontend/src/types.ts
+++ b/src/frontend/src/types.ts
@@ -189,13 +189,6 @@ export interface ToolCall {
    *  工具跑完后由 tool_result 说明结局，历史里不该留一行过期数字。 */
   progressNote?: string;
   scope?: 'ontology_revision' | string;
-  /**
-   * 该工具卡片出现时，持久化正文（含 <think> 标记）的累计字符偏移。
-   * 历史重建按此偏移把「文本 ↔ 工具卡片」按流式原顺序交错还原。
-   */
-  contentOffset?: number;
-  /** 与思考块共用的先后号，同一 contentOffset 下靠它排序。见 ThinkingBlock.stepSeq。 */
-  stepSeq?: number;
   /** 历史列表只给了梗概，完整结果要展开时按需回取（后端 result_truncated）。 */
   outputTruncated?: boolean;
   /** 已经按需取回过完整结果，别重复请求。 */
@@ -267,18 +260,19 @@ export interface UserQuestionAnswer {
 export interface ThinkingBlock {
   content: string;
   timestamp?: number;
-  /**
-   * 该思考块出现时正文的字符偏移。落库时思考与正文分列存储（互不挤占长度上限），
-   * 靠这个偏移把它还原回正文里原来的位置——展示顺序与实时流式时一模一样。
-   * 实时流式的块没有它（位置由 segments 直接决定）。
-   */
-  offset?: number;
-  /**
-   * 落库时统一发的先后号，跨思考块与工具卡片单调递增。两次可见正文之间发生的
-   * 一切共用同一个 offset，只有这个号能排出它们真正的先后。老消息没有。
-   */
-  stepSeq?: number;
 }
+
+/**
+ * 一条历史消息的展示顺序，落库在 `metadata.segments`。
+ *
+ * 顺序在实时流式的那一刻就已确定，后端原样记下来；刷新后照着渲染，不再从字符偏移
+ * 之类的辅助字段反推。正文片段内联，思考与工具卡片按下标引用 `thinking` /
+ * `tool_calls` 两列，长推理不会被存两份。
+ */
+export type StoredSegment =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; index: number }
+  | { type: 'tool'; index: number };
 
 export interface OntologyActivationSummary {
   pack_id?: string;
@@ -1536,7 +1530,7 @@ export interface AdminChatMessage {
   tool_calls: unknown;
   usage: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number } | null;
   error: unknown;
-  metadata: unknown;
+  metadata?: { segments?: StoredSegment[] } | null;
   created_at: string;
 }
 

--- a/src/frontend/src/utils/segments.ts
+++ b/src/frontend/src/utils/segments.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, MessageSegment, ThinkingBlock } from '../types';
+import type { ChatMessage, MessageSegment, StoredSegment, ThinkingBlock } from '../types';
 import { isSingleHanCharacter, liftTrailingSegmentsAboveFinalText } from './streamSegments';
 
 /**
@@ -122,156 +122,94 @@ function parseHistoricalContent(content: string): {
   return { thinkingContents, visibleContent: visibleContent.trim() };
 }
 
-/** 一个待还原的过程步骤：思考块或工具卡片，带它在正文里的位置与先后号。 */
-type StoredStep =
-  | { kind: 'thinking'; at: number; seq: number | undefined; order: number; content: string }
-  | { kind: 'tool'; at: number; seq: number | undefined; order: number; toolIndex: number };
-
 /**
- * 把两列结构化数据（thinking 与 toolCalls）归并成一条按发生顺序排列的步骤表。
+ * 按落库的段落表还原一条历史消息的展示形态。
  *
- * 思考早已单独存进 chat_messages.thinking，正文里不再有它——所以还原时不必把
- * `<think>` 拼回正文再切一遍，直接按位置排就行。offset 与 contentOffset 都是
- * 落库正文的字符偏移，同一坐标系，可直接比较。
- *
- * 两次可见正文之间发生的一切共用同一个 offset，光比 offset 排不出先后，得靠落库
- * 时统一发的 step_seq。老消息没有这个号，退回旧规则：同一位置上思考排在工具卡片
- * 之前（当时的落库顺序就是先 flush 思考再记卡片位置）。
+ * 正文、思考、工具卡片的先后，在实时流式的那一刻就已经确定，落库时原样记进
+ * `metadata.segments`，这里照着渲染即可——不做任何位置反推。段落表里正文片段内联，
+ * 思考与工具卡片按下标引用各自的列。
  */
-function mergeStoredSteps(
-  contentLength: number,
+function renderStoredSegments(
+  stored: StoredSegment[],
   toolCalls: ChatMessage['toolCalls'],
   thinking: ThinkingBlock[] | undefined,
-): StoredStep[] {
-  const clamp = (value: unknown): number =>
-    typeof value === 'number' && value >= 0 ? Math.min(value, contentLength) : contentLength;
+): { segments: MessageSegment[] | undefined; cleanContent: string } {
+  const segments: MessageSegment[] = [];
+  const placedTools = new Set<number>();
+  let visibleAll = '';
 
-  const steps: StoredStep[] = [];
-  (thinking ?? []).forEach((block, order) => {
-    if (!block?.content) return;
-    steps.push({
-      kind: 'thinking',
-      at: clamp(block.offset),
-      seq: typeof block.stepSeq === 'number' ? block.stepSeq : undefined,
-      order,
-      content: block.content,
-    });
-  });
-  (toolCalls ?? []).forEach((tc, toolIndex) => {
-    steps.push({
-      kind: 'tool',
-      at: clamp(tc.contentOffset),
-      seq: typeof tc.stepSeq === 'number' ? tc.stepSeq : undefined,
-      order: toolIndex,
-      toolIndex,
-    });
+  stored.forEach((entry) => {
+    if (entry.type === 'text') {
+      // 内联 reasoning 的模型会把 <think> 写进正文流，这里照旧剥掉，
+      // 否则推理过程会当作正文渲染出来。
+      const visible = segmentTextSlice(entry.text || '', segments);
+      if (visible) visibleAll += (visibleAll ? '\n\n' : '') + visible;
+      return;
+    }
+    if (entry.type === 'thinking') {
+      const block = thinking?.[entry.index];
+      if (block?.content) segments.push({ type: 'thinking', content: block.content });
+      return;
+    }
+    if (toolCalls && entry.index >= 0 && entry.index < toolCalls.length) {
+      placedTools.add(entry.index);
+      segments.push({ type: 'tool', toolIndex: entry.index });
+    }
   });
 
-  const legacyKindRank = (step: StoredStep) => (step.kind === 'thinking' ? 0 : 1);
-  return steps.sort((a, b) => {
-    if (a.at !== b.at) return a.at - b.at;
-    if (a.seq !== undefined && b.seq !== undefined) return a.seq - b.seq;
-    if (a.kind !== b.kind) return legacyKindRank(a) - legacyKindRank(b);
-    return a.order - b.order;
+  // 附件伪工具卡（attachArtifactsToToolCalls 在加载后追加的 artifact_*）不在段落表
+  // 里，它们描述的是本条消息的产物，排在最后。
+  (toolCalls ?? []).forEach((_, index) => {
+    if (!placedTools.has(index)) segments.push({ type: 'tool', toolIndex: index });
   });
+
+  // 与实时视图一致的碎片归并：思考型模型偶尔把下一句的首个汉字与工具调用同轮吐出，
+  // 实时侧用 deferThinkingTextFragmentBeforeTool 把它挪到工具卡之后的正文开头——
+  // 历史照做同样的归并，刷新前后才逐字一致。
+  for (let i = segments.length - 2; i >= 0; i--) {
+    const seg = segments[i];
+    if (seg.type !== 'text' || !isSingleHanCharacter(seg.content || '')) continue;
+    if (segments[i + 1]?.type !== 'tool') continue;
+    const followsProcess = segments
+      .slice(0, i)
+      .some((s) => s.type === 'tool' || s.type === 'thinking');
+    if (!followsProcess) continue;
+    const next = segments.slice(i + 1).find((s) => s.type === 'text');
+    if (!next) continue;
+    next.content = (seg.content || '') + (next.content || '');
+    segments.splice(i, 1);
+  }
+  // 硬规则：工具卡/思考块不允许落在正文末尾之后——最终答案必须是消息的最后一段。
+  liftTrailingSegmentsAboveFinalText(segments);
+
+  const lastToolIdx = segments.map((s) => s.type).lastIndexOf('tool');
+  const tailText = segments
+    .slice(lastToolIdx + 1)
+    .filter((s) => s.type === 'text')
+    .map((s) => s.content || '')
+    .join('\n\n');
+  return {
+    segments: segments.length > 0 ? segments : undefined,
+    cleanContent: tailText || visibleAll,
+  };
 }
 
+/**
+ * 还原一条历史消息：有落库的段落表就照它渲染，没有就只给正文。
+ *
+ * 没有段落表的老消息**不做顺序反推**——展示顺序在当时没有被记下来，猜出来的顺序
+ * 只会是错的。这类消息退化成「正文 + 工具卡片」的堆叠展示，正文里内联的 `<think>`
+ * 仍会剥掉，避免推理过程漏成正文。
+ */
 export function buildHistorySegments(
   rawContent: string,
   rawToolCalls?: ChatMessage['toolCalls'],
-  thinking?: ThinkingBlock[]
+  thinking?: ThinkingBlock[],
+  storedSegments?: StoredSegment[] | null,
 ): { segments: MessageSegment[] | undefined; cleanContent: string } {
-  // thinking 为空则是老消息，思考仍内联在 content 里，走下面的兜底解析。
-  const hasStoredThinking = Array.isArray(thinking) && thinking.length > 0;
-  const content = rawContent;
-  const toolCalls = rawToolCalls;
-  // ── 新历史：思考块与工具卡片都带位置，按发生顺序与正文交错还原 ──
-  // 思考存在 chat_messages.thinking 独立一列，正文里没有它；两列的 offset /
-  // contentOffset 是同一坐标系，直接归并即可，不必把 `<think>` 拼回正文再解析。
-  // 切出来的正文片段仍走 segmentTextSlice：内联 reasoning 的模型可能在正文里
-  // 留下 `<think>`，那部分照旧要剥离。刷新后与实时流式展示一致（问题15）。
-  // 附件伪工具卡（attachArtifactsToToolCalls 追加的 artifact_*）没有 offset，
-  // 视为「排在正文末尾」，不因它们把整条消息打回堆叠兜底。
-  const isArtifactCard = (tc: NonNullable<ChatMessage['toolCalls']>[number]) =>
-    typeof tc.id === 'string' && tc.id.startsWith('artifact_');
-  const hasOffsets = Array.isArray(toolCalls)
-    && toolCalls.length > 0
-    && toolCalls.some((tc) => typeof tc.contentOffset === 'number')
-    && toolCalls.every((tc) => typeof tc.contentOffset === 'number' || isArtifactCard(tc));
-  // 思考单独存一列时每块都带确切位置，没有工具卡片也照样能原位还原——不必退回
-  // 「合并正文」的兜底（那条路会把思考全堆到正文前面，位置就乱了）。
-  if (hasOffsets || (hasStoredThinking && (toolCalls?.length ?? 0) === 0)) {
-    const segments: MessageSegment[] = [];
-    let cursor = 0;
-    let visibleAll = '';
-    const takeVisibleUpTo = (at: number) => {
-      const off = Math.min(Math.max(at, cursor), content.length);
-      const visible = segmentTextSlice(content.slice(cursor, off), segments);
-      if (visible) visibleAll += (visibleAll ? '\n\n' : '') + visible;
-      cursor = off;
-    };
-    mergeStoredSteps(content.length, toolCalls, hasStoredThinking ? thinking : undefined)
-      .forEach((step) => {
-        takeVisibleUpTo(step.at);
-        if (step.kind === 'tool') segments.push({ type: 'tool', toolIndex: step.toolIndex });
-        else segments.push({ type: 'thinking', content: step.content });
-      });
-    const finalVisible = segmentTextSlice(content.slice(cursor), segments);
-    if (finalVisible) visibleAll += (visibleAll ? '\n\n' : '') + finalVisible;
-    // 与实时视图一致的碎片归并：思考型模型偶尔把下一句的首个汉字与工具调用
-    // 同轮吐出，实时侧用 deferThinkingTextFragmentBeforeTool 把它挪到工具卡
-    // 之后的正文开头——历史重建做同样的归并，刷新前后展示才逐字一致。
-    for (let i = segments.length - 2; i >= 0; i--) {
-      const seg = segments[i];
-      if (seg.type !== 'text' || !isSingleHanCharacter(seg.content || '')) continue;
-      if (segments[i + 1]?.type !== 'tool') continue;
-      const followsProcess = segments
-        .slice(0, i)
-        .some((s) => s.type === 'tool' || s.type === 'thinking');
-      if (!followsProcess) continue;
-      const next = segments.slice(i + 1).find((s) => s.type === 'text');
-      if (!next) continue;
-      next.content = (seg.content || '') + (next.content || '');
-      segments.splice(i, 1);
-    }
-    // 硬规则：工具卡/思考块不允许落在正文末尾之后——最终答案必须是消息的
-    // 最后一段。
-    liftTrailingSegmentsAboveFinalText(segments);
-    const lastToolIdx = segments.map((s) => s.type).lastIndexOf('tool');
-    const tailText = segments
-      .slice(lastToolIdx + 1)
-      .filter((s) => s.type === 'text')
-      .map((s) => s.content || '')
-      .join('\n\n');
-    return {
-      segments: segments.length > 0 ? segments : undefined,
-      // cleanContent 维持「最终可见正文」语义：取最后一个工具卡之后的文本；没有则用全部可见文本
-      cleanContent: tailText || visibleAll,
-    };
+  if (Array.isArray(storedSegments) && storedSegments.length > 0) {
+    return renderStoredSegments(storedSegments, rawToolCalls, thinking);
   }
-
-  // ── 兜底（无 contentOffset 的旧历史）：reasoning 块与工具卡片配对，可见
-  // 正文合并成一个 Markdown 块，避免瞎猜切分点。 ──
-  // Both reasoning protocols are normalized in persisted content:
-  // - inline models may emit `reasoning</think>answer` without an opening tag;
-  // - structured reasoning events are stored as `<think>reasoning</think>`.
-  const { thinkingContents, visibleContent } = parseHistoricalContent(content);
-  const toolCount = toolCalls?.length ?? 0;
-  const segments: MessageSegment[] = [];
-  thinkingContents.forEach((thinking, idx) => {
-    segments.push({ type: 'thinking', content: thinking });
-    if (idx < toolCount) segments.push({ type: 'tool', toolIndex: idx });
-  });
-
-  // Any calls left after pairing with reasoning still happened before the
-  // final answer, so keep them above the answer instead of dumping them below.
-  for (let i = thinkingContents.length; i < toolCount; i++) {
-    segments.push({ type: 'tool', toolIndex: i });
-  }
-  if (visibleContent) segments.push({ type: 'text', content: visibleContent });
-
-  return {
-    segments: segments.length > 0 ? segments : undefined,
-    cleanContent: visibleContent,
-  };
+  const { visibleContent } = parseHistoricalContent(rawContent);
+  return { segments: undefined, cleanContent: visibleContent };
 }


### PR DESCRIPTION
## Summary

- persist one ordered `metadata.segments` timeline while streaming text, reasoning, and tool cards
- replay stored history directly from that timeline instead of reconstructing order from character offsets and sequence helpers
- keep reasoning truncation and segment references aligned, with updated backend and frontend regression coverage

## Public repository comparison

This CE tree was derived from private branch `aaronzhu` at `ec83fb9e` and compared with public `main` at `90a56e10`.

- 10 modified files
- 377 insertions
- 353 deletions
- no enterprise-only files included

## Validation

- CE brand, binary asset, required-file, forbidden-artifact, and license gates
- CE import, OpenAPI, and ORM contract checks
- CE release regression suite
- targeted thinking/display-order persistence tests: 8 passed
- frontend production image build with Node.js 22
- `git diff --check`
