### PR TITLE
Sync chat recovery and reduced-motion improvements

### DIFF
--- a/src/backend/api/routes/v1/chats.py
+++ b/src/backend/api/routes/v1/chats.py
@@ -1592,6 +1592,27 @@ async def chat_active_run(
 # ── Regenerate / Edit ────────────────────────────────────────────────────
 
 
+# Explicit per-turn selections persisted on the user message. Regenerating or
+# editing that turn must replay the same skill / plugin / connector / @agent,
+# otherwise the rerun silently loses the capabilities the user picked.
+_INVOCATION_EXTRA_KEYS = (
+    "skill_id",
+    "skill_name",
+    "skill_ids",
+    "mcp_ids",
+    "connector_id",
+    "connector_name",
+    "plugin_name",
+    "mention_agent_id",
+    "mention_name",
+)
+
+
+def _restore_invocation(extra: Any) -> Dict[str, Any]:
+    """Rebuild the original turn's invocation fields from extra_data."""
+    return {key: extra[key] for key in _INVOCATION_EXTRA_KEYS if extra.get(key)}
+
+
 def _restore_attachments(saved: List[Dict]) -> List[AttachmentItem]:
     """Reconstruct AttachmentItem list from extra_data['attachments'] metadata."""
     return [
@@ -1952,6 +1973,7 @@ async def regenerate_message(
         quoted_follow_up=user_extra.get("quoted_follow_up"),
         attachments=attachment_items,
         model_provider_id=user_extra.get("model_provider_id"),
+        **_restore_invocation(user_extra),
     )
     selected_model_provider_id = _resolve_selected_model_provider_id(db, regen_request, db_user_id)
     actual_model_name = _resolve_actual_chat_model_name(
@@ -2047,13 +2069,19 @@ async def edit_and_resend(
     target_extra = target_msg.extra_data or {}
     saved_attachments = target_extra.get("attachments", [])
     attachment_items = _restore_attachments(saved_attachments)
+    # Editing rewrites the text only: the files the user uploaded and the
+    # skill / plugin / connector / @agent this turn referenced are carried over.
+    saved_invocation = _restore_invocation(target_extra)
+    saved_quoted_follow_up = target_extra.get("quoted_follow_up")
 
     edit_request = ChatRequest(
         chat_id=chat_id,
         message=body.new_content,
         model_name="qwen",
         attachments=attachment_items,
+        quoted_follow_up=saved_quoted_follow_up,
         model_provider_id=target_extra.get("model_provider_id"),
+        **saved_invocation,
     )
     selected_model_provider_id = _resolve_selected_model_provider_id(db, edit_request, db_user_id)
     actual_model_name = _resolve_actual_chat_model_name(edit_request, selected_model_provider_id)
@@ -2061,9 +2089,11 @@ async def edit_and_resend(
     _user_settings = UserService(db).get_user_settings(db_user_id)
 
     # Persist the edited user message
-    _edit_extra: Dict[str, Any] = {"timestamp": now_iso()}
+    _edit_extra: Dict[str, Any] = {"timestamp": now_iso(), **saved_invocation}
     if saved_attachments:
         _edit_extra["attachments"] = saved_attachments
+    if saved_quoted_follow_up:
+        _edit_extra["quoted_follow_up"] = saved_quoted_follow_up
     if selected_model_provider_id:
         _edit_extra["model_provider_id"] = selected_model_provider_id
 
@@ -2109,7 +2139,9 @@ async def edit_and_resend(
             chat_id=chat_id,
             user_id=db_user_id,
             session_messages=session_messages,
-            effective_user_message=body.new_content,
+            effective_user_message=_build_effective_user_message(
+                body.new_content, edit_request.quoted_follow_up
+            ),
             raw_user_message=body.new_content,
             context=context,
             model_name=actual_model_name,

--- a/src/backend/core/infra/redis.py
+++ b/src/backend/core/infra/redis.py
@@ -12,15 +12,92 @@ from core.infra.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Two pools per event loop, because the two workloads have opposite shapes.
+#
+# General traffic is short request/response commands (session lookups on every
+# authenticated request, locks, ticket stores). Chat-stream followers instead
+# sit in `XREAD BLOCK 5000`, which holds its connection for the whole block and
+# immediately re-issues — so one live SSE follower occupies ~one connection
+# continuously. Sharing a single pool means N concurrent viewers starve login
+# and every other API call, and redis-py raises `MaxConnectionsError` at once
+# rather than queueing. Separate pools keep a burst of followers confined to
+# their own budget.
+_GENERAL_MAX_CONNECTIONS = 100
+_STREAM_MAX_CONNECTIONS = 200
+
 _redis_pools: WeakKeyDictionary[asyncio.AbstractEventLoop, aioredis.Redis] = (
+    WeakKeyDictionary()
+)
+_stream_pools: WeakKeyDictionary[asyncio.AbstractEventLoop, aioredis.Redis] = (
     WeakKeyDictionary()
 )
 _redis_pools_lock = threading.Lock()
 _fake_server: Optional[object] = None
 
 
-def get_redis() -> aioredis.Redis:
+def _create_client(max_connections: int) -> tuple[aioredis.Redis, str]:
+    """Build one client; ``memory://`` returns a shared in-process fake."""
+    global _fake_server
+    url = settings.redis.url
+    if url.startswith("memory://"):
+        import fakeredis.aioredis as _fakeredis
+
+        if _fake_server is None:
+            _fake_server = _fakeredis.FakeServer()
+        return (
+            _fakeredis.FakeRedis(server=_fake_server, decode_responses=True),
+            "fakeredis",
+        )
+    # NOTE: redis-py 8.0 changed the default socket_timeout from None -> 5s.
+    # The chat-stream follower blocks on `XREAD BLOCK 5000`; if the socket
+    # timeout equals the block (5s) it fires the moment the server returns
+    # its nil reply, raising a spurious "Timeout reading from redis" on
+    # every idle 5s window (log spam + connection churn during long runs).
+    # Pin an explicit timeout that stays well above any BLOCK we issue.
+    client = aioredis.from_url(
+        url,
+        decode_responses=True,
+        max_connections=max_connections,
+        socket_timeout=settings.redis.socket_timeout,
+        socket_keepalive=True,
+        health_check_interval=30,
+    )
+    return client, "redis"
+
+
+def _get_pooled(
+    pools: "WeakKeyDictionary[asyncio.AbstractEventLoop, aioredis.Redis]",
+    *,
+    max_connections: int,
+    role: str,
+) -> aioredis.Redis:
+    loop = asyncio.get_running_loop()
+    with _redis_pools_lock:
+        existing = pools.get(loop)
+        if existing is not None:
+            return existing
+        client, backend = _create_client(max_connections)
+        pools[loop] = client
+        logger.info(
+            "redis_pool_created",
+            url=settings.redis.url.split("@")[-1],  # hide password
+            socket_timeout=settings.redis.socket_timeout,
+            backend=backend,
+            role=role,
+            max_connections=max_connections,
+            event_loop=id(loop),
+        )
+        return client
+
+
+def get_redis(*, blocking: bool = False) -> aioredis.Redis:
     """Get or create the Redis client owned by the current event loop.
+
+    ``blocking=True`` returns the pool reserved for commands that park on the
+    connection (the chat-stream follower's ``XREAD BLOCK``). It stays one
+    function so that redirecting Redis — in a test, or behind a different
+    backend — needs exactly one seam and cannot leave the two pools pointing at
+    different servers.
 
     redis-py async connections bind to the loop that first uses them. The
     backend also runs sub-agents in dedicated thread-local loops, so one
@@ -35,55 +112,23 @@ def get_redis() -> aioredis.Redis:
     an **explicit** opt-in value — we never silently fall back on a connection
     error, so a mis-configured production Redis surfaces as a hard failure.
     """
-    global _fake_server
-    loop = asyncio.get_running_loop()
-    with _redis_pools_lock:
-        existing = _redis_pools.get(loop)
-        if existing is not None:
-            return existing
-
-        url = settings.redis.url
-        if url.startswith("memory://"):
-            import fakeredis.aioredis as _fakeredis
-
-            if _fake_server is None:
-                _fake_server = _fakeredis.FakeServer()
-            client = _fakeredis.FakeRedis(
-                server=_fake_server, decode_responses=True
-            )
-            backend = "fakeredis"
-        else:
-            # NOTE: redis-py 8.0 changed the default socket_timeout from None -> 5s.
-            # The chat-stream follower blocks on `XREAD BLOCK 5000`; if the socket
-            # timeout equals the block (5s) it fires the moment the server returns
-            # its nil reply, raising a spurious "Timeout reading from redis" on
-            # every idle 5s window (log spam + connection churn during long runs).
-            # Pin an explicit timeout that stays well above any BLOCK we issue.
-            client = aioredis.from_url(
-                url,
-                decode_responses=True,
-                max_connections=20,
-                socket_timeout=settings.redis.socket_timeout,
-                socket_keepalive=True,
-                health_check_interval=30,
-            )
-            backend = "redis"
-        _redis_pools[loop] = client
-        logger.info(
-            "redis_pool_created",
-            url=url.split("@")[-1],  # hide password
-            socket_timeout=settings.redis.socket_timeout,
-            backend=backend,
-            event_loop=id(loop),
+    if blocking:
+        return _get_pooled(
+            _stream_pools, max_connections=_STREAM_MAX_CONNECTIONS, role="stream"
         )
-        return client
+    return _get_pooled(
+        _redis_pools, max_connections=_GENERAL_MAX_CONNECTIONS, role="general"
+    )
 
 
 async def close_redis() -> None:
-    """Close the Redis client owned by the current event loop."""
+    """Close every Redis client owned by the current event loop."""
     loop = asyncio.get_running_loop()
     with _redis_pools_lock:
-        client = _redis_pools.pop(loop, None)
-    if client is not None:
-        await client.aclose()
-        logger.info("redis_pool_closed", event_loop=id(loop))
+        clients = [
+            pools.pop(loop, None) for pools in (_redis_pools, _stream_pools)
+        ]
+    for client in clients:
+        if client is not None:
+            await client.aclose()
+    logger.info("redis_pool_closed", event_loop=id(loop))

--- a/src/backend/core/services/compaction_service.py
+++ b/src/backend/core/services/compaction_service.py
@@ -660,6 +660,7 @@ class CompactionCoordinator:
                 return None
             inputs = dict(budget_inputs or {})
             if self.hook_bus is not None:
+                from core.harness.events import thaw_value
                 from core.harness.hooks import HookStage, Invocation
 
                 before = await self.hook_bus.enforce(
@@ -671,9 +672,9 @@ class CompactionCoordinator:
                     )
                 )
                 if before.data.get("history") is not None:
-                    history = list(before.data["history"])
+                    history = thaw_value(before.data["history"])
                 if before.data.get("budget") is not None:
-                    inputs = dict(before.data["budget"])
+                    inputs = thaw_value(before.data["budget"])
             inputs["messages"] = history
             if "system_prompt" not in inputs:
                 inputs["system_prompt"] = _load_base_system_prompt()
@@ -701,6 +702,7 @@ class CompactionCoordinator:
                 max_tokens=cfg.recent_user_max_tokens,
             )
             if self.hook_bus is not None:
+                from core.harness.events import thaw_value
                 from core.harness.hooks import HookStage, Invocation
 
                 after = await self.hook_bus.enforce(
@@ -712,7 +714,7 @@ class CompactionCoordinator:
                     )
                 )
                 if after.data.get("replacement") is not None:
-                    replacement = list(after.data["replacement"])
+                    replacement = thaw_value(after.data["replacement"])
             manifest: Dict[str, Any] = {
                 "phase": phase.value,
                 "source_high_watermark_seq": snapshot.covered_seq,

--- a/src/backend/orchestration/chat_run_executor.py
+++ b/src/backend/orchestration/chat_run_executor.py
@@ -2014,8 +2014,12 @@ async def follow_run(run_id: str, *, from_offset: int = 0) -> AsyncIterator[Dict
     2. XREAD STREAMS key {last_id} BLOCK 5000 blocks waiting for new events
     3. Stop when a ``__terminal__``-typed event is received
     4. Block timeout + run in a terminal state → exit gracefully (backstop so the follower never hangs forever)
+
+    Uses the dedicated stream pool: the blocking read below holds its
+    connection for the whole BLOCK window, so followers must not draw from the
+    connections that ordinary API requests need.
     """
-    redis = get_redis()
+    redis = get_redis(blocking=True)
     key = _stream_key(run_id)
 
     run = get_run(run_id)

--- a/src/backend/tests/api/test_chat_stream_sequencer.py
+++ b/src/backend/tests/api/test_chat_stream_sequencer.py
@@ -398,6 +398,86 @@ def test_edit_busy_does_not_delete_existing_history(monkeypatch, tmp_path):
     engine.dispose()
 
 
+def test_edit_replays_original_turn_invocation(monkeypatch, tmp_path):
+    import api.routes.v1.chats as chats
+    from core.services.chat_service import ChatService
+    from orchestration import chat_run_executor
+
+    engine, Session = _route_database(tmp_path, "edit-invocation.db")
+    saved_extra = {
+        "attachments": [{"name": "a.png", "mime_type": "image/png", "file_id": "file-1"}],
+        "skill_id": "skill-1",
+        "skill_name": "PPT 设计",
+        "skill_ids": ["skill-1"],
+        "mcp_ids": ["mcp-1"],
+        "connector_id": "mcp-1",
+        "connector_name": "内网检索",
+        "plugin_name": "办公套件",
+        "mention_agent_id": "agent-1",
+        "mention_name": "研究员",
+        "quoted_follow_up": {"text": "原文引用"},
+    }
+    with Session() as db:
+        service = ChatService(db)
+        service.add_message(
+            chat_id="chat-1", role="user", content="old wording", extra_data=saved_extra
+        )
+        service.add_message(chat_id="chat-1", role="assistant", content="old reply")
+
+    _patch_common_chat_route(monkeypatch, chats)
+    captured = {}
+
+    def capture_ctx(request, *_args, **_kwargs):
+        captured["request"] = request
+        return {}
+
+    monkeypatch.setattr(chats, "_build_ctx", capture_ctx)
+    monkeypatch.setattr(chats, "_load_session_messages", lambda *_args: [])
+    monkeypatch.setattr(chats, "_release_request_session", lambda _db: None)
+    monkeypatch.setattr(chats, "sse_response", lambda stream: stream)
+    monkeypatch.setattr(chat_run_executor, "follow_run_as_sse", lambda *_a, **_k: None)
+
+    async def fake_start_run(**kwargs):
+        captured["start_run"] = kwargs
+        return kwargs["accepted_run"]
+
+    monkeypatch.setattr(chat_run_executor, "start_run", fake_start_run)
+
+    with Session() as db:
+        asyncio.run(
+            chats.edit_and_resend(
+                "chat-1",
+                chats.EditAndResendRequest(message_index=0, new_content="new wording"),
+                user=_user(),
+                db=db,
+            )
+        )
+
+    request = captured["request"]
+    assert [item.file_id for item in request.attachments] == ["file-1"]
+    assert (request.skill_id, request.skill_name) == ("skill-1", "PPT 设计")
+    assert (request.connector_id, request.connector_name) == ("mcp-1", "内网检索")
+    assert request.mcp_ids == ["mcp-1"]
+    assert request.plugin_name == "办公套件"
+    assert (request.mention_agent_id, request.mention_name) == ("agent-1", "研究员")
+    assert "原文引用" in captured["start_run"]["effective_user_message"]
+
+    with Session() as db:
+        edited = (
+            db.query(ChatMessage)
+            .filter(ChatMessage.role == "user")
+            .order_by(ChatMessage.chat_seq)
+            .all()[-1]
+        )
+    assert edited.content == "new wording"
+    assert edited.extra_data["attachments"] == saved_extra["attachments"]
+    assert edited.extra_data["skill_name"] == "PPT 设计"
+    assert edited.extra_data["connector_name"] == "内网检索"
+    assert edited.extra_data["plugin_name"] == "办公套件"
+    assert edited.extra_data["mention_name"] == "研究员"
+    engine.dispose()
+
+
 def test_batch_resume_busy_does_not_delete_triggering_turn(monkeypatch, tmp_path):
     import api.routes.v1.batch as batch
     import api.routes.v1.chats as chats

--- a/src/backend/tests/llm/test_compaction_e2e.py
+++ b/src/backend/tests/llm/test_compaction_e2e.py
@@ -160,3 +160,44 @@ async def test_second_compaction_rolls_summary_not_resummarize(patched_sessionlo
     assert "summary-v2" in ck.content
     # Both times actually called the summarizer (rolling), without re-counting the old summary as a user message
     assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_compaction_commits_when_the_hook_bus_is_active(
+    patched_sessionlocal, monkeypatch
+):
+    """A run_id activates the HookBus, which freezes every payload it hands back.
+
+    Without a recursive thaw the checkpoint rows stay MappingProxyType and the
+    JSONB write dies with "Object of type mappingproxy is not JSON
+    serializable" — swallowed, so compaction silently never publishes. The
+    cases above pass no run_id, so they never reach that path.
+    """
+    import json
+
+    db = patched_sessionlocal
+    db.add(ChatSession(chat_id=CHAT_ID, user_id="u1", title="hooked"))
+    db.commit()
+    svc = ChatService(db)
+
+    _u(svc, 1, "第一轮问题" * 50)
+    _a(svc, 1, "第一轮回答", [{"tool_name": "web_fetch", "result": "详情" * 2000}])
+    _u(svc, 2, "第二轮问题" * 50)
+    _a(svc, 2, "第二轮回答", [{"tool_name": "web_fetch", "result": "项目" * 2000}])
+
+    async def _fake_summarize(history, *, timeout):
+        return "已完成两轮；待办：无"
+
+    monkeypatch.setattr(S, "_summarize", _fake_summarize)
+
+    ok = await S.run_post_turn_compaction(CHAT_ID, run_id="run_hooked_1")
+    assert ok is True, "hook bus 激活时压缩必须仍能成功落库"
+
+    ck = svc.get_latest_compaction_checkpoint(CHAT_ID)
+    assert ck is not None
+    assert C.is_summary_message(ck.content)
+
+    # Everything persisted must be plain JSON types, not frozen proxies.
+    json.dumps(ck.extra_data, ensure_ascii=False)
+    for row in ck.extra_data["replacement_history"]:
+        assert type(row) is dict

--- a/src/backend/tests/llm/test_compaction_hook_serializable.py
+++ b/src/backend/tests/llm/test_compaction_hook_serializable.py
@@ -1,0 +1,47 @@
+"""Compaction must hand JSON-serializable rows to the checkpoint writer.
+
+HookBus freezes invocation data into MappingProxyType so consumers cannot
+mutate it. A shallow ``list()`` / ``dict()`` copy leaves those proxies nested
+inside, and the JSONB checkpoint write then fails with "Object of type
+mappingproxy is not JSON serializable" — silently disabling compaction.
+"""
+
+from __future__ import annotations
+
+import json
+
+from core.harness.events import thaw_value
+from core.harness.hooks import HookStage, Invocation
+
+
+def _invocation(data):
+    return Invocation.create(
+        run_id="run-1",
+        stage=HookStage.AFTER_COMPACTION,
+        operation_name="context_compaction",
+        data=data,
+    )
+
+
+def test_shallow_copy_of_hook_data_is_not_serializable():
+    inv = _invocation({"replacement": [{"role": "user", "content": "hi"}]})
+    shallow = list(inv.data["replacement"])
+    try:
+        json.dumps(shallow)
+    except TypeError as exc:
+        assert "mappingproxy" in str(exc)
+    else:
+        raise AssertionError("expected the shallow copy to stay frozen")
+
+
+def test_thawed_hook_data_round_trips_through_json():
+    rows = [{"role": "user", "content": "hi", "meta": {"tags": ["a"]}}]
+    inv = _invocation({"replacement": rows, "budget": {"nested": {"k": "v"}}})
+
+    replacement = thaw_value(inv.data["replacement"])
+    budget = thaw_value(inv.data["budget"])
+
+    assert json.loads(json.dumps(replacement)) == rows
+    assert json.loads(json.dumps(budget)) == {"nested": {"k": "v"}}
+    assert type(replacement[0]) is dict
+    assert type(budget["nested"]) is dict

--- a/src/backend/tests/orchestration/test_chat_run_cancel_persistence.py
+++ b/src/backend/tests/orchestration/test_chat_run_cancel_persistence.py
@@ -25,7 +25,7 @@ def cancel_env(tmp_path, monkeypatch):
     sessions = sessionmaker(bind=engine, expire_on_commit=False)
     monkeypatch.setattr(executor, "SessionLocal", sessions)
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     executor._active_runs.clear()
     with sessions() as db:
         db.add(ChatSession(chat_id="chat-1", user_id="user-1", title="test"))

--- a/src/backend/tests/orchestration/test_chat_run_recovery.py
+++ b/src/backend/tests/orchestration/test_chat_run_recovery.py
@@ -131,7 +131,7 @@ def test_active_run_probe_hides_internal_agent_rows(recovery_env):
 async def test_public_worker_keeps_ambiguous_agent_tool_call_recoverable(recovery_env, monkeypatch):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-agent-timeout",
@@ -249,7 +249,7 @@ async def test_legacy_regenerate_stream_injects_a_durable_tool_binding(recovery_
 async def test_plan_worker_pauses_nested_unknown_tool_outcome(recovery_env, monkeypatch):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-plan-tool-unknown",
@@ -290,7 +290,7 @@ async def test_plan_worker_pauses_nested_unknown_tool_outcome(recovery_env, monk
 async def test_plan_generate_fences_late_message_after_lease_takeover(recovery_env, monkeypatch):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-plan-generate-fenced",
@@ -353,7 +353,7 @@ async def test_plan_generate_commits_message_and_terminal_state_atomically(
 ):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-plan-generate-complete",
@@ -419,7 +419,7 @@ async def test_autonomous_worker_pauses_nested_unknown_without_partial_stale_wri
 ):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-loop-tool-unknown",
@@ -459,7 +459,7 @@ async def test_autonomous_project_binding_is_rejected_after_lease_takeover(
 ):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-loop-project-fenced",
@@ -960,7 +960,7 @@ async def test_public_start_follow_and_history_complete_on_durable_offsets(
             "usage": {"input_tokens": 2, "output_tokens": 2},
         }
 
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     monkeypatch.setattr(executor, "astream_chat_workflow", workflow)
     monkeypatch.setattr(executor, "_spawn_followup_task", lambda **_kwargs: None)
     monkeypatch.setattr(executor, "_spawn_compaction_task", lambda **_kwargs: None)
@@ -1002,7 +1002,7 @@ async def test_public_follow_after_recovery_resets_partial_stream_and_keeps_offs
 ):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-partial-stream",
@@ -1074,7 +1074,7 @@ async def test_public_follow_after_recovery_resets_partial_stream_and_keeps_offs
 async def test_active_run_probe_replays_the_complete_existing_prefix(recovery_env, monkeypatch):
     sessions = recovery_env
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     journal = RunJournal(sessions)
     row = journal.accept(
         run_id="run-refresh-replay",
@@ -1201,7 +1201,7 @@ async def test_reaper_terminal_cancels_worker_without_late_user_cancel_projectio
         yield {"type": "model_progress"}
         await asyncio.Event().wait()
 
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     monkeypatch.setattr(executor, "astream_chat_workflow", blocked_workflow)
     run = await executor.start_run(
         chat_id="chat-1",

--- a/src/backend/tests/orchestration/test_chat_steer.py
+++ b/src/backend/tests/orchestration/test_chat_steer.py
@@ -48,7 +48,7 @@ async def test_pending_steer_round_trip_is_single_consumer(
     durable_steer_env, monkeypatch
 ):
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(chat_steer_service, "get_redis", lambda: redis)
+    monkeypatch.setattr(chat_steer_service, "get_redis", lambda **_: redis)
 
     payload = {"steer_id": "s1", "message": "换一种实现", "run_id": "r1"}
     await chat_steer_service.put_pending_steer("r1", payload)
@@ -64,7 +64,7 @@ async def test_pending_steer_round_trip_is_single_consumer(
 @pytest.mark.asyncio
 async def test_withdraw_only_removes_matching_steer(durable_steer_env, monkeypatch):
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(chat_steer_service, "get_redis", lambda: redis)
+    monkeypatch.setattr(chat_steer_service, "get_redis", lambda **_: redis)
     await chat_steer_service.put_pending_steer(
         "r1",
         {"steer_id": "newer", "message": "保留这条"},
@@ -79,7 +79,7 @@ async def test_redis_loss_does_not_drop_database_instruction(
     durable_steer_env, monkeypatch
 ):
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(chat_steer_service, "get_redis", lambda: redis)
+    monkeypatch.setattr(chat_steer_service, "get_redis", lambda **_: redis)
     await chat_steer_service.put_pending_steer(
         "r1",
         {"steer_id": "db-first", "message": "数据库里的指令"},
@@ -103,7 +103,7 @@ async def test_redis_notification_failure_happens_after_durable_accept(
         async def set(self, *_args, **_kwargs):
             raise ConnectionError("redis unavailable")
 
-    monkeypatch.setattr(chat_steer_service, "get_redis", lambda: BrokenRedis())
+    monkeypatch.setattr(chat_steer_service, "get_redis", lambda **_: BrokenRedis())
     accepted = await chat_steer_service.put_pending_steer(
         "r1",
         {"steer_id": "db-before-redis", "message": "先写数据库"},

--- a/src/backend/tests/orchestration/test_stale_reaper.py
+++ b/src/backend/tests/orchestration/test_stale_reaper.py
@@ -53,7 +53,7 @@ def reaper_env(monkeypatch):
     session_factory = sessionmaker(bind=engine)
     fake_redis = FakeRedis()
     monkeypatch.setattr(executor, "SessionLocal", session_factory)
-    monkeypatch.setattr(executor, "get_redis", lambda: fake_redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: fake_redis)
     yield session_factory, fake_redis
     engine.dispose()
 

--- a/src/backend/tests/orchestration/test_thinking_block_persistence.py
+++ b/src/backend/tests/orchestration/test_thinking_block_persistence.py
@@ -34,7 +34,7 @@ def run_env(tmp_path, monkeypatch):
     sessions = sessionmaker(bind=engine, expire_on_commit=False)
     monkeypatch.setattr(executor, "SessionLocal", sessions)
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(executor, "get_redis", lambda: redis)
+    monkeypatch.setattr(executor, "get_redis", lambda **_: redis)
     executor._active_runs.clear()
     with sessions() as db:
         db.add(ChatSession(chat_id="chat-1", user_id="user-1", title="test"))

--- a/src/backend/tests/orchestration/test_worker_base.py
+++ b/src/backend/tests/orchestration/test_worker_base.py
@@ -147,7 +147,7 @@ def test_day_lock_denied_when_another_instance_holds_it(monkeypatch):
         async def set(self, *_a, **_kw):
             return None  # NX failed → someone else holds it
 
-    monkeypatch.setattr(wb, "get_redis", lambda: _Redis())
+    monkeypatch.setattr(wb, "get_redis", lambda **_: _Redis())
     assert _run(wb.acquire_day_lock("t:", log_tag="test")) is False
 
 
@@ -159,7 +159,7 @@ def test_day_lock_acquired_when_free(monkeypatch):
             captured.update(key=key, ex=ex, nx=nx)
             return True
 
-    monkeypatch.setattr(wb, "get_redis", lambda: _Redis())
+    monkeypatch.setattr(wb, "get_redis", lambda **_: _Redis())
     assert _run(wb.acquire_day_lock("t:", ttl_s=99, today="20260729", log_tag="test")) is True
     assert captured["key"] == "t:20260729"
     assert captured["nx"] is True and captured["ex"] == 99

--- a/src/backend/tests/test_mcp_marketplace.py
+++ b/src/backend/tests/test_mcp_marketplace.py
@@ -324,7 +324,7 @@ async def test_oauth_callback_and_status_are_shared_without_plaintext_code(monke
     import fakeredis.aioredis
 
     fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(oauth_service, "get_redis", lambda: fake_redis)
+    monkeypatch.setattr(oauth_service, "get_redis", lambda **_: fake_redis)
     flow = oauth_service.OAuthInstallFlow(
         flow_id="mcpoauth_test",
         slug="gitlab-official",
@@ -355,7 +355,7 @@ async def test_oauth_cancel_marks_flow_failed_and_wakes_worker(monkeypatch):
     import fakeredis.aioredis
 
     fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(oauth_service, "get_redis", lambda: fake_redis)
+    monkeypatch.setattr(oauth_service, "get_redis", lambda **_: fake_redis)
     flow = oauth_service.OAuthInstallFlow(
         flow_id="mcpoauth_cancel",
         slug="gitlab-official",

--- a/src/backend/tests/test_redis_stream_pool.py
+++ b/src/backend/tests/test_redis_stream_pool.py
@@ -1,0 +1,74 @@
+"""Blocking chat-stream reads must not share the general request pool."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from weakref import WeakKeyDictionary
+
+
+def test_blocking_pool_is_separate_and_both_are_closed(monkeypatch):
+    import core.infra.redis as redis_module
+
+    created = []
+
+    class _Client:
+        def __init__(self, max_connections) -> None:
+            self.max_connections = max_connections
+            self.closed = False
+            created.append(self)
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(
+        redis_module,
+        "settings",
+        SimpleNamespace(
+            redis=SimpleNamespace(url="redis://example.invalid:6379/0", socket_timeout=30)
+        ),
+    )
+    monkeypatch.setattr(
+        redis_module.aioredis,
+        "from_url",
+        lambda *args, **kwargs: _Client(kwargs["max_connections"]),
+    )
+    monkeypatch.setattr(redis_module, "_redis_pools", WeakKeyDictionary())
+    monkeypatch.setattr(redis_module, "_stream_pools", WeakKeyDictionary())
+
+    async def _run() -> None:
+        general = redis_module.get_redis()
+        blocking = redis_module.get_redis(blocking=True)
+        assert general is not blocking
+        assert general is redis_module.get_redis()
+        assert blocking is redis_module.get_redis(blocking=True)
+        await redis_module.close_redis()
+
+    asyncio.run(_run())
+
+    assert len(created) == 2
+    assert created[0].max_connections != created[1].max_connections
+    assert all(client.closed for client in created)
+
+
+def test_follower_asks_for_the_blocking_pool():
+    import inspect
+
+    from orchestration import chat_run_executor
+
+    source = inspect.getsource(chat_run_executor.follow_run)
+    assert "get_redis(blocking=True)" in source
+
+
+def test_one_seam_redirects_both_pools(monkeypatch):
+    """Patching ``get_redis`` must redirect the follower too.
+
+    The follower and the XADD writer have to reach the same server; a second
+    accessor would let a redirect move only one of them.
+    """
+    import core.infra.redis as redis_module
+
+    sentinel = object()
+    monkeypatch.setattr(redis_module, "_get_pooled", lambda *args, **kwargs: sentinel)
+    assert redis_module.get_redis() is sentinel
+    assert redis_module.get_redis(blocking=True) is sentinel

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/check-i18n.mjs && node scripts/check-dark-mode.mjs && tsc -b && vite build && node scripts/precompress-dist.mjs",
+    "build": "node scripts/check-i18n.mjs && node scripts/check-dark-mode.mjs && node scripts/check-loading-motion.mjs && tsc -b && vite build && node scripts/precompress-dist.mjs",
     "check:i18n": "node scripts/check-i18n.mjs",
     "check:dark": "node scripts/check-dark-mode.mjs",
+    "check:motion": "node scripts/check-loading-motion.mjs",
     "test:chat-stream": "esbuild scripts/test-chat-stream-segments.ts --bundle --platform=node --format=esm --outfile=node_modules/.tmp/test-chat-stream-segments.mjs && node node_modules/.tmp/test-chat-stream-segments.mjs",
     "test:context-usage": "esbuild scripts/test-context-usage.ts --bundle --platform=node --format=esm --define:import.meta.env='{\"VITE_DEFAULT_LANGUAGE\":\"zh-CN\"}' --outfile=node_modules/.tmp/test-context-usage.mjs && node node_modules/.tmp/test-context-usage.mjs",
     "test:kb-assets": "node scripts/run-kb-asset-test.mjs",

--- a/src/frontend/scripts/check-loading-motion.mjs
+++ b/src/frontend/scripts/check-loading-motion.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * 动效降级门禁（构建前执行，与 check-i18n / check-dark-mode 同级）。
+ *
+ * 背景：系统开启「减弱动画」（Windows 节电模式会自动开）后，装饰性动效该停，但表示
+ * 「正在加载 / 正在运行」的循环动画一停就变成静止的残圈或灰条，比动起来更像卡死——
+ * 而本机不开这个开关就永远看不到，是个没有反馈回路的盲区。
+ *
+ * 降级的实现方式决定了本门禁检查什么：我们**不**用全局选择器压制动画（那会连第三方
+ * 组件的加载转圈一起冻住，而 antd 里只有 Spin 输出 aria-busy，其余转圈没有任何可判定
+ * 的语义），而是**给每条装饰性关键帧就地补一份「定格在终态」的同名覆盖版**放进
+ * @media (prefers-reduced-motion: reduce)——同名 @keyframes 后定义者胜，用到它的规则
+ * 自动一起降级，且不可能误伤第三方。工作指示器的关键帧不补覆盖版，于是原样继续动。
+ *
+ * 于是每条关键帧都必须二选一，本门禁强制这个选择：
+ *   1. 装饰性 → 在同文件里有一份 @media (prefers-reduced-motion: reduce) 内的同名覆盖版；
+ *   2. 工作指示器 → 使用它的规则上标注 `motion-keep: 理由`，说明为什么必须继续动。
+ * 另外禁止同一条关键帧既被 motion-keep 的规则使用、又被补了定格版——那说明它同时承担
+ * 了「在跑」和「装饰」两种语义，应当拆成两条。
+ *
+ * 用法：
+ *   node scripts/check-loading-motion.mjs          # 门禁，有问题退出码 1
+ *   node scripts/check-loading-motion.mjs --list   # 打印每条关键帧的立场
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = join(scriptDir, '..');
+const srcRoot = join(frontendRoot, 'src');
+const repoRoot = join(frontendRoot, '..', '..');
+const ceOverlayStyles = join(repoRoot, 'ce', 'overlay', 'src', 'frontend', 'src');
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      walk(p, out);
+    } else if (entry.name.endsWith('.css')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+const files = [...walk(srcRoot), ...walk(ceOverlayStyles)];
+
+/** name -> { file, defined, stilled(有定格版), keptBy[] } */
+const frames = new Map();
+const get = (name, file) => {
+  if (!frames.has(name)) frames.set(name, { file, defined: false, stilled: false, keptBy: [] });
+  return frames.get(name);
+};
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const rel = relative(frontendRoot, file);
+  const lines = text.split('\n');
+
+  // 关键帧定义；落在 reduced-motion 媒体块里的算「定格版」
+  let mediaDepth = 0;
+  let depth = 0;
+  let inReduceMedia = false;
+  lines.forEach((line) => {
+    const opens = (line.match(/\{/g) || []).length;
+    const closes = (line.match(/\}/g) || []).length;
+    if (/@media[^{]*prefers-reduced-motion[^{]*reduce/.test(line)) {
+      inReduceMedia = true;
+      mediaDepth = depth;
+    }
+    const kf = line.match(/@keyframes\s+([A-Za-z0-9_-]+)/);
+    if (kf) {
+      const entry = get(kf[1], rel);
+      if (inReduceMedia) entry.stilled = true;
+      else { entry.defined = true; entry.file = rel; }
+    }
+    depth += opens - closes;
+    if (inReduceMedia && depth <= mediaDepth) inReduceMedia = false;
+  });
+
+  // 规则的立场注释（motion-keep）——注释可写在规则内或选择器上方 4 行
+  let start = 0;
+  let body = [];
+  depth = 0;
+  lines.forEach((line, i) => {
+    const opens = (line.match(/\{/g) || []).length;
+    const closes = (line.match(/\}/g) || []).length;
+    if (depth === 0 && opens) { start = i; body = [line]; } else if (depth > 0) body.push(line);
+    depth += opens - closes;
+    if (depth === 0 && body.length) {
+      const inner = body.join('\n');
+      const blob = lines.slice(Math.max(0, start - 4), start).join('\n') + inner;
+      if (/motion-keep:/.test(blob)) {
+        for (const m of inner.matchAll(/animation(?:-name)?\s*:\s*([A-Za-z0-9_-]+)/g)) {
+          const name = m[1];
+          if (['none', 'inherit', 'initial'].includes(name)) continue;
+          get(name, rel).keptBy.push(`${rel}:${start + 1}`);
+        }
+      }
+      body = [];
+    }
+  });
+}
+
+const undecided = [];
+const conflicting = [];
+for (const [name, info] of frames) {
+  if (!info.defined) continue;                        // 只在 reduce 块里出现的是定格版本身
+  const kept = info.keptBy.length > 0;
+  if (kept && info.stilled) conflicting.push({ name, info });
+  else if (!kept && !info.stilled) undecided.push({ name, info });
+}
+
+if (process.argv.includes('--list')) {
+  for (const [name, info] of [...frames].sort()) {
+    if (!info.defined) continue;
+    console.log(`${info.keptBy.length ? 'keep' : info.stilled ? 'stop' : '????'}  ${info.file}  ${name}`);
+  }
+}
+
+if (undecided.length || conflicting.length) {
+  if (undecided.length) {
+    console.error('\n[check-loading-motion] 以下关键帧没有表明立场（减弱动效下要继续动还是定格）：');
+    for (const u of undecided) console.error(`    ${u.info.file}  @keyframes ${u.name}`);
+    console.error('  装饰性 → 在同文件里紧跟定义补一份定格版：');
+    console.error('      @media (prefers-reduced-motion: reduce) { @keyframes <名字> { from, to { <终帧声明> } } }');
+    console.error('  工作指示器 → 在使用它的规则上方写 motion-keep: 理由（说明停下为什么会被读成卡死）。');
+  }
+  if (conflicting.length) {
+    console.error('\n[check-loading-motion] 以下关键帧同时被标为工作指示器又补了定格版，语义冲突：');
+    for (const c of conflicting) console.error(`    ${c.info.file}  @keyframes ${c.name}  （keep 于 ${c.info.keptBy.join(', ')}）`);
+    console.error('  同一条关键帧不能既表示「在跑」又是装饰，按用途拆成两条。');
+  }
+  console.error('');
+  process.exit(1);
+}
+
+const keepCount = [...frames.values()].filter((i) => i.defined && i.keptBy.length).length;
+const stopCount = [...frames.values()].filter((i) => i.defined && i.stilled).length;
+console.log(`[check-loading-motion] 通过（关键帧 ${keepCount + stopCount} 条：工作指示器 ${keepCount} 条保持动，装饰性 ${stopCount} 条减弱动效下定格）`);

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -48,7 +48,7 @@ import { CreateKBModal, ReindexModal } from './components/kb';
 import { BatchConfirmModal } from './components/batch';
 import {
   useUIStore, useChatStore, useCatalogStore, useCanvasStore, useAuthStore,
-  useAutomationChatStore, useModelCapabilitiesStore, useEditionStore,
+  useAutomationChatStore, useModelCapabilitiesStore, useEditionStore, isLocalDraftChat,
 } from './stores';
 import type { ChatMode } from './stores/chatStore';
 import { RunTimelinePanel } from './components/automation/RunTimelinePanel';
@@ -395,6 +395,8 @@ export default function App() {
   // restore from it (or clear ones that are no longer valid).
   useEffect(() => {
     if (!authUser || !currentChatId) return;
+    // 只在浏览器里存在、还没发过一句话的新对话：服务端没有它，两个恢复请求必然 404。
+    if (isLocalDraftChat(currentChatId)) return;
     let cancelled = false;
     const chatId = currentChatId;
     const questionIdsAtRequestStart = new Set(

--- a/src/frontend/src/AppThemeProvider.tsx
+++ b/src/frontend/src/AppThemeProvider.tsx
@@ -11,7 +11,13 @@ import { getLang } from './i18n';
 dayjs.locale(getLang() === 'en' ? 'en' : 'zh-cn');
 import { getAppTheme } from './appTheme';
 import { useUIStore } from './stores/uiStore';
-import { applyThemeToDom, systemPrefersDark, watchSystemTheme } from './theme';
+import {
+  applyThemeToDom,
+  systemPrefersDark,
+  systemPrefersReducedMotion,
+  watchReducedMotion,
+  watchSystemTheme,
+} from './theme';
 
 interface AppThemeProviderProps {
   children: ReactNode;
@@ -29,13 +35,15 @@ export function AppThemeProvider({ children, forceLight = false }: AppThemeProvi
   const themeMode = useUIStore((s) => s.themeMode);
   const sysDark = useSyncExternalStore(watchSystemTheme, systemPrefersDark);
   const isDark = !forceLight && (themeMode === 'dark' || (themeMode === 'system' && sysDark));
+  // 系统开了「减弱动画」就顺手关掉 antd 自己的过渡（它的加载转圈不受影响，见 appTheme.ts）
+  const reducedMotion = useSyncExternalStore(watchReducedMotion, systemPrefersReducedMotion);
 
   useEffect(() => {
     applyThemeToDom(isDark);
   }, [isDark]);
 
   return (
-    <ConfigProvider theme={getAppTheme(isDark)} locale={getLang() === 'en' ? enUS : zhCN}>
+    <ConfigProvider theme={getAppTheme(isDark, reducedMotion)} locale={getLang() === 'en' ? enUS : zhCN}>
       {children}
     </ConfigProvider>
   );

--- a/src/frontend/src/SharePreviewApp.tsx
+++ b/src/frontend/src/SharePreviewApp.tsx
@@ -98,7 +98,7 @@ export default function SharePreviewApp() {
   if (loading) {
     return (
       <div className="jx-sharePage">
-        <div className="jx-shareCard jx-shareCardSkeleton" aria-hidden="true">
+        <div className="jx-shareCard jx-shareCardSkeleton" aria-hidden="true" aria-busy="true">
           <div className="jx-shareHeader">
             <div className="jx-shareHeaderTop">
               <div className="jx-skeletonBlock jx-sharePreviewSkEyebrow" />

--- a/src/frontend/src/appTheme.ts
+++ b/src/frontend/src/appTheme.ts
@@ -48,7 +48,9 @@ const darkToken = {
   colorBgSpotlight: '#1C2330',
 };
 
-// 模块级预建常量：同主题下引用稳定，ConfigProvider 无需重算派生 token
+// 模块级预建常量：同主题下引用稳定，ConfigProvider 无需重算派生 token。
+// 「减弱动画」再乘二：antd 的 motion=false 只把自己的过渡时长归零，不碰 Spin / 按钮
+// loading 的转圈——第三方动效交给第三方自己的开关，我们不去枚举人家的类名。
 const LIGHT_THEME: ThemeConfig = {
   algorithm: antdTheme.defaultAlgorithm,
   token: { ...sharedToken, ...lightToken },
@@ -57,7 +59,16 @@ const DARK_THEME: ThemeConfig = {
   algorithm: antdTheme.darkAlgorithm,
   token: { ...sharedToken, ...darkToken },
 };
+const LIGHT_THEME_STILL: ThemeConfig = {
+  ...LIGHT_THEME,
+  token: { ...LIGHT_THEME.token, motion: false },
+};
+const DARK_THEME_STILL: ThemeConfig = {
+  ...DARK_THEME,
+  token: { ...DARK_THEME.token, motion: false },
+};
 
-export function getAppTheme(isDark: boolean): ThemeConfig {
-  return isDark ? DARK_THEME : LIGHT_THEME;
+export function getAppTheme(isDark: boolean, reducedMotion = false): ThemeConfig {
+  if (isDark) return reducedMotion ? DARK_THEME_STILL : DARK_THEME;
+  return reducedMotion ? LIGHT_THEME_STILL : LIGHT_THEME;
 }

--- a/src/frontend/src/components/agent/AgentPanel.tsx
+++ b/src/frontend/src/components/agent/AgentPanel.tsx
@@ -143,7 +143,7 @@ function AgentListSkeleton() {
   return (
     <div className="jx-agentPage-grid">
       {Array.from({ length: 6 }, (_, idx) => (
-        <div key={idx} className="jx-agentCard jx-agentCardSkeleton" aria-hidden="true">
+        <div key={idx} className="jx-agentCard jx-agentCardSkeleton" aria-hidden="true" aria-busy="true">
           <div className="jx-agentCard-body">
             <div className="jx-agentCard-head">
               <Skeleton.Avatar active size={28} shape="circle" />
@@ -162,7 +162,7 @@ function AgentListSkeleton() {
 
 function AgentDetailSkeleton() {
   return (
-    <div className="jx-agentPage jx-agentLibraryPage">
+    <div className="jx-agentPage jx-agentLibraryPage" aria-busy="true">
       <div className="jx-agentDetail-top">
         <button className="jx-agentDetail-backBtn" type="button" aria-hidden="true">
           <LeftOutlined style={{ fontSize: 14 }} />

--- a/src/frontend/src/components/canvas/CanvasPanel.tsx
+++ b/src/frontend/src/components/canvas/CanvasPanel.tsx
@@ -128,7 +128,7 @@ function DocxRenderer({ url, maxBytes }: { url: string; maxBytes: number }) {
   if (error) return <div className="jx-canvas-error">{error}</div>;
   return (
     <>
-      {loading && <div className="jx-canvas-loading"><div className="jx-canvas-spinner" /><span>{t('正在渲染文档…')}</span></div>}
+      {loading && <div className="jx-canvas-loading" aria-busy="true"><div className="jx-canvas-spinner" /><span>{t('正在渲染文档…')}</span></div>}
       {/* fadeIn class is only attached once rendering finishes, so the entrance
           animation starts exactly when the document becomes visible. */}
       <div
@@ -209,7 +209,7 @@ function PptRenderer({ url, maxBytes }: { url: string; maxBytes: number }) {
   }, [maxBytes, url]);
 
   if (error) return <div className="jx-canvas-error">{error}</div>;
-  if (loading || !pdfUrl) return <div className="jx-canvas-loading"><div className="jx-canvas-spinner" /><span>{t('正在渲染演示文稿…')}</span></div>;
+  if (loading || !pdfUrl) return <div className="jx-canvas-loading" aria-busy="true"><div className="jx-canvas-spinner" /><span>{t('正在渲染演示文稿…')}</span></div>;
 
   return (
     <div className="jx-canvas-pdf">
@@ -263,7 +263,7 @@ function TextRenderer({ url, maxBytes }: { url: string; maxBytes: number }) {
   const { content, loading, error } = useRemoteText(url, maxBytes);
 
   if (error) return <div className="jx-canvas-error">{error}</div>;
-  if (loading) return <div className="jx-canvas-loading"><div className="jx-canvas-spinner" /><span>{t('正在加载…')}</span></div>;
+  if (loading) return <div className="jx-canvas-loading" aria-busy="true"><div className="jx-canvas-spinner" /><span>{t('正在加载…')}</span></div>;
   return (
     <div className="jx-canvas-text jx-canvas-fadeIn">
       <pre className="jx-canvas-text-pre">{content}</pre>
@@ -275,7 +275,7 @@ function MarkdownRenderer({ url, maxBytes }: { url: string; maxBytes: number }) 
   const { content, loading, error } = useRemoteText(url, maxBytes);
 
   if (error) return <div className="jx-canvas-error">{error}</div>;
-  if (loading) return <div className="jx-canvas-loading"><div className="jx-canvas-spinner" /><span>{t('正在加载…')}</span></div>;
+  if (loading) return <div className="jx-canvas-loading" aria-busy="true"><div className="jx-canvas-spinner" /><span>{t('正在加载…')}</span></div>;
   return (
     <CitationMarkdownBlock
       text={content}

--- a/src/frontend/src/components/canvas/PluginCanvasPanel.tsx
+++ b/src/frontend/src/components/canvas/PluginCanvasPanel.tsx
@@ -27,7 +27,7 @@ export function PluginCanvasPanel() {
     if (!target) return <div className="jx-rightSidebar-empty">{t('暂无可展示内容')}</div>;
     if (target.status === 'loading') {
       return (
-        <div className="jx-canvas-loading">
+        <div className="jx-canvas-loading" aria-busy="true">
           <div className="jx-canvas-spinner" />
           <span>{t('正在获取数据，完成后将在这里自动展开')}</span>
         </div>

--- a/src/frontend/src/components/canvas/UniverSpreadsheet.tsx
+++ b/src/frontend/src/components/canvas/UniverSpreadsheet.tsx
@@ -265,6 +265,7 @@ export const UniverSpreadsheet = forwardRef<UniverSpreadsheetHandle, UniverSprea
             表格以柔和 cross-fade 呈现；禁止对 Univer canvas 本身做 transform。 */}
         <div
           className={`jx-canvas-loading jx-canvas-univerOverlay${loading ? '' : ' jx-canvas-univerOverlay--done'}`}
+          aria-busy={loading}
           style={{ position: 'absolute', inset: 0, zIndex: 10, background: 'var(--color-bg-container)' }}
         >
           <div className="jx-canvas-spinner" />

--- a/src/frontend/src/components/catalog/CatalogPanel.tsx
+++ b/src/frontend/src/components/catalog/CatalogPanel.tsx
@@ -976,7 +976,7 @@ export function CatalogPanel({ embedded = false }: CatalogPanelProps = {}) {
             >
               {catalogLoading ? (
                 libraryLoadingCards.map((item) => (
-                  <div key={item} className="jx-kbLibraryCard jx-kbLibraryCardSkeleton" aria-hidden="true">
+                  <div key={item} className="jx-kbLibraryCard jx-kbLibraryCardSkeleton" aria-hidden="true" aria-busy="true">
                     <div className="jx-kbLibraryCardTop">
                       <div className="jx-skeletonBlock jx-kbSkIcon" />
                       <div className="jx-kbLibraryMain">
@@ -1274,7 +1274,7 @@ export function CatalogPanel({ embedded = false }: CatalogPanelProps = {}) {
                 </div>
 
                 {kbDocsLoadingId === selectedItem.id ? (
-                  <div className="jx-kbDocLoadingWrap" aria-hidden="true">
+                  <div className="jx-kbDocLoadingWrap" aria-hidden="true" aria-busy="true">
                     {docLoadingRows.map((item) => (
                       <div key={item} className="jx-kbDocRow jx-kbDocRowSkeleton">
                         <div className="jx-kbDocNameCell">

--- a/src/frontend/src/components/chat/ChatArea.tsx
+++ b/src/frontend/src/components/chat/ChatArea.tsx
@@ -9,7 +9,7 @@ import {
   distanceFromBottom,
   scrollElementToBottom,
 } from '../../utils/scroll';
-import { useChatStore, useBatchStore, useEditionStore, usePluginUiStore, useUIStore } from '../../stores';
+import { useChatStore, useBatchStore, useEditionStore, usePluginUiStore, useUIStore, isLocalDraftChat } from '../../stores';
 import { resolveText } from '../../plugin-ui';
 import { useCatalogStore } from '../../stores/catalogStore';
 import { useAgentStore } from '../../stores/agentStore';
@@ -210,7 +210,8 @@ export function ChatArea({
   // Proactively fetch the access level when switching sessions — even if ChatShareBanner
   // is not mounted because it hit the hasNoMessages early-return branch, we still need to know the read level to hide the input box.
   useEffect(() => {
-    if (!currentChatId) {
+    // 只在浏览器里存在、还没发过一句话的新对话：服务端没有它，问详情必然 404。
+    if (!currentChatId || isLocalDraftChat(currentChatId)) {
       setShareAccessLevel(null);
       return;
     }
@@ -341,7 +342,7 @@ export function ChatArea({
       return <div className="jx-emptyPage jx-chatSkeleton" />;
     }
     return (
-      <div className="jx-emptyPage jx-chatSkeleton">
+      <div className="jx-emptyPage jx-chatSkeleton" aria-busy="true">
         <div className="jx-chatSkeletonCenter">
           <div className="jx-chatSkeletonHero">
             <div className="jx-skeletonBlock jx-chatSkeletonTitle" />

--- a/src/frontend/src/components/chat/MessageBubble.tsx
+++ b/src/frontend/src/components/chat/MessageBubble.tsx
@@ -415,30 +415,23 @@ export const MessageBubble = memo(function MessageBubble({ m, messageIndex, curr
     };
   }, []);
 
-  /** Render a thinking block */
-  const renderThinkingBlock = (content: string, thinkKey: string, isActiveThinking: boolean) => {
-    const isExpanded = isActiveThinking || expandedThinking.has(thinkKey);
-    const toggleThink = () => {
-      if (isActiveThinking) return;
-      toggleThinking(thinkKey);
-    };
+  /** Render a settled thinking block. Live thinking is rendered by ThinkingInline. */
+  const renderThinkingBlock = (content: string, thinkKey: string) => {
+    const isExpanded = expandedThinking.has(thinkKey);
+    const toggleThink = () => toggleThinking(thinkKey);
     return (
       <div key={thinkKey} className="jx-thinkingBlock">
-        <div className={`jx-thinkingBlockHeader${isActiveThinking ? ' jx-thinkingActive' : ''}`}
+        <div className="jx-thinkingBlockHeader"
           role="button" tabIndex={0} onClick={toggleThink}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleThink(); } }}>
           <div className="jx-thinkingHeaderLeft">
-            {isActiveThinking ? <div className="jx-thinkingSpinner" /> : <BulbFilled className="jx-thinkingIcon" />}
-            <span className="jx-thinkingLabel">{isActiveThinking ? t('正在思考…') : t('思考过程')}</span>
+            <BulbFilled className="jx-thinkingIcon" />
+            <span className="jx-thinkingLabel">{t('思考过程')}</span>
           </div>
-          {!isActiveThinking && (
-            <DownOutlined className={`jx-expandIcon${isExpanded ? ' jx-expandIcon--open' : ''}`} />
-          )}
+          <DownOutlined className={`jx-expandIcon${isExpanded ? ' jx-expandIcon--open' : ''}`} />
         </div>
         <div className={`jx-expandWrap${isExpanded ? ' jx-expandWrap--open' : ''}`}>
-          <div className="jx-thinkingContent" ref={(el) => { if (el && isActiveThinking) el.scrollTop = el.scrollHeight; }}>
-            {(isExpanded || isActiveThinking) && content}
-          </div>
+          <div className="jx-thinkingContent">{isExpanded && content}</div>
         </div>
       </div>
     );
@@ -1033,7 +1026,7 @@ export const MessageBubble = memo(function MessageBubble({ m, messageIndex, curr
                   <span className="jx-sectionTitle">{t('思考过程 ({n})', { n: m.thinking.length })}</span>
                 </div>
                 <div className="jx-thinkingList">
-                  {m.thinking.map((think, idx) => renderThinkingBlock(think.content, `${m.ts}-think-${idx}`, false))}
+                  {m.thinking.map((think, idx) => renderThinkingBlock(think.content, `${m.ts}-think-${idx}`))}
                 </div>
               </div>
             )}

--- a/src/frontend/src/components/chat/PromptHubPanel.tsx
+++ b/src/frontend/src/components/chat/PromptHubPanel.tsx
@@ -78,7 +78,7 @@ export function PromptHubPanel() {
 
       <div className="jx-promptHub-list">
         {showSkeleton ? (
-          <div className="jx-promptHub-skeletonList" aria-hidden="true">
+          <div className="jx-promptHub-skeletonList" aria-hidden="true" aria-busy="true">
             {Array.from({ length: 5 }).map((_, idx) => (
               <div key={idx} className="jx-promptHub-card jx-promptHub-card--skeleton">
                 <div className="jx-skeletonBlock jx-promptHub-skTitle" />

--- a/src/frontend/src/components/chat/ThinkingInline.tsx
+++ b/src/frontend/src/components/chat/ThinkingInline.tsx
@@ -36,7 +36,7 @@ export function ThinkingInline({ content, isActive }: ThinkingInlineProps) {
       <div className="jx-inlineSummary" role="button" tabIndex={0} aria-expanded={open} onClick={toggle}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }}>
         <BrandLoader done={!isActive} label={isActive ? t('正在思考') : t('思考完成')} />
-        <span className={`jx-inlineSummaryText${isActive ? ' jx-inlineSummaryText--live jx-anim-keep' : ''}`}>
+        <span className={`jx-inlineSummaryText${isActive ? ' jx-inlineSummaryText--live' : ''}`}>
           {isActive ? t('正在思考…') : t('思考过程')}
         </span>
         {hasContent && <RightOutlined className="jx-inlineSummaryArrow" rotate={open ? 90 : 0} />}

--- a/src/frontend/src/components/chat/TurnStatusIndicator.tsx
+++ b/src/frontend/src/components/chat/TurnStatusIndicator.tsx
@@ -38,8 +38,7 @@ export function TurnStatusIndicator({ startTs, label }: TurnStatusIndicatorProps
   return (
     <div className="jx-turnStatus" role="status" aria-live="polite">
       <BrandLoader size={18} done={false} label={text} />
-      {/* jx-anim-keep: "system at work" indicator; under reduced-motion the shimmer slows down but is preserved */}
-      <span className="jx-turnStatus-label jx-anim-keep">{text}</span>
+      <span className="jx-turnStatus-label">{text}</span>
       {showClock && <ElapsedTimer startTs={startTs} className="jx-turnStatus-clock" />}
     </div>
   );

--- a/src/frontend/src/components/common/AppLoadingSkeleton.tsx
+++ b/src/frontend/src/components/common/AppLoadingSkeleton.tsx
@@ -1,6 +1,6 @@
 export function AppLoadingSkeleton() {
   return (
-    <div className="jx-appLoading" aria-hidden="true">
+    <div className="jx-appLoading" aria-hidden="true" aria-busy="true">
       <aside className="jx-appLoading-sidebar">
         <div className="jx-appLoading-brand">
           <div className="jx-skeletonBlock jx-appLoading-skLogo" />

--- a/src/frontend/src/components/common/BrandLoader.tsx
+++ b/src/frontend/src/components/common/BrandLoader.tsx
@@ -14,6 +14,9 @@ interface BrandLoaderProps {
  * - active: `/loader.gif` brand-blue dynamic drawing
  * - done: `/loader-done.png` slate-gray frozen final state + a brief fade-in
  *
+ * The active state carries `aria-busy`, which is both the screen-reader truth
+ * and what keeps its motion alive under reduced-motion (see motion.css).
+ *
  * Used at inline summary positions like ThinkingInline, ToolProgressInline,
  * replacing the earlier two scattered visuals breathingOrbs + pulseDot.
  */
@@ -22,6 +25,7 @@ export function BrandLoader({ size = 16, label, done = false }: BrandLoaderProps
     <span
       className={`jx-brandLoader${done ? ' jx-brandLoader--done' : ''}`}
       role="img"
+      aria-busy={!done}
       aria-label={label ?? (done ? t('已完成') : t('加载中'))}
       style={{ width: size, height: size }}
     />

--- a/src/frontend/src/components/file/MySpaceImportModal.tsx
+++ b/src/frontend/src/components/file/MySpaceImportModal.tsx
@@ -83,7 +83,7 @@ function foldersToOptions(folders: PersonalFolderNode[]): ScopeTreeNode[] {
 
 function FileListSkeleton() {
   return (
-    <div className="jx-spaceImportList" aria-hidden="true">
+    <div className="jx-spaceImportList" aria-hidden="true" aria-busy="true">
       {Array.from({ length: 5 }).map((_, index) => (
         <div key={index} className="jx-spaceImportItem jx-spaceImportItem--skeleton">
           <div className="jx-skeletonBlock jx-spaceImportItem-skCheckbox" />

--- a/src/frontend/src/components/lab/AutomationSkeleton.tsx
+++ b/src/frontend/src/components/lab/AutomationSkeleton.tsx
@@ -3,7 +3,7 @@ import { t } from '../../i18n';
 
 export function AutomationListSkeleton({ count = 4 }: { count?: number }) {
   return (
-    <div className="jx-automation-section" aria-hidden="true">
+    <div className="jx-automation-section" aria-hidden="true" aria-busy="true">
       <div className="jx-skeletonBlock jx-automation-skSectionTitle" />
       {Array.from({ length: count }).map((_, idx) => (
         <div key={idx} className="jx-automation-card jx-automation-card--skeleton">
@@ -29,7 +29,7 @@ export function AutomationListSkeleton({ count = 4 }: { count?: number }) {
 
 export function AutomationDetailSkeleton({ onBack }: { onBack?: () => void }) {
   return (
-    <div className="jx-automation-detail-top" aria-hidden="true">
+    <div className="jx-automation-detail-top" aria-hidden="true" aria-busy="true">
       <button
         className="jx-automation-detail-backBtn"
         onClick={onBack}

--- a/src/frontend/src/components/loop/loop.css
+++ b/src/frontend/src/components/loop/loop.css
@@ -232,6 +232,7 @@
 .loop-item-active .loop-planbar-mark { color: var(--color-primary); }
 .loop-item-active .loop-planbar-desc { font-weight: 600; }
 .loop-item-todo .loop-planbar-mark { color: var(--color-text-placeholder); }
+/* motion-keep: 「审阅中」状态文字的呼吸，停下就看不出这一轮还在跑 */
 .loop-planbar-reviewing {
   flex-shrink: 0; margin-left: 6px; font-size: 11px; font-weight: 600;
   color: var(--color-primary); white-space: nowrap;

--- a/src/frontend/src/components/myspace/MySpaceSearchModal.tsx
+++ b/src/frontend/src/components/myspace/MySpaceSearchModal.tsx
@@ -101,7 +101,7 @@ export function MySpaceSearchModal({ onOpenChat, onPreviewFile }: Props) {
     );
   } else if (!ready) {
     body = (
-      <div key="skeleton" className="jx-searchSkeletonList" aria-hidden="true">
+      <div key="skeleton" className="jx-searchSkeletonList" aria-hidden="true" aria-busy="true">
         {[0, 1, 2, 3].map((i) => (
           <div key={i} className="jx-searchSkeletonItem">
             <div className="jx-skeletonBlock jx-searchSkTitle" />

--- a/src/frontend/src/components/myspace/MySpaceSkeleton.tsx
+++ b/src/frontend/src/components/myspace/MySpaceSkeleton.tsx
@@ -15,7 +15,7 @@ export function MySpaceSkeleton({ tab, assetFilter, rows }: Props) {
 
 function DocumentTableSkeleton({ count }: { count: number }) {
   return (
-    <div className="jx-mySpace-docTable" aria-hidden="true">
+    <div className="jx-mySpace-docTable" aria-hidden="true" aria-busy="true">
       <div className="jx-mySpace-docTable-header">
         <div className="jx-mySpace-docTable-col jx-mySpace-docTable-col--check" />
         <div className="jx-mySpace-docTable-col jx-mySpace-docTable-col--name">
@@ -59,7 +59,7 @@ function DocumentTableSkeleton({ count }: { count: number }) {
 
 function ImageGridSkeleton({ count }: { count: number }) {
   return (
-    <div className="jx-mySpace-imgGrid" aria-hidden="true">
+    <div className="jx-mySpace-imgGrid" aria-hidden="true" aria-busy="true">
       {Array.from({ length: count }).map((_, idx) => (
         <div key={idx} className="jx-mySpace-imgItem jx-mySpace-imgItem--skeleton">
           <div className="jx-skeletonBlock jx-mySpace-skImgCell" />
@@ -71,7 +71,7 @@ function ImageGridSkeleton({ count }: { count: number }) {
 
 function FavoriteSkeleton({ count }: { count: number }) {
   return (
-    <div className="jx-mySpace-favList" aria-hidden="true">
+    <div className="jx-mySpace-favList" aria-hidden="true" aria-busy="true">
       {Array.from({ length: count }).map((_, idx) => (
         <div key={idx} className="jx-mySpace-favCard jx-mySpace-favCard--skeleton">
           <div className="jx-mySpace-favHeader">

--- a/src/frontend/src/components/onboarding/FirstRunSetup.tsx
+++ b/src/frontend/src/components/onboarding/FirstRunSetup.tsx
@@ -995,7 +995,7 @@ export function FirstRunSetup({ user, onComplete }: FirstRunSetupProps) {
   if (loading) {
     return (
       <div className="jx-firstRun-root">
-        <div className="jx-firstRun-loading"><Skeleton active paragraph={{ rows: 5 }} /></div>
+        <div className="jx-firstRun-loading" aria-busy="true"><Skeleton active paragraph={{ rows: 5 }} /></div>
       </div>
     );
   }

--- a/src/frontend/src/components/settings/SettingsModal.tsx
+++ b/src/frontend/src/components/settings/SettingsModal.tsx
@@ -1083,7 +1083,7 @@ export default function SettingsPage() {
         width={720}
       >
         {memoryLoading ? (
-          <Skeleton active title={false} paragraph={{ rows: 4 }} style={{ padding: '16px 0' }} />
+          <div aria-busy="true"><Skeleton active title={false} paragraph={{ rows: 4 }} style={{ padding: '16px 0' }} /></div>
         ) : (
           <Tabs
             activeKey={memoryTab}

--- a/src/frontend/src/components/share/ShareRecordsPage.tsx
+++ b/src/frontend/src/components/share/ShareRecordsPage.tsx
@@ -279,7 +279,7 @@ export default function ShareRecordsPage({ embedded = false, hideEmbeddedDesc = 
       {loading ? (
         <div className="jx-shareRecordsLoading">
           {loadingCards.map((item) => (
-            <div key={item} className="jx-shareRecordCard jx-shareRecordCardSkeleton" aria-hidden="true">
+            <div key={item} className="jx-shareRecordCard jx-shareRecordCardSkeleton" aria-hidden="true" aria-busy="true">
               <div className="jx-shareRecordTop">
                 <div className="jx-shareRecordMain">
                   <div className="jx-shareRecordTitleRow">

--- a/src/frontend/src/components/sidebar/SearchModal.tsx
+++ b/src/frontend/src/components/sidebar/SearchModal.tsx
@@ -224,7 +224,7 @@ export function SearchModal({ onNewChat, onSelectChat, onSelectSearchResult }: S
   let body: React.ReactNode;
   if (hasKeyword && searchLoading) {
     body = (
-      <div key="skeleton" className="jx-searchSkeletonList" aria-hidden="true">
+      <div key="skeleton" className="jx-searchSkeletonList" aria-hidden="true" aria-busy="true">
         {[0, 1, 2, 3].map((i) => (
           <div key={i} className="jx-searchSkeletonItem">
             <div className="jx-skeletonBlock jx-searchSkTitle" />

--- a/src/frontend/src/components/sidebar/Sidebar.tsx
+++ b/src/frontend/src/components/sidebar/Sidebar.tsx
@@ -899,7 +899,7 @@ export function Sidebar({
           {/* History list — the history section title and filter dropdown have been moved down into SearchModal */}
           <div className="jx-historyListWrap">
             {chatsLoading ? (
-              <div className="jx-historySkeletonList" aria-hidden="true">
+              <div className="jx-historySkeletonList" aria-hidden="true" aria-busy="true">
                 {historySkeletonGroups.map((group) => (
                   <div key={group.key} className="jx-historyGroup">
                     <div className="jx-historyGroupTitle">{group.label}</div>

--- a/src/frontend/src/components/tool/PendingStepRow.tsx
+++ b/src/frontend/src/components/tool/PendingStepRow.tsx
@@ -25,8 +25,7 @@ export function PendingStepRow({ startTs }: PendingStepRowProps) {
           <LoadingOutlined spin className="jx-tcr-icon jx-tcr-icon--running" />
         </span>
         <span className="jx-tcr-label">
-          {/* jx-anim-keep: "system at work" indicator; under reduced-motion it slows down but is preserved rather than frozen */}
-          <span className="jx-tcr-prefix jx-tcr-prefix--shimmer jx-anim-keep">{t('正在准备调用工具…')}</span>
+          <span className="jx-tcr-prefix jx-tcr-prefix--shimmer">{t('正在准备调用工具…')}</span>
         </span>
         <ElapsedTimer startTs={startTs} className="jx-tcr-timer" />
       </div>

--- a/src/frontend/src/components/tool/ToolProgressInline.tsx
+++ b/src/frontend/src/components/tool/ToolProgressInline.tsx
@@ -56,9 +56,7 @@ export function ToolProgressInline({ message, toolCalls }: ToolProgressInlinePro
       <div className="jx-inlineSummary" role="button" tabIndex={0} aria-expanded={open} onClick={toggle}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }}>
         <BrandLoader done={!anyRunning} label={anyRunning ? t('正在调用工具') : t('工具调用完成')} />
-        {/* jx-anim-keep：减弱动效下流光不能被冻住——它是靠 background-clip:text 抠出来的字，
-            停在任意一帧就变成一段忽深忽浅的灰，反而比动起来更难读（motion.css 的白名单） */}
-        <span className={`jx-inlineSummaryText${anyRunning ? ' jx-inlineSummaryText--live jx-anim-keep' : ''}`}>
+        <span className={`jx-inlineSummaryText${anyRunning ? ' jx-inlineSummaryText--live' : ''}`}>
           {anyRunning ? t('正在调用 {label}', { label }) : t('已调用 {label}', { label })}
         </span>
         {/* 长工具（批量作业）的实时进度：这条摘要行在折叠态是用户唯一的信息源 */}

--- a/src/frontend/src/hooks/useChatActions.ts
+++ b/src/frontend/src/hooks/useChatActions.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { Modal, message } from 'antd';
 import { t } from '../i18n';
 import { authFetch } from '../api';
-import { nowId, registerDeletedChatId } from '../storage';
+import { newDraftChatId, registerDeletedChatId } from '../storage';
 import { buildHistorySegments } from '../utils/segments';
 import { triggerPdfDownload, toSafeFileName } from '../utils/export';
 import { SUMMARY_MAX_ROUNDS } from '../utils/constants';
@@ -31,7 +31,7 @@ export function useChatActions(effectiveApiUrl: string) {
   }
 
   function newChat(inputRef: React.RefObject<HTMLTextAreaElement | null>) {
-    const id = nowId('chat');
+    const id = newDraftChatId(useChatStore.getState().currentUserId);
     if (useAutomationChatStore.getState().activeGroup) {
       useAutomationChatStore.getState().exitAutomationChat();
     }
@@ -60,7 +60,7 @@ export function useChatActions(effectiveApiUrl: string) {
           const next = { chats: { ...prev.chats }, order: (prev.order || []).filter((x) => x !== id) };
           delete (next.chats as any)[id];
           if (currentChatId === id) {
-            const nextId = next.order?.[0] || nowId('chat');
+            const nextId = next.order?.[0] || newDraftChatId(useChatStore.getState().currentUserId);
             setCurrentChatId(nextId);
           }
           return next;

--- a/src/frontend/src/hooks/useChatInit.ts
+++ b/src/frontend/src/hooks/useChatInit.ts
@@ -9,7 +9,7 @@ import { markResolvedPlanPreviews } from '../utils/planHistory';
 import { stripMcpToolPrefix } from '../utils/constants';
 import { parseContextCompactionState, parseContextUsageSnapshot } from '../utils/contextUsage';
 import { shouldRestorePlanModeFromHistory } from '../utils/chatMode';
-import { LOGIN_LANDING_KEY, useAuthStore, useSettingsStore, useUIStore, useChatStore, useCatalogStore, useAutomationChatStore, useBatchStore, useSidebarOrderStore } from '../stores';
+import { isLocalDraftChat, LOGIN_LANDING_KEY, useAuthStore, useSettingsStore, useUIStore, useChatStore, useCatalogStore, useAutomationChatStore, useBatchStore, useSidebarOrderStore } from '../stores';
 import type { Catalog, ChatItem, ChatMessage, CitationItem, ContextCompactionState, ContextUsageSnapshot, EvolutionSummary, OntologyGovernanceSummary, StoredSegment, ThinkingBlock, ToolCall, UpdateEntry, BatchPlanMeta, BatchSourceType, BatchItemResult } from '../types';
 
 const effectiveApiUrl = (import.meta.env.VITE_API_BASE_URL as string || '').trim() || '/api';
@@ -755,6 +755,8 @@ export function useChatInit() {
     // the user hasn't typed into yet), the 404 response short-circuits us.
     const hydrateSessionIfMissing = async (): Promise<boolean> => {
       if (state.backendSessionIds.has(chatId)) return true;
+      // 只在浏览器里存在、还没发过一句话的新对话：服务端必然 404，别去问。
+      if (isLocalDraftChat(chatId)) return false;
       const localChat = state.store.chats[chatId];
       if (localChat && localChat.messages.length > 0) {
         // Local-only chat with content — don't hit backend

--- a/src/frontend/src/hooks/useStreaming.ts
+++ b/src/frontend/src/hooks/useStreaming.ts
@@ -1082,9 +1082,18 @@ export function useStreaming(
         truncateMessagesFrom(streamChatId, targetMsg.ts);
       }
 
-      // Add the edited user message to local store
+      // Add the edited user message to local store. Editing only rewrites the text —
+      // the backend replays the original turn's attachments and its skill / plugin /
+      // connector / @agent selection, so the local echo has to keep showing them.
       const userMsg: ChatMessage = {
         role: 'user', content: newContent.trim(), isMarkdown: false, ts: Date.now(),
+        ...(targetMsg?.attachments?.length ? { attachments: targetMsg.attachments } : {}),
+        ...(targetMsg?.quotedFollowUp ? { quotedFollowUp: targetMsg.quotedFollowUp } : {}),
+        ...(targetMsg?.skillId ? { skillId: targetMsg.skillId } : {}),
+        ...(targetMsg?.skillName ? { skillName: targetMsg.skillName } : {}),
+        ...(targetMsg?.pluginName ? { pluginName: targetMsg.pluginName } : {}),
+        ...(targetMsg?.connectorName ? { connectorName: targetMsg.connectorName } : {}),
+        ...(targetMsg?.mentionName ? { mentionName: targetMsg.mentionName } : {}),
       };
       useChatStore.getState().updateStore((prev) => {
         const c = prev.chats[streamChatId];

--- a/src/frontend/src/plugin-ui/styles.css
+++ b/src/frontend/src/plugin-ui/styles.css
@@ -700,6 +700,12 @@
     transform: translateX(0);
   }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-pv-chain-companyPanelIn { from, to { opacity: 1;
+    transform: translateX(0) } }
+}
+
 
 .jx-pv-chain-companyHeader {
   display: flex;

--- a/src/frontend/src/storage.ts
+++ b/src/frontend/src/storage.ts
@@ -434,3 +434,45 @@ export function nowId(prefix = 'chat') {
   const rand = Math.random().toString(36).slice(2, 8);
   return `${prefix}_${ts}_${rand}`;
 }
+
+/** 只在浏览器里存在、还没在服务端建档的对话 id（点了「新对话」但一句话没发）。
+ *
+ *  这类 id 刷新后仍会被恢复成「当前对话」，前端随后拿它去问会话详情 / 待确认 /
+ *  待回答提问，服务端一律 404。功能上这就是「没东西可恢复」，但浏览器会把每个
+ *  404 响应打成红色报错，看着像页面坏了。登记下来，就能在发请求前先跳过。
+ *
+ *  登记只增不减：这段对话一旦真发了消息，它就有了本地消息、也会进
+ *  backendSessionIds，isLocalDraftChat 的另外两个条件不再成立，登记项自然失效。
+ *  按账号隔离并封顶，避免长期积累。 */
+const DRAFT_CHAT_IDS_KEY = 'hugagent_ui_draft_chat_ids_v1';
+const DRAFT_CHAT_IDS_MAX = 50;
+
+function readDraftChatIds(userId: string | null | undefined): string[] {
+  const key = userScopedKey(DRAFT_CHAT_IDS_KEY, userId);
+  if (!key || typeof window === 'undefined') return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) || '[]');
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function registerDraftChatId(userId: string | null | undefined, chatId: string) {
+  const key = userScopedKey(DRAFT_CHAT_IDS_KEY, userId);
+  if (!key || !chatId || typeof window === 'undefined') return;
+  const next = [...readDraftChatIds(userId).filter((id) => id !== chatId), chatId]
+    .slice(-DRAFT_CHAT_IDS_MAX);
+  try { window.localStorage.setItem(key, JSON.stringify(next)); } catch { /* ignore */ }
+}
+
+export function isDraftChatId(userId: string | null | undefined, chatId: string): boolean {
+  return !!chatId && readDraftChatIds(userId).includes(chatId);
+}
+
+/** 新开一段本地对话：生成 id 的同时登记为草稿。 */
+export function newDraftChatId(userId: string | null | undefined): string {
+  const id = nowId('chat');
+  registerDraftChatId(userId, id);
+  return id;
+}

--- a/src/frontend/src/stores/chatStore.ts
+++ b/src/frontend/src/stores/chatStore.ts
@@ -7,7 +7,7 @@ import type {
   ContextUsageSnapshot,
   PlanProgressState,
 } from '../types';
-import { loadChatStore, saveChatStoreDebounced, flushChatStore, nowId, userScopedKey, purgeLegacyUnscopedKeys, mergeChatStores, registerDeletedChatId, setStreamingIdsProvider, subscribeChatStoreChanges, STORAGE_KEY, writeLocal, removeLocal } from '../storage';
+import { loadChatStore, saveChatStoreDebounced, flushChatStore, nowId, newDraftChatId, isDraftChatId, userScopedKey, purgeLegacyUnscopedKeys, mergeChatStores, registerDeletedChatId, setStreamingIdsProvider, subscribeChatStoreChanges, STORAGE_KEY, writeLocal, removeLocal } from '../storage';
 import { usePageConfigStore } from './pageConfigStore';
 import { usePluginStore } from './pluginStore';
 import { t } from '../i18n';
@@ -85,7 +85,20 @@ function loadCurrentChatId(userId: string | null | undefined) {
     const tabLocal = window.sessionStorage.getItem(key);
     if (tabLocal) return tabLocal;
   } catch { /* sessionStorage 不可用时退回 localStorage */ }
-  return window.localStorage.getItem(key) || nowId('chat');
+  return window.localStorage.getItem(key) || newDraftChatId(userId);
+}
+
+/** 这段对话只在浏览器里存在、服务端还没有：登记过是本地草稿、不在服务端会话列表里、
+ *  本地也一条消息都没有。三条同时成立才算 —— 任何一条不成立都退回原来的行为（照常
+ *  请求服务端），所以自动化生成、通知点进来的会话不会被误判。
+ *
+ *  用途是免掉必然 404 的会话详情 / 待确认 / 待回答提问请求：浏览器会把 404 响应打成
+ *  红色报错，刷新一次刷屏一片，看着像页面坏了。 */
+export function isLocalDraftChat(chatId: string): boolean {
+  const s = useChatStore.getState();
+  if (!chatId || s.backendSessionIds.has(chatId)) return false;
+  if ((s.store.chats[chatId]?.messages?.length ?? 0) > 0) return false;
+  return isDraftChatId(s.currentUserId, chatId);
 }
 
 function saveCurrentChatId(userId: string | null | undefined, chatId: string) {
@@ -866,7 +879,7 @@ export const useChatStore = create<ChatState>((set, get) => {
     // inPlace: always switch the current chat in place (no new chat, no navigation).
     // Otherwise: current chat has no messages yet → reuse in place; has messages → create a new chat in that mode.
     const reuse = inPlace || !existing || existing.messages.length === 0;
-    const targetId = reuse ? currentChatId : nowId('chat');
+    const targetId = reuse ? currentChatId : newDraftChatId(currentUserId);
     const base: ChatItem = reuse && existing
       ? existing
       : {
@@ -960,7 +973,7 @@ export const useChatStore = create<ChatState>((set, get) => {
     const now = Date.now();
     // If the current chat is empty and this isn't an edit, reuse in place; otherwise create a new site-building chat (consistent with enterChatMode).
     const reuse = !isEdit && (!existing || existing.messages.length === 0);
-    const targetId = reuse ? currentChatId : nowId('chat');
+    const targetId = reuse ? currentChatId : newDraftChatId(currentUserId);
     const base: ChatItem = reuse && existing
       ? existing
       : {
@@ -1013,7 +1026,7 @@ export const useChatStore = create<ChatState>((set, get) => {
   },
 
   newChat: () => {
-    const id = nowId('chat');
+    const id = newDraftChatId(get().currentUserId);
     saveCurrentChatId(get().currentUserId, id);
     set({
       currentChatId: id,
@@ -1063,7 +1076,7 @@ export const useChatStore = create<ChatState>((set, get) => {
     saveChatStoreDebounced(currentUserId, next);
     saveQueuedMessages(currentUserId, nextQueued);
     if (currentChatId === id) {
-      const newId = next.order[0] || nowId('chat');
+      const newId = next.order[0] || newDraftChatId(currentUserId);
       const nextChat = next.chats[newId];
       saveCurrentChatId(currentUserId, newId);
       set({

--- a/src/frontend/src/stores/index.ts
+++ b/src/frontend/src/stores/index.ts
@@ -1,5 +1,5 @@
 export { LOGIN_LANDING_KEY, useAuthStore } from './authStore';
-export { useChatStore } from './chatStore';
+export { useChatStore, isLocalDraftChat } from './chatStore';
 export { useCatalogStore } from './catalogStore';
 export { useKbStore } from './kbStore';
 export { useSettingsStore } from './settingsStore';

--- a/src/frontend/src/styles/admin.css
+++ b/src/frontend/src/styles/admin.css
@@ -10,18 +10,33 @@
   0%   { background-color: var(--color-error-light); }
   100% { background-color: var(--color-bg-container); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes admin-flash-error { from, to { background-color: var(--color-bg-container) } }
+}
+
 
 /* 计数徽标 0→n 的一次性脉冲 */
 @keyframes admin-pulse {
   0%, 100% { transform: scale(1); }
   50%      { transform: scale(1.15); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes admin-pulse { from, to { transform: scale(1) } }
+}
+
 
 /* 日志呼吸光标 */
 @keyframes admin-caret {
   0%, 100% { opacity: 1; }
   50%      { opacity: 0; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes admin-caret { from, to { opacity: 1 } }
+}
+
 
 /* ── 表格行反馈（一律 rowClassName + CSS，不在 antd Table 里塞 motion） ── */
 
@@ -116,6 +131,7 @@
 
 /* ── 长任务日志：run 进行中底部呼吸光标 ─────────────────────── */
 
+/* motion-stop: 日志尾随光标，定格成一根竖线仍然可读，闪烁本身是纯装饰 */
 .admin-log-caret {
   display: inline-block;
   width: 8px;

--- a/src/frontend/src/styles/automation-timeline.css
+++ b/src/frontend/src/styles/automation-timeline.css
@@ -425,11 +425,21 @@
   0%   { border-color: var(--color-success); box-shadow: 0 0 0 3px rgba(2, 181, 137, 0.18); }
   100% { border-color: var(--color-border); box-shadow: 0 0 0 0 rgba(2, 181, 137, 0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-runTimeline-finishFlash { from, to { border-color: var(--color-border) } }
+}
+
 
 @keyframes jx-runTimeline-finishFlashFail {
   0%   { border-color: var(--color-error); box-shadow: 0 0 0 3px rgba(252, 93, 93, 0.16); }
   100% { border-color: var(--color-border); box-shadow: 0 0 0 0 rgba(252, 93, 93, 0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-runTimeline-finishFlashFail { from, to { border-color: var(--color-border) } }
+}
+
 
 .jx-runTimeline-item:hover:not(.is-disabled) {
   border-color: var(--color-primary);

--- a/src/frontend/src/styles/canvas.css
+++ b/src/frontend/src/styles/canvas.css
@@ -546,6 +546,7 @@
   font-size: 13px;
 }
 
+/* motion-keep: 画布加载转圈，停下会被读成渲染卡死 */
 .jx-canvas-spinner {
   width: 28px;
   height: 28px;

--- a/src/frontend/src/styles/catalog.css
+++ b/src/frontend/src/styles/catalog.css
@@ -469,6 +469,12 @@
     transform:translateY(-56px);
   }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-appCenterFadeIn { from, to { opacity:1;
+    transform:translateY(-56px) } }
+}
+
 
 /* Skill metadata card */
 .jx-skillMeta{

--- a/src/frontend/src/styles/chat.css
+++ b/src/frontend/src/styles/chat.css
@@ -523,6 +523,7 @@
 /* ── 流式打字光标：尾随圆点呼吸（非竖线闪烁——markdown 全量重渲染会重置相位，
    圆点 pulse 对相位不敏感）。.jx-msgText 是 CitationMarkdownBlock 的包装层。 ── */
 .jx-msg.assistant .jx-bubble.streaming > .jx-msgText > div > :last-child::after,
+/* motion-stop: 流式输出末尾的光标，停在实心态仍是一根光标，不影响判断在不在跑 */
 .jx-msg.assistant .jx-bubble.streaming > span.jx-msgText::after{
   content:'';
   display:inline-block;
@@ -547,6 +548,11 @@
   0%, 100% { opacity:.35; transform:scale(.8); }
   50%      { opacity:.9;  transform:scale(1); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jxStreamCaret { from, to { opacity:.35; transform:scale(.8) } }
+}
+
 
 .jx-msgContent::selection,
 .jx-msgContent *::selection{
@@ -560,6 +566,7 @@
   margin-left:8px;
   vertical-align:middle;
 }
+/* motion-keep: 流式输出中的三点，停下就分不清还在生成还是断流 */
 .jx-streamingDot{
   width:5px;
   height:5px;
@@ -591,9 +598,11 @@
   white-space:nowrap;
 }
 /* logo 动图与运行中的工具壳同款轻呼吸 */
+/* motion-keep: 「正在执行」的品牌动图，停下就只剩一枚静止图标，读起来像卡死 */
 .jx-turnStatus .jx-brandLoader{
   animation:jx-trs-breathe 1.8s ease-in-out infinite;
 }
+/* motion-keep: 状态行流光，靠 background-clip 抠字，定格会变成一段忽深忽浅的灰字 */
 .jx-turnStatus-label{
   /* 中灰而非近黑：slate-400 打底、slate-600 做流光高亮，加粗后仍显轻盈 */
   background:linear-gradient(90deg,
@@ -2422,6 +2431,11 @@ textarea.jx-composer{
   from{ opacity:0; transform:translate(-50%, -100%) translateY(4px) scale(.96); }
   to{ opacity:1; transform:translate(-50%, -100%); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jxSelToolbarIn { from, to { opacity:1; transform:translate(-50%, -100%) } }
+}
+
 .jx-selectionToolbarBtn{
   appearance:none;
   border:none;

--- a/src/frontend/src/styles/evolution.css
+++ b/src/frontend/src/styles/evolution.css
@@ -280,6 +280,11 @@
   from { opacity: 0; transform: translateY(-3px); }
   to { opacity: 1; transform: translateY(0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-evoApproval-reveal { from, to { opacity: 1; transform: translateY(0) } }
+}
+
 .jx-evoApproval-detailPanel section { display: flex; flex-direction: column; gap: 5px; }
 .jx-evoApproval-detailPanel section > strong { font-size: 11.5px; font-weight: 650; }
 .jx-evoApproval-detailPanel section > p {

--- a/src/frontend/src/styles/kb-wiki.css
+++ b/src/frontend/src/styles/kb-wiki.css
@@ -204,6 +204,11 @@
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-wikiItemIn { from, to { opacity: 1; transform: translateY(0) } }
+}
+
 
 .jx-wikiListItem:hover {
   background: var(--color-bg-gray);
@@ -1216,6 +1221,12 @@
     transform: translateX(0);
   }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-wikiGraphDrawerIn { from, to { opacity: 1;
+    transform: translateX(0) } }
+}
+
 
 .jx-wikiGraphPanelHead {
   display: flex;

--- a/src/frontend/src/styles/motion.css
+++ b/src/frontend/src/styles/motion.css
@@ -19,12 +19,22 @@
   from { opacity: 0; transform: translateY(var(--fadeInUp-distance, 10px)); }
   to   { opacity: 1; transform: translateY(0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-fadeInUp { from, to { opacity: 1; transform: translateY(0) } }
+}
+
 .jx-anim-fadeInUp {
   animation: jx-kf-fadeInUp var(--motion-duration-slow) var(--motion-ease-brand-out) backwards;
 }
 
 /* 2. fade-in：纯透明度入场（不适合位移的大面积区域 / iframe 容器） */
 @keyframes jx-kf-fadeIn { from { opacity: 0; } to { opacity: 1; } }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-fadeIn { from, to { opacity: 1 } }
+}
+
 .jx-anim-fadeIn {
   animation: jx-kf-fadeIn var(--motion-duration-normal) var(--motion-ease-standard) backwards;
 }
@@ -34,6 +44,11 @@
   from { opacity: 0; transform: translateY(6px) scale(.97); }
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-scaleIn { from, to { opacity: 1; transform: translateY(0) scale(1) } }
+}
+
 .jx-anim-scaleIn {
   animation: jx-kf-scaleIn var(--motion-duration-fast) var(--motion-ease-brand-out) backwards;
   transform-origin: top center;
@@ -52,6 +67,7 @@
   0%, 100% { opacity: .35; }
   50%      { opacity: .85; }
 }
+/* motion-keep: 通用「进行中」脉冲工具类 */
 .jx-anim-pulse { animation: jx-kf-pulse 1.6s var(--motion-ease-standard) infinite; }
 
 /* 6. shimmer：骨架屏流光 */
@@ -59,6 +75,7 @@
   0%   { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+/* motion-keep: 通用「加载中」流光工具类 */
 .jx-anim-shimmer {
   background: linear-gradient(90deg,
     var(--color-bg-gray) 0%, var(--color-fill-hover) 50%, var(--color-bg-gray) 100%);
@@ -74,6 +91,11 @@
   0%   { background-color: var(--flash-color, var(--color-primary-bg)); }
   100% { background-color: transparent; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-flash { from, to { background-color: transparent } }
+}
+
 .jx-anim-flash { animation: jx-kf-flash var(--flash-dur, 1.2s) var(--motion-ease-standard) 1; }
 .jx-anim-flash-row > td { animation: jx-kf-flash var(--flash-dur, 1.2s) var(--motion-ease-standard) 1; }
 
@@ -82,6 +104,11 @@
   from { opacity: 0; transform: scale(.7); }
   to   { opacity: 1; transform: scale(1); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-statusIn { from, to { opacity: 1; transform: scale(1) } }
+}
+
 .jx-anim-statusIn {
   animation: jx-kf-statusIn var(--motion-duration-fast) var(--motion-ease-brand-out) backwards;
 }
@@ -92,7 +119,13 @@
   from { transform: scale(1); opacity: .45; }
   to   { transform: scale(var(--ripple-scale, 1.9)); opacity: 0; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-ripple { from, to { transform: scale(var(--ripple-scale, 1.9)); opacity: 0 } }
+}
+
 .jx-anim-ripple { position: relative; }
+/* motion-stop: 涟漪强调，纯装饰 */
 .jx-anim-ripple::after {
   content: '';
   position: absolute;
@@ -109,6 +142,11 @@
   25%      { transform: translateX(-3px); }
   75%      { transform: translateX(3px); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-shakeX { from, to { transform: translateX(0) } }
+}
+
 .jx-anim-shake { animation: jx-kf-shakeX .3s var(--motion-ease-standard) 1; }
 
 /* 11. card-lift：卡片 hover 抬升三件套（transition + hover + 按压回落）。
@@ -121,29 +159,33 @@
 .jx-card-lift:hover { transform: translateY(-2px); }
 .jx-card-lift:active { transform: translateY(0); transition-duration: var(--motion-duration-instant); }
 
-/* ══════════ 无障碍：reduced motion 全局降级 ══════════
- * 策略：动画压到 1ms（保留 fill-mode 终态），过渡直接归零。
- * 不能把全局 transition-duration 设成正数：CSS 初始 transition-property 是 all，
- * 这会让 Ant Design 弹层定位用的 left/top 也产生过渡；rc-trigger 在同一帧同步测量时
- * 会读到 -1000vw 的动画起点，导致下拉框永久停在屏幕外。
- * 白名单豁免纯 opacity 的"系统在工作"指示器（降速保留，去掉会损害可用性）。
- * 区域内需保留的工作指示器可自挂 .jx-anim-keep 进入白名单。
- * 旧的零散 @media (prefers-reduced-motion) 块已由本规则统一替代。 */
+/* ══════════ 无障碍：reduced motion ══════════
+ * 边界：**我们只降级自己的动效**，第三方组件的动效交给它自己的开关。
+ *
+ * 1) 过渡（transition）全局归零。过渡是一次性的，归零不会让任何东西看起来卡住。
+ *    不能改成正数：CSS 初始 transition-property 是 all，会让 Ant Design 弹层定位用的
+ *    left/top 也产生过渡；rc-trigger 在同一帧同步测量时会读到 -1000vw 的动画起点，
+ *    导致下拉框永久停在屏幕外。
+ *
+ * 2) 动画（animation）**不做全局压制**。历史上这里是一条
+ *    `*{animation-iteration-count:1 !important}`，它会把一切循环动画冻住——包括第三方
+ *    组件的加载转圈。转圈停下就不再表示「在跑」，只剩一枚静止残圈，比动起来更像卡死；
+ *    而 antd 里只有 Spin 输出 aria-busy，按钮 / 下拉 / 上传的转圈都没有任何可判定的语义，
+ *    我们又不该去枚举别人家的类名来挽救（人家改版就悄悄失效）。
+ *    现在改为：**每条装饰性关键帧在自己的定义处就地给出一份「定格在终态」的同名覆盖版**
+ *    （同名 @keyframes 后定义者胜，用到它的规则自动一起降级，不需要任何选择器，
+ *    也就不可能误伤第三方）。工作指示器的关键帧不给覆盖版，于是原样继续动。
+ *    构建门禁 scripts/check-loading-motion.mjs 强制每条关键帧二选一，漏了就挂构建。
+ *
+ * 3) antd 自己的动效由它自己的 motion token 关闭（见 appTheme.ts）：该开关只归零过渡
+ *    时长，不碰 Spin / 按钮 loading 的转圈——正是我们要的语义。
+ */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
   *::after {
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
     transition-duration: 0s !important;
     transition-delay: 0s !important;
     scroll-behavior: auto !important;
-  }
-  .jx-streamingDot,
-  .jx-skeletonBlock,
-  .jx-anim-shimmer,
-  .jx-anim-keep {
-    animation-duration: 2.4s !important;
-    animation-iteration-count: infinite !important;
   }
 }

--- a/src/frontend/src/styles/myspace.css
+++ b/src/frontend/src/styles/myspace.css
@@ -817,7 +817,13 @@
   0%, 100% { transform: translateY(0); }
   50%      { transform: translateY(-4px); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-mySpace-emptyFloat { from, to { transform: translateY(0) } }
+}
 
+
+/* motion-stop: 空态插画漂浮，纯装饰 */
 .jx-mySpace-emptyIcon {
   margin-bottom: 12px;
   opacity: 0.54;

--- a/src/frontend/src/styles/ontology.css
+++ b/src/frontend/src/styles/ontology.css
@@ -205,6 +205,11 @@
   from { opacity: 0; transform: translate3d(0, 6px, 0); }
   to { opacity: 1; transform: translate3d(0, 0, 0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-ontologyInlineEnter { from, to { opacity: 1; transform: translate3d(0, 0, 0) } }
+}
+
 
 .jx-ontologyRevision {
   position: relative;

--- a/src/frontend/src/styles/plan.css
+++ b/src/frontend/src/styles/plan.css
@@ -39,6 +39,7 @@
 .jx-plan-card--complete::after{
   opacity:1;
 }
+/* motion-keep: 计划执行中的进度流光，停下就看不出计划还在跑 */
 .jx-plan-card--executing::before{
   background:linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary-hover) 50%, var(--color-primary) 100%);
   background-size:200% 100%;
@@ -146,6 +147,11 @@
   35%{filter:brightness(1.4)}
   100%{filter:brightness(1)}
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-plan-fillFlash { from, to { filter:brightness(1) } }
+}
+
 .jx-plan-progressLabel{
   flex-shrink:0;
   font-size:12px;
@@ -213,6 +219,11 @@
   0%{background-color:rgba(2,181,137,.16);}
   100%{background-color:transparent;}
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-plan-stepDoneFlash { from, to { background-color:transparent } }
+}
+
 .jx-plan-stepHeader{
   display:flex;
   align-items:center;

--- a/src/frontend/src/styles/search-modal.css
+++ b/src/frontend/src/styles/search-modal.css
@@ -12,10 +12,20 @@
   from{ opacity:0; transform:scale(.98) translateY(-8px); }
   to  { opacity:1; transform:none; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-searchModalIn { from, to { opacity:1; transform:none } }
+}
+
 @keyframes jx-kf-searchModalOut{
   from{ opacity:1; transform:none; }
   to  { opacity:0; transform:scale(.98) translateY(-6px); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-searchModalOut { from, to { opacity:0; transform:scale(.98) translateY(-6px) } }
+}
+
 .jx-searchModal.ant-zoom-enter,
 .jx-searchModal.ant-zoom-appear{
   opacity:0;

--- a/src/frontend/src/styles/sidebar.css
+++ b/src/frontend/src/styles/sidebar.css
@@ -137,6 +137,11 @@
   from{ opacity:0; transform:translateX(-6px); }
   to  { opacity:1; transform:none; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-siderContentIn { from, to { opacity:1; transform:none } }
+}
+
 .jx-siderInner,
 .jx-miniRail{
   animation:jx-kf-siderContentIn var(--motion-duration-slow) var(--motion-ease-standard) both;
@@ -416,6 +421,7 @@
   100%{ background-position:-200% 0; }
 }
 
+/* motion-keep: 全站骨架屏基础块，停下就是一片静止灰条，读起来像加载失败 */
 .jx-skeletonBlock{
   border-radius:999px;
   /* 从文字令牌派生的低透明度灰，深浅两个主题下都是「比底色深/亮一点」的微光 */
@@ -677,6 +683,7 @@
 .jx-historyItem:hover .jx-historyTypeIcon{ color:color-mix(in srgb, var(--color-text) 55%, transparent); }
 
 /* ── Running indicator (pulse dot) ── */
+/* motion-keep: 会话「正在运行」小圆点 */
 .jx-historyRunningDot{
   flex-shrink:0;
   width:7px; height:7px;
@@ -749,6 +756,11 @@
   from{ opacity:0; transform:scaleX(.98); }
   to  { opacity:1; transform:none; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-kf-renameIn { from, to { opacity:1; transform:none } }
+}
+
 .jx-historyEditInput{
   flex:1; min-width:0;
   transform-origin:left center;

--- a/src/frontend/src/styles/tool.css
+++ b/src/frontend/src/styles/tool.css
@@ -111,6 +111,7 @@
 }
 /* "正在准备调用工具…" 等待文字流光 — 单色灰阶，参数缓冲空窗期的活性信号。
    隐藏工具调用时那行折叠摘要（--live）共用同一套：运行中它是唯一在动的字。 */
+/* motion-keep: 工具运行中的文字流光，定格会变成一段忽深忽浅的灰字 */
 .jx-tcr-prefix--shimmer,
 .jx-inlineSummaryText--live {
   background: linear-gradient(90deg,
@@ -394,7 +395,13 @@
   0%   { transform: scale(0.55); opacity: 0.9; }
   100% { transform: scale(1.55); opacity: 0; }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-trs-ring { from, to { transform: scale(1.55); opacity: 0 } }
+}
+
 /* Gentle breathing on the live brand GIF for extra life */
+/* motion-keep: 「正在执行」的品牌动图，停下就只剩一枚静止图标，读起来像卡死 */
 .jx-trs-mark--running .jx-brandLoader {
   animation: jx-trs-breathe 1.8s ease-in-out infinite;
 }
@@ -1119,6 +1126,11 @@
   from{opacity:0;transform:translate(-50%, 8px);}
   to  {opacity:1;transform:translate(-50%, 0);}
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-imgPreviewToolbarIn { from, to { opacity:1;transform:translate(-50%, 0) } }
+}
+
 .jx-imagePreviewZoomLabel{
   min-width:46px;
   text-align:center;
@@ -1578,20 +1590,6 @@
 .jx-thinkingContent::-webkit-scrollbar{width:5px}
 .jx-thinkingContent::-webkit-scrollbar-thumb{background:var(--scrollbar-thumb-drag);border-radius:3px}
 
-/* 思考中旋转动画 */
-.jx-thinkingSpinner{
-  width:12px;
-  height:12px;
-  border:2px solid color-mix(in srgb, var(--color-text-placeholder) 50%, transparent);
-  border-top-color:color-mix(in srgb, var(--color-text-secondary) 86%, transparent);
-  border-radius:50%;
-  animation:jxThinkSpin .8s linear infinite;
-  flex-shrink:0;
-}
-@keyframes jxThinkSpin{
-  to{transform:rotate(360deg);}
-}
-
 /* ══════════════════════════════════════════════════════════════════════════
    Inline Summary + Canvas Detail (tool progress & thinking)
    ══════════════════════════════════════════════════════════════════════════ */
@@ -1616,6 +1614,11 @@
   from{opacity:0;transform:scale(.85);}
   to  {opacity:1;transform:scale(1);}
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jxBrandSettle { from, to { opacity:1;transform:scale(1) } }
+}
+
 /* 深色下把「已完成」定格标记提亮一档。
    它是一张单一色值（slate-400 #94A3B8）铺满的 PNG，CSS 改不了图里的颜色，只能上滤镜；
    ×1.15 后约 #AABBD4，与旁边的浅色文字同一亮度带，仍明显区别于运行中的品牌蓝动图。
@@ -1972,6 +1975,7 @@
   gap:10px;
   padding:10px 0 2px;
 }
+/* motion-keep: 代码执行运行态脉冲 */
 .jx-ce-runningPulse{
   width:7px;height:7px;
   border-radius:50%;
@@ -1988,6 +1992,7 @@
   color:var(--color-text-secondary);
   display:flex;align-items:center;gap:4px;
 }
+/* motion-keep: 代码执行运行态图标闪烁 */
 .jx-ce-runningIcon{
   font-size:10px;
   color:var(--color-primary);
@@ -2316,6 +2321,11 @@
   from{ opacity:0; transform:translateY(8px); }
   to{ opacity:1; transform:translateY(0); }
 }
+/* motion-stop: 减弱动效下定格在终态（同名关键帧后定义者胜，用到它的规则一起生效） */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes jx-confirmBar-in { from, to { opacity:1; transform:translateY(0) } }
+}
+
 .jx-confirmBar-icon{
   flex:none;
   display:flex; align-items:center; justify-content:center;

--- a/src/frontend/src/theme.ts
+++ b/src/frontend/src/theme.ts
@@ -51,6 +51,22 @@ export function applyThemeToDom(isDark: boolean): void {
 }
 
 /** 监听系统外观变化；返回取消函数。非浏览器环境（SSR/测试）为 no-op。 */
+/** 系统是否开启「减弱动画」（Windows 节电模式会自动开启）。 */
+export function systemPrefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export function watchReducedMotion(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+  media.addEventListener('change', onChange);
+  return () => media.removeEventListener('change', onChange);
+}
+
 export function watchSystemTheme(onChange: () => void): () => void {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
   const media = window.matchMedia('(prefers-color-scheme: dark)');


### PR DESCRIPTION
## Summary

- isolate blocking Redis stream reads from shared command traffic and add regression coverage
- make compaction hook payloads safely serializable while strengthening chat run recovery and replay behavior
- avoid repeated draft-chat refresh failures and preserve the intended session state
- refine reduced-motion handling so active progress remains understandable without overriding unrelated component motion

## CE comparison

- compared against `origin/main` at `a701e9955283f34874010a6d14f308407339554d`
- 67 files changed, with 909 insertions and 176 deletions
- generated from the private source through the repository CE derivation pipeline

## Validation

- CE import, OpenAPI, and ORM self-check
- CE release regression suite
- CE frontend production build, i18n check, dark-mode check, and loading-motion check
- CE brand, license, required-runtime, and forbidden-artifact gates
